### PR TITLE
Initial triage: Add sickbay.yaml for cisco_xr_ios_vpnv4 lab

### DIFF
--- a/snapshots/cisco_xr_ios_vpnv4/validation/sickbay.yaml
+++ b/snapshots/cisco_xr_ios_vpnv4/validation/sickbay.yaml
@@ -1,0 +1,57 @@
+entries:
+  - hostname: CE2
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: CE3
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: CE4
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: PE1
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: PE2
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: PE3
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: RR1
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: RR2
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: CE2
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: CE3
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: CE4
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: PE1
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: PE2
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69
+  - hostname: PE3
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/69


### PR DESCRIPTION
- Created GitHub issue #69 documenting MPLS VPN validation failures
- Added sickbay.yaml marking 14 expected failures as xfailed
- Lab contains 5 IOS-XR provider devices and 4 IOS customer edge devices
- Failures include main RIB routes and BGP RIB route validation discrepancies
- Lab now runs cleanly with proper expected failure tracking

Resolves initial triage of previously untested cisco_xr_ios_vpnv4 lab.