### PR TITLE
Add YAML formatting to prettier pre-commit hook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,9 +6,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, develop ]
+    branches: [main, develop]
   pull_request:
-    branches: [ main, develop ]
+    branches: [main, develop]
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -41,17 +41,17 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        cache: 'pip'
-        cache-dependency-path: '.pre-commit-config.yaml'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: ".pre-commit-config.yaml"
 
-    - name: Run pre-commit hooks
-      uses: pre-commit/action@v3.0.1
+      - name: Run pre-commit hooks
+        uses: pre-commit/action@v3.0.1
 
   test:
     runs-on: ubuntu-latest
@@ -59,40 +59,40 @@ jobs:
       id-token: write
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        cache: 'pip'
-        cache-dependency-path: 'requirements*.txt'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "requirements*.txt"
 
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install -r requirements.txt
-        pip install -r requirements-dev.txt
-        pip install -e .
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+          pip install -e .
 
-    - name: Run tests with coverage
-      run: |
-        pytest tests/ -v --tb=short --cov=lab_validation --cov-report=xml --cov-report=term-missing
+      - name: Run tests with coverage
+        run: |
+          pytest tests/ -v --tb=short --cov=lab_validation --cov-report=xml --cov-report=term-missing
 
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      with:
-        files: ./coverage.xml
-        flags: unittests
-        name: codecov-umbrella
-        fail_ci_if_error: false
-        use_oidc: true
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ./coverage.xml
+          flags: unittests
+          name: codecov-umbrella
+          fail_ci_if_error: false
+          use_oidc: true
 
