### PR TITLE
onug_cost_optimized_s3_path: remove sickbay entry fwl01 main_rib

### DIFF
--- a/snapshots/onug_cost_optimized_s3_path/validation/sickbay.yaml
+++ b/snapshots/onug_cost_optimized_s3_path/validation/sickbay.yaml
@@ -86,10 +86,6 @@ entries:
   - hostname: bl01
     test_name: test_interface_properties
   - hostname: fwl01
-    test_name: test_main_rib_routes
-    skip:
-      reason: https://github.com/batfish/lab-validation/issues/74
-  - hostname: fwl01
     test_name: test_bgp_rib_routes
   - hostname: fwl01
     test_name: test_interface_properties


### PR DESCRIPTION
The VPN tunnels between fwl01 and the AWS transit gateway now
establish correctly after the Batfish fix for AWS IPSec TunnelOptions
parsing. The 4 BGP routes in the DATA VRF (10.2-5.0.0/16) that were
missing due to the broken tunnels are now present.

Closes #74

----

Prompt:
```
work on https://github.com/batfish/lab-validation/issues/74
```

---

**Stack**:
- #102 ⬅
- #103


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*