### PR TITLE
Fix onug_cost_optimized_s3_path lab by adding missing sickbay entries

### DIFF
--- a/snapshots/onug_cost_optimized_s3_path/validation/sickbay.yaml
+++ b/snapshots/onug_cost_optimized_s3_path/validation/sickbay.yaml
@@ -89,6 +89,14 @@ entries:
     test_name: test_bgp_rib_routes
   - hostname: fwl01
     test_name: test_interface_properties
+  - hostname: fwl01
+    test_name: test_configuration_format
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/64
+  - hostname: fwl01
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/64
   - hostname: bor01
     test_name: test_bgp_rib_routes
   - hostname: exitgw


### PR DESCRIPTION
- Add sickbay entries for fwl01 test_configuration_format and test_main_rib_routes
- These tests fail due to Batfish parsing regression with Junos configuration groups
- Created GitHub issue #64 to track the Batfish parsing limitation
- Lab now passes with all failures properly documented as expected

---

**Stack**:
- #66
- #65 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*