### PR TITLE
ci: Add summary job for lab integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,19 @@ jobs:
       run: |
         echo "=== Batfish logs ==="
         tail -100 batfish.log || echo "No batfish log found"
+
+  # Summary job for required status checks
+  all-labs-passed:
+    runs-on: ubuntu-latest
+    needs: [lab-integration-test]
+    if: always()  # Run even if some lab tests failed
+
+    steps:
+    - name: Check all lab tests passed
+      run: |
+        if [ "${{ needs.lab-integration-test.result }}" != "success" ]; then
+          echo "❌ Some lab integration tests failed"
+          exit 1
+        else
+          echo "✅ All lab integration tests passed"
+        fi


### PR DESCRIPTION
## Summary

Adds a summary job `all-labs-passed` that provides a single status check for GitHub branch protection rules, ensuring all lab integration tests must pass before merging.

## Problem

GitHub requires specifying required status checks ahead of time, but our lab integration tests run as a matrix with dynamically generated lab names. This makes it difficult to require all labs to pass without knowing the specific matrix job names in advance.

## Solution

Add a summary job that:
- Depends on the entire `lab-integration-test` matrix
- Always runs (even if lab tests fail) 
- Succeeds only if ALL lab integration tests pass
- Provides a consistent job name (`all-labs-passed`) for branch protection rules
- Gives clear pass/fail feedback with emoji status messages

## Usage

Configure GitHub branch protection rules to require:
- `lint`
- `test` 
- `all-labs-passed`

This ensures all lab tests must pass while providing a clean, single status check.

## Testing

This PR will test the new workflow by running it on this branch. The `all-labs-passed` job should appear as a status check.