### PR TITLE
IOS: static routes should have admin 1

### DIFF
--- a/src/lab_validation/parsers/ios/commands/route.py
+++ b/src/lab_validation/parsers/ios/commands/route.py
@@ -112,12 +112,13 @@ def _get_v4_route(
         B        192.168.123.1 [20/0] via 10.12.11.1, 00:42:30
         B        192.168.123.2 [20/0] via 10.12.11.1, 00:42:30
     """
+    default_admin = 1 if protocol == "static" else 0
     return IosIpRoute(
         network=_get_network(network, subnet_prefix),
         protocol=protocol,
         next_hop_ip=parsed_route.get("nh_ip", None),
         next_hop_int=parsed_route.get("nh_iface", None),
-        admin=parsed_route.get("admin", 0),
+        admin=parsed_route.get("admin", default_admin),
         metric=parsed_route.get("metric", 0),
         vrf=vrf,
     )

--- a/tests/lab_validation/parsers/ios/ios/commands/test_route.py
+++ b/tests/lab_validation/parsers/ios/ios/commands/test_route.py
@@ -122,7 +122,7 @@ S 10.100.128.0/24 is directly connected, Null0
             protocol="static",
             next_hop_ip=None,
             next_hop_int="Null0",
-            admin=0,
+            admin=1,
             metric=0,
         ),
     ]


### PR DESCRIPTION
The show data doens't include an AD, but we should.