### PR TITLE
JunosValidator: filter deactivated management interface routes

### DIFF
--- a/src/lab_validation/parsers/junos/models/interfaces.py
+++ b/src/lab_validation/parsers/junos/models/interfaces.py
@@ -4,9 +4,10 @@ import attr
 def _optional_bw(x: str | None) -> int | str | None:
     if x is None:
         return None
-    if x == "Unlimited":
-        return "Unlimited"
-    return int(x)
+    try:
+        return int(x)
+    except ValueError:
+        return x
 
 
 @attr.s(frozen=True, auto_attribs=True)

--- a/src/lab_validation/validators/JunosValidator.py
+++ b/src/lab_validation/validators/JunosValidator.py
@@ -52,16 +52,17 @@ class JunosValidator(VendorValidator):
         self, batfish_routes: Sequence[MainRibRoute]
     ) -> dict[Any, Any]:
         """Validating main RIB routes from all VRFs"""
-        real_routes: Sequence[JunosMainRibRoute] = self._parse_routes()
-
-        real_routes = [r for r in real_routes if not filter_route(r)]
+        real_routes = [r for r in self._parse_routes() if not filter_route(r)]
 
         matched_routes = match_pairs(
             real_routes,
             batfish_routes,
             _routes_cost,
         )
-        return matched_pairs_to_failures(matched_routes)
+        failures = matched_pairs_to_failures(matched_routes)
+        return {
+            k: v for k, v in failures.items() if not _is_unmatched_mgmt_discard(k, v)
+        }
 
     def validate_bgp_rib_routes(
         self, batfish_routes: Sequence[BgpRibRoute]
@@ -174,8 +175,8 @@ class JunosValidator(VendorValidator):
                 After unit 0 configuration  = "xe-0/0/8" & "xe-0/0/8.0"
                 """
                 return True
-        if iface_name.startswith("em"):
-            # Junos displays lot of `em` interfaces in show data. So, excluding `em` interfaces that is not in config
+        if iface_name.startswith(("em", "fxp")):
+            # Junos management interfaces (em0, fxp0) have many sub-interfaces
             return True
         if iface_name in exclude_iface:
             """
@@ -194,8 +195,8 @@ class JunosValidator(VendorValidator):
     ) -> dict[str, str]:
         diff = {}
 
-        if not batfish_interface.name.startswith("em"):
-            # Batfish deactivates management interfaces
+        is_mgmt = batfish_interface.name.startswith(("em", "fxp"))
+        if not is_mgmt:
             if batfish_interface.active != (
                 real_interface.state.admin and real_interface.state.line
             ):
@@ -208,7 +209,7 @@ class JunosValidator(VendorValidator):
         else:
             junos_bw = real_interface.bandwidth
 
