### PR TITLE
Enable mypy type checking in pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,3 +42,4 @@ repos:
           ]
         args: [src/]
         pass_filenames: false
+        files: ^src/.*\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,12 +23,22 @@ repos:
       - id: prettier
         types_or: [markdown, yaml]
         exclude: ^snapshots/.*/show/
-# MyPy type checking (run manually with: mypy src/)
-# Disabled in pre-commit due to module resolution issues in isolated environment
-# - repo: https://github.com/pre-commit/mirrors-mypy
-#   rev: v1.8.0
-#   hooks:
-#   - id: mypy
-#     additional_dependencies: [pybatfish, attrs, pyparsing, pandas-stubs, types-requests]
-#     args: [--explicit-package-bases, --namespace-packages]
-#     files: ^src/
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.18.1
+    hooks:
+      - id: mypy
+        additional_dependencies:
+          [
+            pybatfish,
+            attrs,
+            pyparsing,
+            pandas-stubs,
+            types-requests,
+            PyYAML,
+            requests,
+            pandas,
+            pytest,
+            types-PyYAML,
+          ]
+        args: [src/]
+        pass_filenames: false


### PR DESCRIPTION
This PR enables mypy type checking in the pre-commit hooks configuration.

## Changes

- Add mypy hook using the mirrors version for CI compatibility
- Include all necessary dependencies for proper type checking
- Configure mypy to run on `src/` directory only
- Use `pass_filenames: false` to avoid module resolution issues

## Benefits

- **Type safety**: Catch type-related bugs before they reach the main branch
- **CI integration**: Works seamlessly in GitHub Actions and other CI environments
- **Developer experience**: Automatic type checking on every commit
- **Code quality**: Maintains strict typing standards established in `pyproject.toml`

## Technical Details

- Uses `repo: https://github.com/pre-commit/mirrors-mypy` for CI compatibility
- Includes comprehensive `additional_dependencies` list for all project imports
- Configured with `args: [src/]` and `pass_filenames: false` to handle package structure correctly
- Runs mypy v1.18.1 with strict type checking settings from `pyproject.toml`

## Testing

- ✅ All 138 source files in `src/` pass mypy type checking
- ✅ All pre-commit hooks work together successfully  
- ✅ Configuration tested locally and ready for CI

The test files in `tests/` have 126+ type issues that would require significant refactoring, so they are excluded for now but could be addressed in a future PR.