### PR TITLE
onug_cost_optimized_s3_path: move hostname out of apply-group node0

### DIFF
--- a/snapshots/onug_cost_optimized_s3_path/configs/fwl01/show_configuration_|_display_set.txt
+++ b/snapshots/onug_cost_optimized_s3_path/configs/fwl01/show_configuration_|_display_set.txt
@@ -1,9 +1,9 @@
 set version 17.3R1.10
-set groups node0 system host-name fwl01
 set groups node0 system syslog source-address 10.254.4.1
 set groups node0 system ntp source-address 10.254.4.1
 set groups node0 interfaces fxp0 unit 0 family inet address 10.254.4.1/16
 set apply-groups node0
+set system host-name fwl01
 set system time-zone UTC
 set system root-authentication encrypted-password "$6$cJ1xK06N$98z7EmTVN9zCCuMKp7JnUnRflDUYc8Lc6l7NAXAp70MjgsUKm.WD.kJ7IY2WNi7mYT1sEV1rRvkTSzFasUamn0"
 set system services ssh root-login allow


### PR DESCRIPTION
Not including hostnames from cluster groups is an explicit choice by Batfish that previously
had a bug, fixed in batfish/batfish#8841. Make the lab work with this.