### PR TITLE
Add daily CI workflow with Slack notifications

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,34 @@
+# GitHub Actions Workflows
+
+## ci.yml
+
+The main continuous integration workflow that runs on pull requests and pushes to main/develop branches. It includes:
+
+- Code linting with pre-commit hooks
+- Unit tests with coverage reporting
+- Lab discovery and parallel integration testing
+- Batfish JAR building and caching
+
+## daily-ci.yml
+
+A scheduled workflow that runs the full CI suite daily at 8AM Pacific time. Features:
+
+- Reuses the existing `ci.yml` workflow
+- Runs automatically via cron schedule: `0 15 * * *` (8AM Pacific)
+- Can be triggered manually via `workflow_dispatch`
+- Sends Slack notifications to a configured channel on failure
+
+### Setup Required
+
+To enable Slack notifications, add the following secret to your repository:
+
+- `LAB_VALIDATION_SLACK_WEBHOOK_URL`: Your Slack incoming webhook URL
+
+### Notification Details
+
+The Slack notification includes:
+
+- Workflow name and status
+- Trigger type (scheduled vs manual)
+- Repository and commit information
+- Direct link to the failed workflow run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [ main, develop ]
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   lint:

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -4,16 +4,28 @@ on:
   schedule:
     - cron: "0 15 * * *" # 8AM Pacific; daily
   workflow_dispatch: # Allow manual triggering
+  push:
+    branches: [ add-daily-ci-workflow ] # Temporary for testing
 
 jobs:
+  # Temporary test job to simulate failure (remove after testing)
+  test-failure:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Simulate failure for testing
+        run: |
+          echo "Testing Slack notification on failure"
+          exit 1
+
   # Run the existing CI workflow
   ci:
     uses: ./.github/workflows/ci.yml
+    needs: test-failure
 
   # Send Slack notification on failure
   notify-slack-on-failure:
-    needs: ci
-    if: failure()
+    needs: [test-failure, ci]
+    if: always() && (needs.test-failure.result == 'failure' || needs.ci.result == 'failure')
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification on failure

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -1,0 +1,77 @@
+name: Daily CI
+
+on:
+  schedule:
+    - cron: "0 15 * * *" # 8AM Pacific; daily
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  # Run the existing CI workflow
+  ci:
+    uses: ./.github/workflows/ci.yml
+
+  # Send Slack notification on failure
+  notify-slack-on-failure:
+    needs: ci
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification on failure
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          webhook: ${{ secrets.LAB_VALIDATION_SLACK_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*Lab validation daily CI workflow failed*",
+              "blocks": [
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Lab validation daily CI workflow failed*"
+                  }
+                },
+                {
+                  "type": "section",
+                  "fields": [
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Workflow:*\n${{ github.workflow }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Status:*\nFailed"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Trigger:*\n${{ github.event_name == 'schedule' && 'Daily scheduled run' || 'Manual trigger' }}"
+                    },
+                    {
+                      "type": "mrkdwn",
+                      "text": "*Repository:*\n${{ github.repository }}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*Commit:* ${{ github.sha }}\n*Branch:* ${{ github.ref_name }}"
+                  }
+                },
+                {
+                  "type": "actions",
+                  "elements": [
+                    {
+                      "type": "button",
+                      "text": {
+                        "type": "plain_text",
+                        "text": "View Workflow Run in GitHub Actions"
+                      },
+                      "url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                    }
+                  ]
+                }
+              ]
+            }

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -4,28 +4,16 @@ on:
   schedule:
     - cron: "0 15 * * *" # 8AM Pacific; daily
   workflow_dispatch: # Allow manual triggering
-  push:
-    branches: [ add-daily-ci-workflow ] # Temporary for testing
 
 jobs:
-  # Temporary test job to simulate failure (remove after testing)
-  test-failure:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Simulate failure for testing
-        run: |
-          echo "Testing Slack notification on failure"
-          exit 1
-
-  # Run the existing CI workflow (will be skipped due to test-failure)
+  # Run the existing CI workflow
   ci:
     uses: ./.github/workflows/ci.yml
-    needs: test-failure
 
   # Send Slack notification on failure
   notify-slack-on-failure:
-    needs: [test-failure, ci]
-    if: always() && (needs.test-failure.result == 'failure' || needs.ci.result == 'failure' || needs.ci.result == 'skipped')
+    needs: ci
+    if: failure()
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification on failure

--- a/.github/workflows/daily-ci.yml
+++ b/.github/workflows/daily-ci.yml
@@ -17,7 +17,7 @@ jobs:
           echo "Testing Slack notification on failure"
           exit 1
 
-  # Run the existing CI workflow
+  # Run the existing CI workflow (will be skipped due to test-failure)
   ci:
     uses: ./.github/workflows/ci.yml
     needs: test-failure
@@ -25,7 +25,7 @@ jobs:
   # Send Slack notification on failure
   notify-slack-on-failure:
     needs: [test-failure, ci]
-    if: always() && (needs.test-failure.result == 'failure' || needs.ci.result == 'failure')
+    if: always() && (needs.test-failure.result == 'failure' || needs.ci.result == 'failure' || needs.ci.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
       - name: Send Slack notification on failure


### PR DESCRIPTION
This PR adds a scheduled workflow that runs the existing CI suite daily and sends Slack notifications on failure.

## Changes
- Add  workflow that runs daily at 8AM Pacific 
- Reuses existing  workflow to avoid duplication
- Sends Slack notifications on failure using same pattern as pybatfish/docker repos
- Includes manual trigger capability via 
- Add documentation in  explaining setup and usage

## Setup Required
Repository admins need to add a secret  with the Slack webhook URL to enable notifications.

## Benefits
- Daily validation that the full lab suite continues to pass
- Proactive notification when issues are introduced
- Consistent with CI patterns used in other Batfish repositories
- Easy to trigger manually for testing