-    - name: Test package build
-      run: |
-        python -m build
-        pip install dist/*.whl
-        python -c "import lab_validation; print('Package imports successfully')"
+      - name: Test package build
+        run: |
+          python -m build
+          pip install dist/*.whl
+          python -c "import lab_validation; print('Package imports successfully')"
 
   # First job to discover available labs
   discover-labs:
@@ -100,59 +100,59 @@ jobs:
     outputs:
       labs: ${{ steps.discover.outputs.labs }}
     steps:
-    - name: Checkout lab-validation
-      uses: actions/checkout@v4
+      - name: Checkout lab-validation
+        uses: actions/checkout@v4
 
-    - name: Discover available labs
-      id: discover
-      run: |
-        # Find all directories in snapshots/ and create JSON array
-        labs=$(ls -1 snapshots/ | jq -R -s -c 'split("\n")[:-1]')
-        echo "labs=$labs" >> $GITHUB_OUTPUT
-        echo "Discovered labs: $labs"
+      - name: Discover available labs
+        id: discover
+        run: |
+          # Find all directories in snapshots/ and create JSON array
+          labs=$(ls -1 snapshots/ | jq -R -s -c 'split("\n")[:-1]')
+          echo "labs=$labs" >> $GITHUB_OUTPUT
+          echo "Discovered labs: $labs"
 
   # Build Batfish JAR once and cache it (only if not using Docker)
   build-batfish:
     runs-on: ubuntu-latest
     if: inputs.batfish_docker == ''
     steps:
-    - name: Checkout Batfish
-      uses: actions/checkout@v4
-      with:
-        repository: batfish/batfish
-        path: batfish
-        ref: ${{ inputs.batfish_ref || 'master' }}
+      - name: Checkout Batfish
+        uses: actions/checkout@v4
+        with:
+          repository: batfish/batfish
+          path: batfish
+          ref: ${{ inputs.batfish_ref || 'master' }}
 
-    - name: Set up Java 17
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
-    - name: Cache Bazel
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/bazel
-        key: ${{ runner.os }}-bazel-17-${{ hashFiles('batfish/.bazelversion', 'batfish/WORKSPACE', 'batfish/maven_install.json') }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-bazel-17-${{ hashFiles('batfish/.bazelversion', 'batfish/WORKSPACE', 'batfish/maven_install.json') }}-
+      - name: Cache Bazel
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: ${{ runner.os }}-bazel-17-${{ hashFiles('batfish/.bazelversion', 'batfish/WORKSPACE', 'batfish/maven_install.json') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-17-${{ hashFiles('batfish/.bazelversion', 'batfish/WORKSPACE', 'batfish/maven_install.json') }}-
 
-    - name: Build Batfish JAR and questions
-      working-directory: batfish
-      run: |
-        bazel build //projects/allinone:allinone_main_deploy.jar
-        cp bazel-bin/projects/allinone/allinone_main_deploy.jar allinone.jar
-        # Create questions archive following pybatfish pattern
-        tar -czf questions.tgz questions/
+      - name: Build Batfish JAR and questions
+        working-directory: batfish
+        run: |
+          bazel build //projects/allinone:allinone_main_deploy.jar
+          cp bazel-bin/projects/allinone/allinone_main_deploy.jar allinone.jar
+          # Create questions archive following pybatfish pattern
+          tar -czf questions.tgz questions/
 
-    - name: Upload Batfish artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: batfish-artifacts
-        path: |
-          batfish/allinone.jar
-          batfish/questions.tgz
-        retention-days: 1
+      - name: Upload Batfish artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: batfish-artifacts
+          path: |
+            batfish/allinone.jar
+            batfish/questions.tgz
+          retention-days: 1
 
   # Matrix job to run each lab in parallel
   lab-integration-test:
@@ -163,131 +163,131 @@ jobs:
     strategy:
       matrix:
         lab: ${{ fromJson(needs.discover-labs.outputs.labs) }}
-      fail-fast: false  # Don't cancel other jobs if one fails
+      fail-fast: false # Don't cancel other jobs if one fails
 
     steps:
-    - name: Checkout lab-validation
-      uses: actions/checkout@v4
-      with:
-        path: lab-validation
+      - name: Checkout lab-validation
+        uses: actions/checkout@v4
+        with:
+          path: lab-validation
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        cache: 'pip'
-        cache-dependency-path: 'requirements*.txt'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "requirements*.txt"
 
-    - name: Set up Java 17
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
-    - name: Download Batfish artifacts
-      if: inputs.batfish_docker == ''
-      uses: actions/download-artifact@v4
-      with:
-        name: batfish-artifacts
-        path: .
+      - name: Download Batfish artifacts
+        if: inputs.batfish_docker == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: batfish-artifacts
+          path: .
 
-    - name: Install lab-validation dependencies
-      working-directory: lab-validation
-      run: |
-        python -m pip install --upgrade pip
+      - name: Install lab-validation dependencies
+        working-directory: lab-validation
+        run: |
+          python -m pip install --upgrade pip
 
-        # Install base dependencies from requirements.txt
-        pip install -r requirements.txt
+          # Install base dependencies from requirements.txt
+          pip install -r requirements.txt
 
-        # Install Pybatfish based on input parameters (may override version from requirements.txt)
-        if [ "${{ inputs.pybatfish_version }}" != "" ]; then
-          if [ "${{ inputs.pybatfish_pypi_repo }}" = "test" ]; then
-            # Retry installation from test.pypi.org to handle propagation delays
-            for attempt in 1 2 3 4 5; do
-              if pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple pybatfish==${{ inputs.pybatfish_version }}; then
-                break
-              else
-                echo "Attempt $attempt failed, waiting 30 seconds before retry..."
-                if [ $attempt -lt 5 ]; then
-                  sleep 30
+          # Install Pybatfish based on input parameters (may override version from requirements.txt)
+          if [ "${{ inputs.pybatfish_version }}" != "" ]; then
+            if [ "${{ inputs.pybatfish_pypi_repo }}" = "test" ]; then
+              # Retry installation from test.pypi.org to handle propagation delays
+              for attempt in 1 2 3 4 5; do
+                if pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple pybatfish==${{ inputs.pybatfish_version }}; then
+                  break
                 else
-                  echo "Failed to install pybatfish after 5 attempts"
-                  exit 1
+                  echo "Attempt $attempt failed, waiting 30 seconds before retry..."
+                  if [ $attempt -lt 5 ]; then
+                    sleep 30
+                  else
+                    echo "Failed to install pybatfish after 5 attempts"
+                    exit 1
+                  fi
                 fi
-              fi
-            done
+              done
+            else
+              pip install pybatfish==${{ inputs.pybatfish_version }}
+            fi
           else
-            pip install pybatfish==${{ inputs.pybatfish_version }}
+            # Default: install from git ref (override requirements.txt version)
+            PYBF_REF="${{ inputs.pybatfish_ref || 'master' }}"
+            pip install git+https://github.com/batfish/pybatfish.git@${PYBF_REF}
           fi
-        else
-          # Default: install from git ref (override requirements.txt version)
-          PYBF_REF="${{ inputs.pybatfish_ref || 'master' }}"
-          pip install git+https://github.com/batfish/pybatfish.git@${PYBF_REF}
-        fi
 
-        pip install -r requirements-dev.txt
-        pip install -e .
+          pip install -r requirements-dev.txt
+          pip install -e .
 
-    - name: Start Batfish service (Docker)
-      if: inputs.batfish_docker != ''
-      run: |
-        # Start Batfish using Docker container
-        docker run -d --name batfish \
-          -p 9996:9996 \
-          ${{ inputs.batfish_docker }}
+      - name: Start Batfish service (Docker)
+        if: inputs.batfish_docker != ''
+        run: |
+          # Start Batfish using Docker container
+          docker run -d --name batfish \
+            -p 9996:9996 \
+            ${{ inputs.batfish_docker }}
 
-        # Wait for service to start
-        sleep 15
+          # Wait for service to start
+          sleep 15
 
-    - name: Start Batfish service (JAR)
-      if: inputs.batfish_docker == ''
-      run: |
-        # Extract questions archive and start from JAR
-        tar -xzf questions.tgz
+      - name: Start Batfish service (JAR)
+        if: inputs.batfish_docker == ''
+        run: |
+          # Extract questions archive and start from JAR
+          tar -xzf questions.tgz
 
-        # Start Batfish using simple allinone mode (like pybatfish CI)
-        coordinator_args=(\
-          -templatedirs=questions \
-          -periodassignworkms=5 \
-        )
-        allinone_args=(\
-          -runclient=false \
-          -coordinatorargs="$(echo -n "${coordinator_args[@]}")" \
-        )
-        java -cp allinone.jar org.batfish.allinone.Main "${allinone_args[@]}" > batfish.log 2>&1 &
+          # Start Batfish using simple allinone mode (like pybatfish CI)
+          coordinator_args=(\
+            -templatedirs=questions \
+            -periodassignworkms=5 \
+          )
+          allinone_args=(\
+            -runclient=false \
+            -coordinatorargs="$(echo -n "${coordinator_args[@]}")" \
+          )
+          java -cp allinone.jar org.batfish.allinone.Main "${allinone_args[@]}" > batfish.log 2>&1 &
 
-        # Wait for service to start
-        sleep 10
+          # Wait for service to start
+          sleep 10
 
-    - name: Run lab integration test - ${{ matrix.lab }}
-      working-directory: lab-validation
-      run: |
-        python -m pytest lab_tests/test_labs.py -v --tb=short --labname=${{ matrix.lab }}
+      - name: Run lab integration test - ${{ matrix.lab }}
+        working-directory: lab-validation
+        run: |
+          python -m pytest lab_tests/test_labs.py -v --tb=short --labname=${{ matrix.lab }}
 
-    - name: Show Batfish logs on failure
-      if: failure()
-      run: |
-        echo "=== Batfish logs ==="
-        if [ "${{ inputs.batfish_docker }}" != "" ]; then
-          # Save docker logs to batfish.log for consistency, then display
-          docker logs batfish > batfish.log 2>&1 || echo "No Docker container logs found"
-          tail -100 batfish.log || echo "No batfish log found"
-        else
-          tail -100 batfish.log || echo "No batfish log found"
-        fi
+      - name: Show Batfish logs on failure
+        if: failure()
+        run: |
+          echo "=== Batfish logs ==="
+          if [ "${{ inputs.batfish_docker }}" != "" ]; then
+            # Save docker logs to batfish.log for consistency, then display
+            docker logs batfish > batfish.log 2>&1 || echo "No Docker container logs found"
+            tail -100 batfish.log || echo "No batfish log found"
+          else
+            tail -100 batfish.log || echo "No batfish log found"
+          fi
 
   # Summary job for required status checks
   all-labs-passed:
     runs-on: ubuntu-latest
     needs: [lab-integration-test]
-    if: always()  # Run even if some lab tests failed
+    if: always() # Run even if some lab tests failed
 
     steps:
-    - name: Check all lab tests passed
-      run: |
-        if [ "${{ needs.lab-integration-test.result }}" != "success" ]; then
-          echo "❌ Some lab integration tests failed"
-          exit 1
-        else
-          echo "✅ All lab integration tests passed"
-        fi
+      - name: Check all lab tests passed
+        run: |
+          if [ "${{ needs.lab-integration-test.result }}" != "success" ]; then
+            echo "❌ Some lab integration tests failed"
+            exit 1
+          else
+            echo "✅ All lab integration tests passed"
+          fi

--- a/.github/workflows/reusable-lab-validation.yml
+++ b/.github/workflows/reusable-lab-validation.yml
@@ -42,66 +42,66 @@ jobs:
     outputs:
       labs: ${{ steps.discover.outputs.labs }}
     steps:
-    - name: Checkout lab-validation
-      uses: actions/checkout@v4
-      with:
-        repository: batfish/lab-validation
+      - name: Checkout lab-validation
+        uses: actions/checkout@v4
+        with:
+          repository: batfish/lab-validation
 
-    - name: Discover available labs
-      id: discover
-      run: |
-        if [ "${{ inputs.lab_filter }}" != "" ]; then
-          # Apply filter pattern
-          labs=$(ls -1 snapshots/ | grep -E "${{ inputs.lab_filter }}" | jq -R -s -c 'split("\n")[:-1]')
-        else
-          # Find all directories in snapshots/
-          labs=$(ls -1 snapshots/ | jq -R -s -c 'split("\n")[:-1]')
-        fi
-        echo "labs=$labs" >> $GITHUB_OUTPUT
-        echo "Discovered labs: $labs"
+      - name: Discover available labs
+        id: discover
+        run: |
+          if [ "${{ inputs.lab_filter }}" != "" ]; then
+            # Apply filter pattern
+            labs=$(ls -1 snapshots/ | grep -E "${{ inputs.lab_filter }}" | jq -R -s -c 'split("\n")[:-1]')
+          else
+            # Find all directories in snapshots/
+            labs=$(ls -1 snapshots/ | jq -R -s -c 'split("\n")[:-1]')
+          fi
+          echo "labs=$labs" >> $GITHUB_OUTPUT
+          echo "Discovered labs: $labs"
 
   # Build Batfish JAR once and cache it (only if not using Docker)
   build-batfish:
     runs-on: ubuntu-latest
     if: inputs.batfish_docker == ''
     steps:
-    - name: Checkout Batfish
-      uses: actions/checkout@v4
-      with:
-        repository: batfish/batfish
-        path: batfish
-        ref: ${{ inputs.batfish_ref || 'master' }}
+      - name: Checkout Batfish
+        uses: actions/checkout@v4
+        with:
+          repository: batfish/batfish
+          path: batfish
+          ref: ${{ inputs.batfish_ref || 'master' }}
 
-    - name: Set up Java 17
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
-    - name: Cache Bazel
-      uses: actions/cache@v3
-      with:
-        path: ~/.cache/bazel
-        key: ${{ runner.os }}-bazel-17-${{ hashFiles('batfish/.bazelversion', 'batfish/WORKSPACE', 'batfish/maven_install.json') }}-${{ github.run_id }}
-        restore-keys: |
-          ${{ runner.os }}-bazel-17-${{ hashFiles('batfish/.bazelversion', 'batfish/WORKSPACE', 'batfish/maven_install.json') }}-
+      - name: Cache Bazel
+        uses: actions/cache@v3
+        with:
+          path: ~/.cache/bazel
+          key: ${{ runner.os }}-bazel-17-${{ hashFiles('batfish/.bazelversion', 'batfish/WORKSPACE', 'batfish/maven_install.json') }}-${{ github.run_id }}
+          restore-keys: |
+            ${{ runner.os }}-bazel-17-${{ hashFiles('batfish/.bazelversion', 'batfish/WORKSPACE', 'batfish/maven_install.json') }}-
 
-    - name: Build Batfish JAR and questions
-      working-directory: batfish
-      run: |
-        bazel build //projects/allinone:allinone_main_deploy.jar
-        cp bazel-bin/projects/allinone/allinone_main_deploy.jar allinone.jar
-        # Create questions archive following pybatfish pattern
-        tar -czf questions.tgz questions/
+      - name: Build Batfish JAR and questions
+        working-directory: batfish
+        run: |
+          bazel build //projects/allinone:allinone_main_deploy.jar
+          cp bazel-bin/projects/allinone/allinone_main_deploy.jar allinone.jar
+          # Create questions archive following pybatfish pattern
+          tar -czf questions.tgz questions/
 
-    - name: Upload Batfish artifacts
-      uses: actions/upload-artifact@v4
-      with:
-        name: batfish-artifacts
-        path: |
-          batfish/allinone.jar
-          batfish/questions.tgz
-        retention-days: 1
+      - name: Upload Batfish artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: batfish-artifacts
+          path: |
+            batfish/allinone.jar
+            batfish/questions.tgz
+          retention-days: 1
 
   # Matrix job to run each lab in parallel
   lab-integration-test:
@@ -112,132 +112,132 @@ jobs:
     strategy:
       matrix:
         lab: ${{ fromJson(needs.discover-labs.outputs.labs) }}
-      fail-fast: false  # Don't cancel other jobs if one fails
+      fail-fast: false # Don't cancel other jobs if one fails
 
     steps:
-    - name: Checkout lab-validation
-      uses: actions/checkout@v4
-      with:
-        repository: batfish/lab-validation
-        path: lab-validation
+      - name: Checkout lab-validation
+        uses: actions/checkout@v4
+        with:
+          repository: batfish/lab-validation
+          path: lab-validation
 
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v4
-      with:
-        python-version: "3.10"
-        cache: 'pip'
-        cache-dependency-path: 'requirements*.txt'
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+          cache: "pip"
+          cache-dependency-path: "requirements*.txt"
 
-    - name: Set up Java 17
-      uses: actions/setup-java@v4
-      with:
-        distribution: 'temurin'
-        java-version: '17'
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
 
-    - name: Download Batfish artifacts
-      if: inputs.batfish_docker == ''
-      uses: actions/download-artifact@v4
-      with:
-        name: batfish-artifacts
-        path: .
+      - name: Download Batfish artifacts
+        if: inputs.batfish_docker == ''
+        uses: actions/download-artifact@v4
+        with:
+          name: batfish-artifacts
+          path: .
 
-    - name: Install lab-validation dependencies
-      working-directory: lab-validation
-      run: |
-        python -m pip install --upgrade pip
+      - name: Install lab-validation dependencies
+        working-directory: lab-validation
+        run: |
+          python -m pip install --upgrade pip
 
-        # Install base dependencies from requirements.txt
-        pip install -r requirements.txt
+          # Install base dependencies from requirements.txt
+          pip install -r requirements.txt
 
-        # Install Pybatfish based on input parameters (may override version from requirements.txt)
-        if [ "${{ inputs.pybatfish_version }}" != "" ]; then
-          if [ "${{ inputs.pybatfish_pypi_repo }}" = "test" ]; then
-            # Retry installation from test.pypi.org to handle propagation delays
-            for attempt in 1 2 3 4 5; do
-              if pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple pybatfish==${{ inputs.pybatfish_version }}; then
-                break
-              else
-                echo "Attempt $attempt failed, waiting 30 seconds before retry..."
-                if [ $attempt -lt 5 ]; then
-                  sleep 30
+          # Install Pybatfish based on input parameters (may override version from requirements.txt)
+          if [ "${{ inputs.pybatfish_version }}" != "" ]; then
+            if [ "${{ inputs.pybatfish_pypi_repo }}" = "test" ]; then
+              # Retry installation from test.pypi.org to handle propagation delays
+              for attempt in 1 2 3 4 5; do
+                if pip install -i https://test.pypi.org/simple --extra-index-url https://pypi.org/simple pybatfish==${{ inputs.pybatfish_version }}; then
+                  break
                 else
-                  echo "Failed to install pybatfish after 5 attempts"
-                  exit 1
+                  echo "Attempt $attempt failed, waiting 30 seconds before retry..."
+                  if [ $attempt -lt 5 ]; then
+                    sleep 30
+                  else
+                    echo "Failed to install pybatfish after 5 attempts"
+                    exit 1
+                  fi
                 fi
-              fi
-            done
+              done
+            else
+              pip install pybatfish==${{ inputs.pybatfish_version }}
+            fi
           else
-            pip install pybatfish==${{ inputs.pybatfish_version }}
+            # Default: install from git ref (override requirements.txt version)
+            PYBF_REF="${{ inputs.pybatfish_ref || 'master' }}"
+            pip install git+https://github.com/batfish/pybatfish.git@${PYBF_REF}
           fi
-        else
-          # Default: install from git ref (override requirements.txt version)
-          PYBF_REF="${{ inputs.pybatfish_ref || 'master' }}"
-          pip install git+https://github.com/batfish/pybatfish.git@${PYBF_REF}
-        fi
 
-        pip install -r requirements-dev.txt
-        pip install -e .
+          pip install -r requirements-dev.txt
+          pip install -e .
 
-    - name: Start Batfish service (Docker)
-      if: inputs.batfish_docker != ''
-      run: |
-        # Start Batfish using Docker container
-        docker run -d --name batfish \
-          -p 9996:9996 \
-          ${{ inputs.batfish_docker }}
+      - name: Start Batfish service (Docker)
+        if: inputs.batfish_docker != ''
+        run: |
+          # Start Batfish using Docker container
+          docker run -d --name batfish \
+            -p 9996:9996 \
+            ${{ inputs.batfish_docker }}
 
-        # Wait for service to start
-        sleep 15
+          # Wait for service to start
+          sleep 15
 
-    - name: Start Batfish service (JAR)
-      if: inputs.batfish_docker == ''
-      run: |
-        # Extract questions archive and start from JAR
-        tar -xzf questions.tgz
+      - name: Start Batfish service (JAR)
+        if: inputs.batfish_docker == ''
+        run: |
+          # Extract questions archive and start from JAR
+          tar -xzf questions.tgz
 
-        # Start Batfish using simple allinone mode (like pybatfish CI)
-        coordinator_args=(\
-          -templatedirs=questions \
-          -periodassignworkms=5 \
-        )
-        allinone_args=(\
-          -runclient=false \
-          -coordinatorargs="$(echo -n "${coordinator_args[@]}")" \
-        )
-        java -cp allinone.jar org.batfish.allinone.Main "${allinone_args[@]}" > batfish.log 2>&1 &
+          # Start Batfish using simple allinone mode (like pybatfish CI)
+          coordinator_args=(\
+            -templatedirs=questions \
+            -periodassignworkms=5 \
+          )
+          allinone_args=(\
+            -runclient=false \
+            -coordinatorargs="$(echo -n "${coordinator_args[@]}")" \
+          )
+          java -cp allinone.jar org.batfish.allinone.Main "${allinone_args[@]}" > batfish.log 2>&1 &
 
-        # Wait for service to start
-        sleep 10
+          # Wait for service to start
+          sleep 10
 
-    - name: Run lab integration test - ${{ matrix.lab }}
-      working-directory: lab-validation
-      run: |
-        python -m pytest lab_tests/test_labs.py -v --tb=short --labname=${{ matrix.lab }}
+      - name: Run lab integration test - ${{ matrix.lab }}
+        working-directory: lab-validation
+        run: |
+          python -m pytest lab_tests/test_labs.py -v --tb=short --labname=${{ matrix.lab }}
 
-    - name: Show Batfish logs on failure
-      if: failure()
-      run: |
-        echo "=== Batfish logs ==="
-        if [ "${{ inputs.batfish_docker }}" != "" ]; then
-          # Save docker logs to batfish.log for consistency, then display
-          docker logs batfish > batfish.log 2>&1 || echo "No Docker container logs found"
-          tail -100 batfish.log || echo "No batfish log found"
-        else
-          tail -100 batfish.log || echo "No batfish log found"
-        fi
+      - name: Show Batfish logs on failure
+        if: failure()
+        run: |
+          echo "=== Batfish logs ==="
+          if [ "${{ inputs.batfish_docker }}" != "" ]; then
+            # Save docker logs to batfish.log for consistency, then display
+            docker logs batfish > batfish.log 2>&1 || echo "No Docker container logs found"
+            tail -100 batfish.log || echo "No batfish log found"
+          else
+            tail -100 batfish.log || echo "No batfish log found"
+          fi
 
   # Summary job for required status checks
   all-labs-passed:
     runs-on: ubuntu-latest
     needs: [lab-integration-test]
-    if: always()  # Run even if some lab tests failed
+    if: always() # Run even if some lab tests failed
 
     steps:
-    - name: Check all lab tests passed
-      run: |
-        if [ "${{ needs.lab-integration-test.result }}" != "success" ]; then
-          echo "❌ Some lab integration tests failed"
-          exit 1
-        else
-          echo "✅ All lab integration tests passed"
-        fi
+      - name: Check all lab tests passed
+        run: |
+          if [ "${{ needs.lab-integration-test.result }}" != "success" ]; then
+            echo "❌ Some lab integration tests failed"
+            exit 1
+          else
+            echo "✅ All lab integration tests passed"
+          fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,8 @@ repos:
     rev: v3.0.3
     hooks:
       - id: prettier
-        types_or: [markdown]
+        types_or: [markdown, yaml]
+        exclude: ^snapshots/.*/show/
 
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.3.1