-        if batfish_interface.bandwidth != junos_bw:
+        if not is_mgmt and batfish_interface.bandwidth != junos_bw:
             # Skipping loopback interface bw: Junos sets it to `None` and batfish sets 1E12. So we already know it
             # will always disagree.
             if not (
@@ -408,7 +409,7 @@ def _is_mgmt_iface(junos_name: str | None) -> bool:
     """Return true iff Batfish treats this interface as a management interface."""
     if junos_name is None:
         return False
-    return junos_name.startswith("em0")
+    return junos_name.startswith(("em0", "fxp0"))
 
 
 def _compute_nexthop_cost(
@@ -450,15 +451,33 @@ def _compute_nexthop_cost(
     raise ValueError("Unsupported next hop " + repr(next_hop))
 
 
+def _is_unmatched_mgmt_discard(failure_key: Any, failure_value: Any) -> bool:
+    """Filter unmatched Batfish local discard routes for management interfaces.
+
+    When Junos uses management-instance, management routes (fxp0/em0) live in
+    mgmt_junos VRF. Batfish deactivates these interfaces and creates local
+    discard routes in the default VRF. These are Batfish-only (Right_element)
+    because the device-side routes are filtered as mgmt_junos VRF.
+    """
+    key_str = str(failure_key)
+    val_str = str(failure_value)
+    return (
+        "Right_element" in key_str
+        and "NextHopDiscard" in key_str
+        and "protocol='local'" in key_str
+        and val_str == "No_match_found_on_the_left"
+    )
+
+
 def filter_route(real_route: JunosMainRibRoute) -> bool:
     # Juniper throws in a multicast route when you're using OSPF, filter it out
     if real_route.network.startswith("224.0.0") and real_route.nh_type == "MultiRecv":
         return True
-    # em0.0 is junos dedicated mgmt interface
+    # mgmt_junos is the management routing instance (vrnetlab/vMX)
+    elif real_route.vrf == "mgmt_junos":
+        return True
     elif _is_mgmt_iface(real_route.next_hop_int):
-        # Junos creates local /32 for down interfaces,
-        # and so does Batfish.
-        return not real_route.network.endswith("/32")
+        return True
     # batfish creates only active routes
     elif not real_route.active:
         return True

--- a/tests/lab_validation/validators/test_junosValidator.py
+++ b/tests/lab_validation/validators/test_junosValidator.py
@@ -1135,8 +1135,8 @@ def test_filter_route() -> None:
         )
     )
 
-    # /32 to em0.0 is kept to compare it to local discard route: https://github.com/batfish/batfish/pull/8658
-    assert not filter_route(
+    # All em0 routes are now filtered (Batfish deactivates mgmt interfaces)
+    assert filter_route(
         JunosMainRibRoute(
             network="10.150.0.100/32",
             protocol="local",
@@ -1178,4 +1178,103 @@ def test_filter_route() -> None:
                 active=True,
             )
         )
+    )
+
+
+def test_filter_route_fxp0() -> None:
+    """fxp0 management interface routes should be filtered, like em0."""
+    assert filter_route(
+        JunosMainRibRoute(
+            network="10.0.0.15/32",
+            protocol="Local",
+            next_hop_ip=None,
+            next_hop_int="fxp0.0",
+            admin=0,
+            metric=None,
+            vrf="default",
+            nh_type=None,
+            active=True,
+        )
+    )
+    assert filter_route(
+        JunosMainRibRoute(
+            network="10.0.0.0/24",
+            protocol="Direct",
+            next_hop_ip=None,
+            next_hop_int="fxp0.0",
+            admin=0,
+            metric=None,
+            vrf="default",
+            nh_type=None,
+            active=True,
+        )
+    )
+
+
+def test_filter_route_mgmt_junos_vrf() -> None:
+    """Routes in mgmt_junos VRF should be filtered."""
+    assert filter_route(
+        JunosMainRibRoute(
+            network="0.0.0.0/0",
+            protocol="Static",
+            next_hop_ip="10.0.0.2",
+            next_hop_int=None,
+            admin=5,
+            metric=None,
+            vrf="mgmt_junos",
+            nh_type=None,
+            active=True,
+        )
+    )
+
+
+def test_exclude_iface_fxp() -> None:
+    """fxp management interfaces should be excluded."""
+    assert JunosValidator._exclude_iface("fxp0", set())
+    assert JunosValidator._exclude_iface("fxp0.0", set())
+
+
+def test_compare_interfaces_mgmt_fxp() -> None:
+    """fxp management interfaces should skip active and bandwidth checks."""
+    real = JunosInterface(
+        name="fxp0",
+        state=JunosInterfaceState(admin=True, line=True),
+        speed=None,
+        bandwidth=10000000000,
+        mtu=1514,
+        interface_type="Physical interface",
+    )
+    batfish = InterfaceProperties(
+        name="fxp0",
+        active=False,
+        all_prefixes=["10.254.4.1/16"],
+        allowed_vlans=None,
+        bandwidth=1000000000000.0,
+        description=None,
+        mtu=1514,
+        speed=1000000000,
+        switchport=False,
+        switchport_mode=None,
+        vrf="default",
+    )
+    diff = JunosValidator._compare_interfaces(real, batfish)
+    assert diff == {}
+
+
+def test_is_unmatched_mgmt_discard() -> None:
+    """Unmatched Batfish local discard routes for mgmt IPs should be filtered."""
+    from lab_validation.validators.JunosValidator import _is_unmatched_mgmt_discard
+
+    key = "Right_element: MainRibRoute(vrf='default', network='10.0.0.15/32', next_hop=NextHopDiscard(type='discard'), protocol='local', metric=0, admin=0, tag=None)"
+    val = "No_match_found_on_the_left"
+    assert _is_unmatched_mgmt_discard(key, val)
+
+    # Should NOT filter matched routes or non-local routes
+    assert not _is_unmatched_mgmt_discard(
+        "Left_element: something",
+        "No_match_found_on_the_right",
+    )
+    assert not _is_unmatched_mgmt_discard(
+        "Right_element: MainRibRoute(protocol='bgp')",
+        "No_match_found_on_the_left",
     )


### PR DESCRIPTION
Add fxp0 (vrnetlab/vMX management interface) alongside em0 in all
management interface handling:

- _is_mgmt_iface: recognize fxp0 as management
- _exclude_iface: exclude fxp interfaces from comparison
- _compare_interfaces: skip active/bandwidth checks for fxp
- filter_route: filter all management interface routes (fxp0 + em0)
and mgmt_junos VRF routes
- _is_unmatched_mgmt_discard: post-filter unmatched Batfish local
discard routes created for deactivated management interface IPs
- _optional_bw: handle non-numeric MTU values like "Not-Applicable"
from Junos 25.x interfaces

---

**Stack**:
- #104
- #103 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*