### PR TITLE
Fix flaky test.pypi.org installs with retry mechanism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,7 +202,20 @@ jobs:
         # Install Pybatfish based on input parameters (may override version from requirements.txt)
         if [ "${{ inputs.pybatfish_version }}" != "" ]; then
           if [ "${{ inputs.pybatfish_pypi_repo }}" = "test" ]; then
-            pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple pybatfish==${{ inputs.pybatfish_version }}
+            # Retry installation from test.pypi.org to handle propagation delays
+            for attempt in 1 2 3 4 5; do
+              if pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple pybatfish==${{ inputs.pybatfish_version }}; then
+                break
+              else
+                echo "Attempt $attempt failed, waiting 30 seconds before retry..."
+                if [ $attempt -lt 5 ]; then
+                  sleep 30
+                else
+                  echo "Failed to install pybatfish after 5 attempts"
+                  exit 1
+                fi
+              fi
+            done
           else
             pip install pybatfish==${{ inputs.pybatfish_version }}
           fi

--- a/.github/workflows/reusable-lab-validation.yml
+++ b/.github/workflows/reusable-lab-validation.yml
@@ -152,7 +152,20 @@ jobs:
         # Install Pybatfish based on input parameters (may override version from requirements.txt)
         if [ "${{ inputs.pybatfish_version }}" != "" ]; then
           if [ "${{ inputs.pybatfish_pypi_repo }}" = "test" ]; then
-            pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple pybatfish==${{ inputs.pybatfish_version }}
+            # Retry installation from test.pypi.org to handle propagation delays
+            for attempt in 1 2 3 4 5; do
+              if pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple pybatfish==${{ inputs.pybatfish_version }}; then
+                break
+              else
+                echo "Attempt $attempt failed, waiting 30 seconds before retry..."
+                if [ $attempt -lt 5 ]; then
+                  sleep 30
+                else
+                  echo "Failed to install pybatfish after 5 attempts"
+                  exit 1
+                fi
+              fi
+            done
           else
             pip install pybatfish==${{ inputs.pybatfish_version }}
           fi


### PR DESCRIPTION
## Summary
Fix intermittent failures in the docker pre-release job where lab-validation tests fail with "No matching distribution found for pybatfish==X.X.X.X" when installing from test.pypi.org.

## Problem
The lab-validation jobs in the docker repo's cross-version test workflow were experiencing flaky failures due to a race condition:

1. `upload_dev` job uploads pybatfish wheel to test.pypi.org
2. `lab_validation` jobs start immediately after upload completes
3. Some runners fail because test.pypi.org needs time to propagate the new package
4. This causes intermittent "No matching distribution found" errors

Pattern observed: ~6 out of ~80 lab jobs would fail within 20-30 seconds, while successful ones took 1+ minutes.

## Solution
Added retry mechanism with 5 attempts and 30-second delays when installing from test.pypi.org to handle PyPI propagation delays gracefully.

## Test Plan
- [x] Verified the retry logic handles pip install failures correctly
- [x] Applied the same fix to both ci.yml and reusable-lab-validation.yml (kept in sync per existing comment)
- [ ] Monitor next scheduled docker pre-release run for reduced flakiness

## Files Changed
- `.github/workflows/reusable-lab-validation.yml` - Reusable workflow called by docker repo
- `.github/workflows/ci.yml` - Main CI workflow (kept in sync)

Both files now retry test.pypi.org installs up to 5 times with 30-second delays between attempts.