--- a/snapshots/aws_nlb_multi_az/validation/sickbay.yaml
+++ b/snapshots/aws_nlb_multi_az/validation/sickbay.yaml
@@ -1,5 +1,5 @@
 entries:
- - hostname: 8.8.8.8
-   test_name: test_connectivity
-   skip:
-     reason: https://github.com/batfish/lab-validation/issues/36
+  - hostname: 8.8.8.8
+    test_name: test_connectivity
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/36


### PR DESCRIPTION
This PR extends prettier formatting to include YAML files in the pre-commit hooks while preserving raw device output.

## Changes

- Add `yaml` to prettier `types_or` configuration in `.pre-commit-config.yaml`
- Add exclude pattern `^snapshots/.*/show/` to skip raw device output files
- Run prettier on appropriate YAML files to apply consistent formatting
- Format GitHub workflow files and sickbay validation files
- Preserve original formatting for device show command outputs in `snapshots/*/show/` directories

## Benefits

- Consistent YAML formatting across configuration and workflow files
- Automatic YAML formatting during pre-commit to maintain consistency
- Improved readability of GitHub Actions workflows and configuration files
- Preserves raw device output exactly as captured from network devices
- Reduces formatting-related diff noise in future changes

This change ensures all YAML files follow consistent formatting standards while respecting the need to preserve raw device data unchanged.