### PR TITLE
ci: Switch from coverage comments to codecov.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,3 +205,19 @@ jobs:
       run: |
         echo "=== Batfish logs ==="
         tail -100 batfish.log || echo "No batfish log found"
+
+  # Summary job for required status checks
+  all-labs-passed:
+    runs-on: ubuntu-latest
+    needs: [lab-integration-test]
+    if: always()  # Run even if some lab tests failed
+
+    steps:
+    - name: Check all lab tests passed
+      run: |
+        if [ "${{ needs.lab-integration-test.result }}" != "success" ]; then
+          echo "❌ Some lab integration tests failed"
+          exit 1
+        else
+          echo "✅ All lab integration tests passed"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,25 +48,13 @@ jobs:
       run: |
         pytest tests/ -v --tb=short --cov=lab_validation --cov-report=xml --cov-report=term-missing
 
-    - name: Code Coverage Summary
-      uses: irongut/CodeCoverageSummary@v1.3.0
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v4
       with:
-        filename: coverage.xml
-        badge: true
-        fail_below_min: false
-        format: markdown
-        hide_branch_rate: false
-        hide_complexity: true
-        indicators: true
-        output: both
-        thresholds: '60 80'
-
-    - name: Add Coverage PR Comment
-      uses: marocchino/sticky-pull-request-comment@v2
-      if: github.event_name == 'pull_request'
-      with:
-        recreate: true
-        path: code-coverage-results.md
+        file: ./coverage.xml
+        flags: unittests
+        name: codecov-umbrella
+        fail_ci_if_error: false
 
     - name: Test package build
       run: |


### PR DESCRIPTION
## Summary

Replaces the current coverage comment system with codecov.io integration for better coverage tracking and open source best practices.

## Changes

### Removed:
- `irongut/CodeCoverageSummary` action that generates markdown summaries
- `marocchino/sticky-pull-request-comment` action that posts PR comments

### Added:
- `codecov/codecov-action@v4` to upload coverage data to codecov.io
- Configured with `fail_ci_if_error: false` for graceful handling
- Uses existing coverage.xml from pytest

## Benefits

✅ **Professional coverage reporting** with codecov.io dashboard  
✅ **Coverage badges** for README  
✅ **Coverage trend tracking** over time  
✅ **Better open source integration** - standard for OSS projects  
✅ **No more PR comment spam** - cleaner PR experience  
✅ **Free for open source** projects  

## Setup Required

After merging, you'll need to:

1. **Visit [codecov.io](https://codecov.io)** and sign in with GitHub
2. **Enable the batfish/lab-validation repository**
3. **Add coverage badge** to README (optional)

No additional secrets or configuration needed - codecov-action works automatically for public repos.

## Testing

This PR tests the new codecov integration. The coverage data should be uploaded to codecov.io when the CI runs.