### PR TITLE
Fix reusable workflow to checkout lab-validation repository

### DIFF
--- a/.github/workflows/reusable-lab-validation.yml
+++ b/.github/workflows/reusable-lab-validation.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
     - name: Checkout lab-validation
       uses: actions/checkout@v4
+      with:
+        repository: batfish/lab-validation
 
     - name: Discover available labs
       id: discover
@@ -116,6 +118,7 @@ jobs:
     - name: Checkout lab-validation
       uses: actions/checkout@v4
       with:
+        repository: batfish/lab-validation
         path: lab-validation
 
     - name: Set up Python 3.10


### PR DESCRIPTION
## Problem

The reusable workflow was checking out the calling repository instead of the lab-validation repository, causing the discover-labs job to fail when trying to find the snapshots/ directory.

When called from batfish/docker, the workflow would check out the docker repository and then try to run:
```bash
ls -1 snapshots/  # This fails because docker repo has no snapshots/ directory
```

## Solution

Fixed both checkout actions to explicitly specify the lab-validation repository:

1. **discover-labs job**: Added `repository: batfish/lab-validation`
2. **lab-integration-test job**: Added `repository: batfish/lab-validation` to the existing path specification

## Impact

This enables the reusable workflow to be called from any repository (like batfish/docker) while still accessing the lab snapshots and test framework from lab-validation.

## Testing

This fix is needed for batfish/docker#140 which integrates lab-validation testing into the docker release pipeline.