### PR TITLE
Update pre-commit hooks to latest versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
@@ -18,7 +18,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v3.0.3
+    rev: v4.0.0-alpha.8
     hooks:
       - id: prettier
         types_or: [markdown, yaml]

--- a/snapshots/panos_ebgp_loop_prevention/README.MD
+++ b/snapshots/panos_ebgp_loop_prevention/README.MD
@@ -5,7 +5,6 @@
 ## LAB Facts
 
 - Lab is created to understand the `ebgp loop prevention` in `panos`
-
   - `d1` advertises route(`192.168.123.2/32`) to all peers `D2`
   - Based on the bgp peer configuration on D2, route will be accepted/rejected/not_sent
     - D2 does not advertise route to D3


### PR DESCRIPTION
This PR updates the pre-commit hooks to their latest versions to benefit from bug fixes and improvements.

## Changes

- **pre-commit-hooks**: Updated from v4.4.0 to v6.0.0
- **mirrors-prettier**: Updated from v3.0.3 to v4.0.0-alpha.8

## Updates Applied

The update includes:
- Version bumps in `.pre-commit-config.yaml`
- Prettier formatting fix applied to one README file (removed extra blank line)

## Benefits

- Latest bug fixes and security updates
- Improved performance and reliability
- Continued compatibility with existing code style

All pre-commit hooks pass successfully after the update.