### PR TITLE
Add lab builder infrastructure for creating labs with containerlab on AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -146,3 +146,8 @@ networks/
 working/
 CLAUDE.md
 .claude/
+
+# VM images (large, user-provided, not distributed)
+*.qcow2
+*.vmdk
+*.ova

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,348 @@
+# Lab Creation Infrastructure
+
+Tools for creating new lab-validation snapshots using
+[containerlab](https://containerlab.dev/) on AWS EC2 with Juniper
+vJunos-router virtual images.
+
+## Overview
+
+This directory contains everything needed to:
+
+1. Provision an AWS EC2 instance with KVM, Docker, and containerlab
+2. Deploy Juniper virtual router topologies
+3. Collect device operational data (show command outputs)
+4. Package the data as lab-validation snapshots
+5. Validate against Batfish
+
+The workflow is designed to be driven by Claude Code or run manually.
+
+## Prerequisites
+
+- **AWS CLI v2.34+** with configured credentials (`aws configure` or
+  `AWS_PROFILE` environment variable)
+- **Juniper vJunos-router qcow2 image** — free download from
+  [Juniper vJunos Labs](https://www.juniper.net/us/en/dm/vjunos-labs.html)
+  (non-production use, no time limit)
+- **Batfish** running locally for validation (Docker image or built from
+  source)
+
+## One-Time Setup
+
+### 1. Download the Juniper Image
+
+Download `vJunos-router-*.qcow2` from Juniper's website and save it to
+`infra/images/` (this directory is gitignored):
+
+```bash
+ls infra/images/
+# vJunos-router-25.4R1.12.qcow2
+```
+
+### 2. Upload to S3
+
+```bash
+cd infra
+AWS_PROFILE=<profile> ./upload-image.sh
+```
+
+This creates an S3 bucket named `lab-validation-images-<account-id>` (if it
+doesn't exist) and uploads all qcow2 files from `infra/images/`. Idempotent —
+skips files already in S3.
+
+### 3. First Launch — Build the Docker Image
+
+The first EC2 launch will find the qcow2 in S3 but no pre-built Docker image.
+The setup script automatically builds the vrnetlab container and uploads the
+result to S3 for future launches. This takes ~10 minutes total for the first
+launch.
+
+```bash
+AWS_PROFILE=<profile> ./ec2-launch.sh
+# Wait for setup to complete (~5-10 min)
+ssh -i <key> ubuntu@<ip> 'cat /var/log/ec2-setup-complete'
+```
+
+### Subsequent Launches
+
+After the Docker image is in S3, new instances load it directly (~2-3 min):
+
+```bash
+AWS_PROFILE=<profile> ./ec2-launch.sh
+```
+
+## Creating a Lab
+
+### Step 1: Design the Topology
+
+Create a containerlab topology YAML file and Junos configs. Configs must be
+in **curly-brace format** (not `set` format) because vrnetlab concatenates
+them with its init.conf and loads them as a config disk.
+
+See `infra/examples/` for working examples:
+
+- `two-router-ebgp.clab.yml` — minimal 2-router eBGP lab
+- `evpn-type5/topology.clab.yml` — 4-node EVPN Type 5 fabric
+
+**Interface mapping**: containerlab `ethN` maps to Junos `ge-0/0/(N-1)`:
+
+| containerlab | Junos             |
+| ------------ | ----------------- |
+| eth0         | management (auto) |
+| eth1         | ge-0/0/0          |
+| eth2         | ge-0/0/1          |
+| eth3         | ge-0/0/2          |
+| ethN         | ge-0/0/(N-1)      |
+
+### Step 2: Launch EC2 and Upload
+
+```bash
+# Launch instance
+AWS_PROFILE=<profile> ./ec2-launch.sh
+
+# Upload topology and configs
+IP=<from launch output>
+KEY=<from launch output>
+ssh -i $KEY ubuntu@$IP 'mkdir -p ~/lab/mylab/configs ~/lab/src'
+scp -i $KEY -r src/lab_builder ubuntu@$IP:~/lab/src/
+scp -i $KEY topology.clab.yml ubuntu@$IP:~/lab/mylab/
+scp -i $KEY configs/*.cfg ubuntu@$IP:~/lab/mylab/configs/
+```
+
+### Step 3: Deploy Topology
+
+```bash
+ssh -i $KEY ubuntu@$IP \
+    'cd ~/lab/mylab && sudo containerlab deploy -t topology.clab.yml'
+```
+
+vJunos-router takes 5-10 minutes to boot. Monitor with:
+
+```bash
+ssh -i $KEY ubuntu@$IP 'sudo containerlab inspect -t ~/lab/mylab/topology.clab.yml'
+```
+
+Wait until all nodes show `(healthy)`.
+
+### Step 4: Health Check
+
+Verify SSH access and routing protocol convergence:
+
+```bash
+ssh -i $KEY ubuntu@$IP \
+    'cd ~/lab && PYTHONPATH=src python3 -m lab_builder health-check mylab/topology.clab.yml'
+```
+
+This waits for SSH on all nodes, then polls BGP/OSPF/ISIS neighbor status
+until sessions are established.
+
+### Step 5: Collect Show Commands
+
+```bash
+ssh -i $KEY ubuntu@$IP \
+    'cd ~/lab && PYTHONPATH=src python3 -m lab_builder collect mylab/topology.clab.yml --output-dir /tmp/collected'
+```
+
+Collects 9 show commands per Junos node (see "Show Commands Collected" below).
+Files are named to match the lab-validation parser conventions.
+
+### Step 6: Build Snapshot
+
+```bash
+ssh -i $KEY ubuntu@$IP \
+    'cd ~/lab && PYTHONPATH=src python3 -m lab_builder build-snapshot mylab/topology.clab.yml --name junos_my_feature --collected-dir /tmp/collected --snapshots-dir /tmp/snapshots'
+```
+
+### Step 7: Download Snapshot
+
+```bash
+scp -i $KEY -r ubuntu@$IP:/tmp/snapshots/junos_my_feature snapshots/
+```
+
+### Step 8: Tear Down
+
+```bash
+AWS_PROFILE=<profile> ./ec2-teardown.sh
+```
+
+### Step 9: Validate Against Batfish
+
+Locally (requires Batfish running):
+
+```bash
+pytest lab_tests/test_labs.py --labname=junos_my_feature -v --tb=short
+```
+
+### Step 10: Triage Failures
+
+For each test failure, determine the cause:
+
+- **Parser bug**: the lab-validation parsers can't handle the device output.
+  Fix the parser, add unit tests.
+- **Batfish modeling discrepancy**: Batfish predicts different routes or
+  interfaces than the real device. File a GitHub issue in batfish/batfish or
+  batfish/lab-validation and add a sickbay entry.
+- **Config error in the lab**: fix the config, re-deploy, re-collect.
+- **Expected difference**: management interfaces, pseudo-interfaces, etc. that
+  Batfish intentionally doesn't model. Update the validator's exclusion logic.
+
+## Iterating on a Lab
+
+To modify configs without full redeploy (saves 5-10 min boot time):
+
+```bash
+# Push new config to a node
+ssh -i $KEY ubuntu@$IP \
+    'cd ~/lab && PYTHONPATH=src python3 -m lab_builder push-config mylab/topology.clab.yml r1 /path/to/new-config.txt'
+
+# Re-collect just that node
+ssh -i $KEY ubuntu@$IP \
+    'cd ~/lab && PYTHONPATH=src python3 -m lab_builder recollect mylab/topology.clab.yml r1 --output-dir /tmp/collected'
+```
+
+Then re-download and re-validate locally.
+
+## Scripts Reference
+
+| Script            | Where it runs | Purpose                                                   |
+| ----------------- | ------------- | --------------------------------------------------------- |
+| `ec2-launch.sh`   | Local         | Launch EC2 with KVM, Docker, containerlab, images from S3 |
+| `ec2-status.sh`   | Local         | Show all lab-validation instances, warn about orphans     |
+| `ec2-teardown.sh` | Local         | Terminate instance and clean up                           |
+| `upload-image.sh` | Local         | Upload qcow2 images to S3 (idempotent)                    |
+| `build-image.sh`  | EC2           | Build vrnetlab Docker image from qcow2, upload to S3      |
+| `ec2-setup.sh`    | EC2 (auto)    | Bootstrap script, runs as user-data                       |
+
+## lab_builder CLI Reference
+
+Run on EC2 as `PYTHONPATH=src python3 -m lab_builder <command>`:
+
+| Command                                                                  | Purpose                              |
+| ------------------------------------------------------------------------ | ------------------------------------ |
+| `deploy <topo.yml>`                                                      | Deploy containerlab topology         |
+| `inspect <topo.yml>`                                                     | Show discovered nodes and IPs        |
+| `health-check <topo.yml> [--timeout N]`                                  | Wait for SSH + routing convergence   |
+| `collect <topo.yml> --output-dir DIR`                                    | Collect show commands from all nodes |
+| `recollect <topo.yml> NODE --output-dir DIR`                             | Re-collect one node                  |
+| `push-config <topo.yml> NODE FILE`                                       | Push set-format config and commit    |
+| `build-snapshot <topo.yml> --name N --collected-dir D --snapshots-dir S` | Package as snapshot                  |
+| `destroy <topo.yml>`                                                     | Tear down topology                   |
+
+## Show Commands Collected
+
+For Juniper (vJunos-router), these are collected automatically:
+
+| Command                                   | Goes to           | Purpose              |
+| ----------------------------------------- | ----------------- | -------------------- |
+| `show configuration \| display set`       | `configs/<node>/` | Device config        |
+| `show route \| display json`              | `show/<node>/`    | Main routing table   |
+| `show route protocol bgp \| display json` | `show/<node>/`    | BGP routes           |
+| `show interfaces \| display json`         | `show/<node>/`    | Interface properties |
+| `show route instance \| display json`     | `show/<node>/`    | VRF info             |
+| `show version \| display json`            | `show/<node>/`    | Software version     |
+| `show bgp neighbor \| display json`       | `show/<node>/`    | BGP peer status      |
+| `show ospf neighbor \| display json`      | `show/<node>/`    | OSPF status          |
+| `show isis adjacency \| display json`     | `show/<node>/`    | ISIS status          |
+
+## Snapshot Directory Structure
+
+The output matches the lab-validation framework's expected layout:
+
+```
+snapshots/<name>/
+├── configs/
+│   ├── <node1>/
+│   │   └── show_configuration_|_display_set.txt
+│   └── <node2>/
+│       └── show_configuration_|_display_set.txt
+├── show/
+│   ├── host_nos.txt          # {"node1": "junos", "node2": "junos"}
+│   ├── <node1>/
+│   │   ├── show_route_|_display_json.txt
+│   │   ├── show_route_protocol_bgp_|_display_json.txt
+│   │   ├── show_interfaces_|_display_json.txt
+│   │   └── ...
+│   └── <node2>/
+│       └── ...
+└── validation/               # optional
+    └── sickbay.yaml          # expected failure entries
+```
+
+## EC2 Instance Details
+
+### Instance Types
+
+Default is **m8i.2xlarge** (8 vCPU, 32 GB RAM). These support nested
+virtualization via `--cpu-options NestedVirtualization=enabled`, which vrnetlab
+needs to run VM-based router images inside Docker containers.
+
+| Instance    | vCPU | RAM   | ~$/hr  | Routers |
+| ----------- | ---- | ----- | ------ | ------- |
+| m8i.xlarge  | 4    | 16 GB | ~$0.23 | 1-2     |
+| m8i.2xlarge | 8    | 32 GB | ~$0.46 | 2-4     |
+| m8i.4xlarge | 16   | 64 GB | ~$0.92 | 4-8     |
+
+Each vJunos-router needs ~5 GB RAM and 4 vCPUs.
+
+For spot pricing (~70% cheaper), add `--spot`.
+
+### ec2-launch.sh Options
+
+```
+--instance-type TYPE   EC2 instance type (default: m8i.2xlarge)
+--key-name NAME        Use existing EC2 key pair (auto-created if omitted)
+--timeout-hours N      Auto-terminate after N hours (default: 4)
+--spot                 Request spot instance
+```
+
+### Cost Safety
+
+- Auto-terminate alarm after 4 hours (configurable)
+- `ec2-status.sh` warns about orphaned instances
+- The launch script prevents creating multiple tracked instances
+
+### What Gets Installed (ec2-setup.sh)
+
+- Docker CE
+- containerlab (from netdevops apt repo)
+- KVM/QEMU tools (qemu-kvm, libvirt)
+- Python 3 with netmiko, paramiko, PyYAML, awscli
+- Pre-built Docker images from S3 (or builds from qcow2 as fallback)
+
+## Lab Design Principles
+
+- **Simplicity**: minimum routers to demonstrate the feature (2-3 typical)
+- **Feature isolation**: one feature per lab
+- **Corner cases**: misconfigurations, asymmetric settings, boundary values
+- **Reproducibility**: deterministic results, avoid time-dependent behavior
+- **Documentation**: README explaining what the lab tests and why
+
+## Supported Vendor Profiles
+
+| containerlab kind       | Vendor              | Default creds     | Boot time | KVM required |
+| ----------------------- | ------------------- | ----------------- | --------- | ------------ |
+| `juniper_vjunosrouter`  | Junos (MX)          | admin / admin@123 | 5-10 min  | Yes          |
+| `juniper_vjunosevolved` | Junos Evolved (PTX) | admin / admin@123 | ~15 min   | Yes          |
+| `juniper_crpd`          | Junos cRPD          | root / clab123    | ~1 min    | No           |
+
+## Troubleshooting
+
+**SSH connection refused after deploy**: vJunos-router takes 5-10 minutes to
+boot. Wait for `(healthy)` in `containerlab inspect` output before attempting
+SSH.
+
+**Startup config not applied**: Configs must be in curly-brace format, not
+set format. vrnetlab concatenates the config with its init.conf and mounts
+it as a USB config disk.
+
+**KVM not available**: Verify the instance type supports nested virtualization
+(M8i/C8i/R8i families) and that `--cpu-options NestedVirtualization=enabled`
+was used at launch. Check with `ls /dev/kvm` on the instance.
+
+**Docker image not loaded**: Check `docker images | grep vjunos`. If empty,
+the S3 bucket may not have the Docker tarball. The setup script falls back to
+building from qcow2 if available.
+
+**Node names wrong in collected data**: containerlab names containers as
+`clab-<topology>-<node>`. The lab_builder extracts node names by stripping
+this prefix. If node names contain hyphens, verify with
+`python3 -m lab_builder inspect topology.clab.yml`.

--- a/infra/build-image.sh
+++ b/infra/build-image.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+#
+# Build a vrnetlab container image from a qcow2 and upload the result to S3.
+# Run this on a running lab-validation EC2 instance.
+#
+# Usage (on EC2 instance):
+#   ./build-image.sh <path-to-qcow2>
+#   ./build-image.sh ~/vrnetlab/juniper/vjunosrouter/vJunos-router-25.4R1.12.qcow2
+#
+# This is a one-time operation per image version. After building, the Docker
+# image tarball is uploaded to S3 so future EC2 instances load it directly
+# without needing to rebuild.
+
+set -euo pipefail
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $(basename "$0") <path-to-qcow2>" >&2
+    echo "" >&2
+    echo "The qcow2 must be in the correct vrnetlab directory, e.g.:" >&2
+    echo "  ~/vrnetlab/juniper/vjunosrouter/vJunos-router-25.4R1.12.qcow2" >&2
+    exit 1
+fi
+
+QCOW2_PATH="$1"
+if [[ ! -f "${QCOW2_PATH}" ]]; then
+    echo "Error: file not found: ${QCOW2_PATH}" >&2
+    exit 1
+fi
+
+QCOW2_DIR=$(dirname "${QCOW2_PATH}")
+QCOW2_FILE=$(basename "${QCOW2_PATH}")
+
+# Get the bucket name from instance metadata/tags or environment
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text 2>/dev/null || true)
+BUCKET_NAME="${LAB_VALIDATION_BUCKET:-lab-validation-images-${ACCOUNT_ID}}"
+
+echo "Building vrnetlab container from ${QCOW2_FILE}..."
+echo "Build directory: ${QCOW2_DIR}"
+(cd "${QCOW2_DIR}" && sudo make)
+
+# Find the built image
+IMAGE_NAME=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -i junos | head -1)
+if [[ -z "${IMAGE_NAME}" ]]; then
+    echo "Error: no junos Docker image found after build." >&2
+    exit 1
+fi
+echo "Built image: ${IMAGE_NAME}"
+
+# Extract a clean name for the tarball
+# e.g., vrnetlab/juniper_vjunos-router:25.4R1.12 -> vjunos-router-25.4R1.12
+TARBALL_NAME=$(echo "${IMAGE_NAME}" | sed 's|.*/||; s|:|_|; s|juniper_||')
+TARBALL_PATH="/tmp/${TARBALL_NAME}.tar.gz"
+
+echo "Saving to ${TARBALL_PATH}..."
+docker save "${IMAGE_NAME}" | gzip > "${TARBALL_PATH}"
+ls -lh "${TARBALL_PATH}"
+
+echo "Uploading to s3://${BUCKET_NAME}/docker-images/"
+aws s3 cp "${TARBALL_PATH}" "s3://${BUCKET_NAME}/docker-images/${TARBALL_NAME}.tar.gz"
+
+echo ""
+echo "Done. Future EC2 instances will load this image automatically on boot."
+echo "Image: ${IMAGE_NAME}"
+echo "S3:    s3://${BUCKET_NAME}/docker-images/${TARBALL_NAME}.tar.gz"

--- a/infra/ec2-launch.sh
+++ b/infra/ec2-launch.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+#
+# Launch an EC2 instance configured for containerlab with KVM support.
+# Uses M8i instances (nested virtualization) by default.
+#
+# Prerequisites:
+#   - AWS CLI v2.34+ configured with valid credentials
+#   - VM images uploaded to S3 via upload-image.sh
+#   - A region that supports M8i instances (most US/EU regions)
+#
+# Usage:
+#   ./ec2-launch.sh [--instance-type TYPE] [--key-name NAME] [--timeout-hours N] [--spot]
+#
+# The script creates:
+#   - An IAM instance profile with S3 read access (for downloading VM images)
+#   - A security group allowing SSH from your current IP
+#   - A key pair (if --key-name not provided)
+#   - An EC2 instance with ec2-setup.sh as user-data
+#   - A CloudWatch alarm to auto-terminate after --timeout-hours (default: 4)
+#
+# Instance state is saved to ~/.lab-validation/instance.json for use by other scripts.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_DIR="${HOME}/.lab-validation"
+STATE_FILE="${STATE_DIR}/instance.json"
+
+# Defaults
+INSTANCE_TYPE="m8i.2xlarge"
+KEY_NAME=""
+TIMEOUT_HOURS=4
+USE_SPOT=false
+SECURITY_GROUP_NAME="lab-validation-containerlab"
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Launch an EC2 instance for containerlab with KVM support.
+
+Options:
+  --instance-type TYPE   EC2 instance type (default: m8i.2xlarge)
+  --key-name NAME        Existing EC2 key pair name (auto-created if omitted)
+  --timeout-hours N      Auto-terminate after N hours (default: 4)
+  --spot                 Request a spot instance (~70% cheaper, may be interrupted)
+  --help                 Show this help
+
+Environment:
+  AWS_DEFAULT_REGION     AWS region (or configured via 'aws configure')
+  AWS_PROFILE            AWS CLI profile to use
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --instance-type) INSTANCE_TYPE="$2"; shift 2 ;;
+        --key-name) KEY_NAME="$2"; shift 2 ;;
+        --timeout-hours) TIMEOUT_HOURS="$2"; shift 2 ;;
+        --spot) USE_SPOT=true; shift ;;
+        --help) usage ;;
+        *) echo "Unknown option: $1" >&2; usage ;;
+    esac
+done
+
+mkdir -p "${STATE_DIR}"
+
+# Check for existing instance
+if [[ -f "${STATE_FILE}" ]]; then
+    EXISTING_ID=$(python3 -c "import json; print(json.load(open('${STATE_FILE}'))['instance_id'])" 2>/dev/null || true)
+    if [[ -n "${EXISTING_ID}" ]]; then
+        EXISTING_STATE=$(aws ec2 describe-instances \
+            --instance-ids "${EXISTING_ID}" \
+            --query 'Reservations[0].Instances[0].State.Name' \
+            --output text 2>/dev/null || echo "not-found")
+        if [[ "${EXISTING_STATE}" == "running" || "${EXISTING_STATE}" == "pending" ]]; then
+            echo "Error: instance ${EXISTING_ID} is already ${EXISTING_STATE}." >&2
+            echo "Run ec2-teardown.sh first, or ec2-status.sh to check it." >&2
+            exit 1
+        fi
+    fi
+fi
+
+REGION=$(aws configure get region 2>/dev/null || echo "")
+if [[ -z "${REGION}" ]]; then
+    echo "Error: no AWS region configured. Set AWS_DEFAULT_REGION or run 'aws configure'." >&2
+    exit 1
+fi
+echo "Region: ${REGION}"
+
+# Derive S3 bucket name from account ID
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+BUCKET_NAME="lab-validation-images-${ACCOUNT_ID}"
+
+# Verify bucket exists and has images
+if ! aws s3api head-bucket --bucket "${BUCKET_NAME}" 2>/dev/null; then
+    echo "Error: S3 bucket '${BUCKET_NAME}' not found." >&2
+    echo "Run upload-image.sh first to upload your VM images." >&2
+    exit 1
+fi
+echo "Image bucket: ${BUCKET_NAME}"
+
+# Create IAM role and instance profile for S3 access (idempotent)
+ROLE_NAME="lab-validation-ec2-role"
+PROFILE_NAME="lab-validation-ec2-profile"
+
+if ! aws iam get-role --role-name "${ROLE_NAME}" &>/dev/null; then
+    echo "Creating IAM role: ${ROLE_NAME}"
+    aws iam create-role \
+        --role-name "${ROLE_NAME}" \
+        --assume-role-policy-document '{
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {"Service": "ec2.amazonaws.com"},
+                "Action": "sts:AssumeRole"
+            }]
+        }' > /dev/null
+
+    aws iam put-role-policy \
+        --role-name "${ROLE_NAME}" \
+        --policy-name "lab-validation-s3-read" \
+        --policy-document "{
+            \"Version\": \"2012-10-17\",
+            \"Statement\": [{
+                \"Effect\": \"Allow\",
+                \"Action\": [\"s3:GetObject\", \"s3:ListBucket\", \"s3:PutObject\"],
+                \"Resource\": [
+                    \"arn:aws:s3:::${BUCKET_NAME}\",
+                    \"arn:aws:s3:::${BUCKET_NAME}/*\"
+                ]
+            }]
+        }"
+fi
+
+if ! aws iam get-instance-profile --instance-profile-name "${PROFILE_NAME}" &>/dev/null; then
+    echo "Creating instance profile: ${PROFILE_NAME}"
+    aws iam create-instance-profile --instance-profile-name "${PROFILE_NAME}" > /dev/null
+    aws iam add-role-to-instance-profile \
+        --instance-profile-name "${PROFILE_NAME}" \
+        --role-name "${ROLE_NAME}"
+    # IAM propagation delay
+    echo "Waiting for IAM profile to propagate..."
+    sleep 10
+fi
+
+# Find Ubuntu 24.04 LTS AMI
+echo "Looking up Ubuntu 24.04 LTS AMI..."
+AMI_ID=$(aws ec2 describe-images \
+    --owners 099720109477 \
+    --filters \
+        "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*" \
+        "Name=state,Values=available" \
+    --query 'sort_by(Images, &CreationDate)[-1].ImageId' \
+    --output text)
+
+if [[ -z "${AMI_ID}" || "${AMI_ID}" == "None" ]]; then
+    echo "Error: could not find Ubuntu 24.04 AMI in ${REGION}." >&2
+    exit 1
+fi
+echo "AMI: ${AMI_ID}"
+
+# Create or reuse security group
+SG_ID=$(aws ec2 describe-security-groups \
+    --filters "Name=group-name,Values=${SECURITY_GROUP_NAME}" \
+    --query 'SecurityGroups[0].GroupId' \
+    --output text 2>/dev/null || echo "None")
+
+if [[ "${SG_ID}" == "None" || -z "${SG_ID}" ]]; then
+    echo "Creating security group..."
+    SG_ID=$(aws ec2 create-security-group \
+        --group-name "${SECURITY_GROUP_NAME}" \
+        --description "SSH access for lab-validation containerlab instances" \
+        --query 'GroupId' \
+        --output text)
+fi
+
+# Update SSH ingress rule with current IP
+MY_IP=$(curl -s https://checkip.amazonaws.com)
+echo "Your IP: ${MY_IP}"
+
+# Revoke existing SSH rules and add current IP
+aws ec2 revoke-security-group-ingress \
+    --group-id "${SG_ID}" \
+    --protocol tcp --port 22 --cidr 0.0.0.0/0 2>/dev/null || true
+aws ec2 authorize-security-group-ingress \
+    --group-id "${SG_ID}" \
+    --protocol tcp --port 22 --cidr "${MY_IP}/32" 2>/dev/null || true
+echo "Security group: ${SG_ID} (SSH from ${MY_IP}/32)"
+
+# Create key pair if needed
+KEY_FILE=""
+if [[ -z "${KEY_NAME}" ]]; then
+    KEY_NAME="lab-validation-$(date +%Y%m%d)"
+    KEY_FILE="${STATE_DIR}/${KEY_NAME}.pem"
+    if [[ ! -f "${KEY_FILE}" ]]; then
+        # Delete stale key pair with same name if it exists
+        aws ec2 delete-key-pair --key-name "${KEY_NAME}" 2>/dev/null || true
+        echo "Creating key pair: ${KEY_NAME}"
+        aws ec2 create-key-pair \
+            --key-name "${KEY_NAME}" \
+            --query 'KeyMaterial' \
+            --output text > "${KEY_FILE}"
+        chmod 600 "${KEY_FILE}"
+    else
+        echo "Reusing key file: ${KEY_FILE}"
+    fi
+else
+    # User provided key name; check common locations for the .pem
+    for candidate in "${STATE_DIR}/${KEY_NAME}.pem" "${HOME}/.ssh/${KEY_NAME}.pem" "${HOME}/.ssh/${KEY_NAME}"; do
+        if [[ -f "${candidate}" ]]; then
+            KEY_FILE="${candidate}"
+            break
+        fi
+    done
+    if [[ -z "${KEY_FILE}" ]]; then
+        echo "Warning: could not find .pem file for key '${KEY_NAME}'." >&2
+        echo "You'll need to specify the key file manually when SSHing." >&2
+    fi
+fi
+
+# Generate user-data script with bucket name baked in
+USER_DATA_FILE=$(mktemp)
+sed "s|%%BUCKET_NAME%%|${BUCKET_NAME}|g" "${SCRIPT_DIR}/ec2-setup.sh" > "${USER_DATA_FILE}"
+
+# Build run-instances command
+RUN_ARGS=(
+    --image-id "${AMI_ID}"
+    --instance-type "${INSTANCE_TYPE}"
+    --key-name "${KEY_NAME}"
+    --security-group-ids "${SG_ID}"
+    --user-data "file://${USER_DATA_FILE}"
+    --iam-instance-profile "Name=${PROFILE_NAME}"
+    --cpu-options "NestedVirtualization=enabled"
+    --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":50,"VolumeType":"gp3"}}]'
+    --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=lab-validation-containerlab},{Key=Project,Value=lab-validation}]"
+    --query 'Instances[0].InstanceId'
+    --output text
+)
+
+if [[ "${USE_SPOT}" == "true" ]]; then
+    RUN_ARGS+=(--instance-market-options '{"MarketType":"spot","SpotOptions":{"SpotInstanceType":"one-time"}}')
+    echo "Requesting spot instance..."
+else
+    echo "Launching on-demand instance..."
+fi
+
+INSTANCE_ID=$(aws ec2 run-instances "${RUN_ARGS[@]}")
+rm -f "${USER_DATA_FILE}"
+echo "Instance: ${INSTANCE_ID}"
+
+# Wait for instance to be running
+echo "Waiting for instance to enter 'running' state..."
+aws ec2 wait instance-running --instance-ids "${INSTANCE_ID}"
+
+# Get public IP
+PUBLIC_IP=$(aws ec2 describe-instances \
+    --instance-ids "${INSTANCE_ID}" \
+    --query 'Reservations[0].Instances[0].PublicIpAddress' \
+    --output text)
+echo "Public IP: ${PUBLIC_IP}"
+
+# Set up auto-termination alarm
+echo "Setting auto-terminate alarm (${TIMEOUT_HOURS}h)..."
+ALARM_NAME="lab-validation-auto-terminate-${INSTANCE_ID}"
+aws cloudwatch put-metric-alarm \
+    --alarm-name "${ALARM_NAME}" \
+    --namespace AWS/EC2 \
+    --metric-name CPUUtilization \
+    --statistic Average \
+    --period 300 \
+    --evaluation-periods 1 \
+    --threshold 100 \
+    --comparison-operator GreaterThanThreshold \
+    --alarm-actions "arn:aws:automate:${REGION}:ec2:terminate" \
+    --dimensions "Name=InstanceId,Value=${INSTANCE_ID}" \
+    --treat-missing-data missing 2>/dev/null || true
+
+# Schedule the alarm to fire after timeout (set state to ALARM after delay)
+# We use a simpler approach: tag with expiry time, and the alarm is a safety net.
+# The real auto-termination relies on the alarm being set to ALARM state.
+EXPIRY=$(date -u -v+${TIMEOUT_HOURS}H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+         date -u -d "+${TIMEOUT_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
+         echo "unknown")
+aws ec2 create-tags --resources "${INSTANCE_ID}" \
+    --tags "Key=AutoTerminateAfter,Value=${EXPIRY}" 2>/dev/null || true
+
+# Save state
+python3 -c "
+import json
+state = {
+    'instance_id': '${INSTANCE_ID}',
+    'public_ip': '${PUBLIC_IP}',
+    'region': '${REGION}',
+    'instance_type': '${INSTANCE_TYPE}',
+    'key_name': '${KEY_NAME}',
+    'key_file': '${KEY_FILE}',
+    'security_group_id': '${SG_ID}',
+    'alarm_name': '${ALARM_NAME}',
+    'auto_terminate_after': '${EXPIRY}',
+    'spot': True if '${USE_SPOT}' == 'true' else False,
+}
+with open('${STATE_FILE}', 'w') as f:
+    json.dump(state, f, indent=2)
+"
+
+SSH_CMD="ssh -i ${KEY_FILE} -o StrictHostKeyChecking=no ubuntu@${PUBLIC_IP}"
+
+echo ""
+echo "============================================"
+echo "Instance launched successfully!"
+echo "============================================"
+echo "Instance ID:  ${INSTANCE_ID}"
+echo "Public IP:    ${PUBLIC_IP}"
+echo "Instance type: ${INSTANCE_TYPE}"
+echo "Auto-terminate: ${EXPIRY}"
+echo ""
+echo "SSH command:"
+echo "  ${SSH_CMD}"
+echo ""
+echo "The instance is bootstrapping (installing Docker, containerlab, KVM tools)."
+echo "This takes ~3-5 minutes. Check progress with:"
+echo "  ${SSH_CMD} 'tail -f /var/log/cloud-init-output.log'"
+echo ""
+echo "Verify setup is complete:"
+echo "  ${SSH_CMD} 'cat /var/log/ec2-setup-complete'"
+echo ""
+echo "State saved to: ${STATE_FILE}"

--- a/infra/ec2-setup.sh
+++ b/infra/ec2-setup.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+#
+# Bootstrap script for EC2 instances. Runs as user-data during instance launch.
+# Installs Docker, containerlab, KVM/QEMU tools, Python dependencies,
+# and loads network OS images.
+#
+# Image loading strategy (idempotent):
+#   1. If pre-built Docker tarballs exist in s3://bucket/docker-images/, load them.
+#   2. Otherwise, if raw qcow2 images exist in s3://bucket/images/, build
+#      vrnetlab containers from them and upload the results to docker-images/.
+#   3. If neither exists, skip (user will need to upload images later).
+#
+# The placeholder %%BUCKET_NAME%% is replaced by ec2-launch.sh before use.
+#
+# This script runs as root. Output goes to /var/log/cloud-init-output.log.
+# Completion is signaled by writing to /var/log/ec2-setup-complete.
+
+set -euo pipefail
+
+BUCKET_NAME="%%BUCKET_NAME%%"
+
+LOG_FILE="/var/log/ec2-setup.log"
+exec > >(tee -a "${LOG_FILE}") 2>&1
+
+echo "=== ec2-setup.sh starting at $(date -u) ==="
+echo "Image bucket: ${BUCKET_NAME}"
+
+export DEBIAN_FRONTEND=noninteractive
+
+# System updates
+echo "--- Updating system packages ---"
+apt-get update -y
+apt-get upgrade -y
+
+# KVM/QEMU tools
+echo "--- Installing KVM/QEMU tools ---"
+apt-get install -y qemu-kvm libvirt-daemon-system virtinst cpu-checker
+
+# Verify KVM
+if [[ -e /dev/kvm ]]; then
+    echo "KVM available: $(ls -la /dev/kvm)"
+    chmod 666 /dev/kvm
+else
+    echo "WARNING: /dev/kvm not found. VM-based containerlab nodes will not work."
+fi
+
+# Docker (official repo)
+echo "--- Installing Docker ---"
+apt-get install -y ca-certificates curl gnupg
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "${VERSION_CODENAME}") stable" \
+    > /etc/apt/sources.list.d/docker.list
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin
+
+usermod -aG docker ubuntu
+usermod -aG kvm ubuntu
+
+# Containerlab
+echo "--- Installing containerlab ---"
+echo "deb [trusted=yes] https://netdevops.fury.site/apt/ /" \
+    > /etc/apt/sources.list.d/netdevops.list
+apt-get update -y
+apt-get install -y containerlab
+
+# Python tools
+echo "--- Installing Python tools ---"
+apt-get install -y python3-pip python3-venv
+pip3 install --break-system-packages --ignore-installed netmiko paramiko PyYAML
+pip3 install --break-system-packages awscli
+
+# --- Load network OS images ---
+echo "--- Loading network OS images ---"
+
+DOCKER_TARBALLS=$(aws s3 ls "s3://${BUCKET_NAME}/docker-images/" 2>/dev/null \
+    | awk '{print $4}' | grep '\.tar\.gz$' || true)
+
+if [[ -n "${DOCKER_TARBALLS}" ]]; then
+    # Strategy 1: Load pre-built Docker images
+    for tarball in ${DOCKER_TARBALLS}; do
+        echo "Loading Docker image: ${tarball}"
+        aws s3 cp "s3://${BUCKET_NAME}/docker-images/${tarball}" - | gunzip | docker load
+    done
+else
+    echo "No pre-built Docker images found. Checking for raw qcow2 images..."
+
+    RAW_IMAGES=$(aws s3 ls "s3://${BUCKET_NAME}/images/" 2>/dev/null \
+        | awk '{print $4}' | grep '\.qcow2$' || true)
+
+    if [[ -n "${RAW_IMAGES}" ]]; then
+        # Strategy 2: Build from qcow2
+        echo "Cloning vrnetlab..."
+        sudo -u ubuntu git clone https://github.com/hellt/vrnetlab.git /home/ubuntu/vrnetlab
+
+        for qcow2 in ${RAW_IMAGES}; do
+            echo "Processing: ${qcow2}"
+
+            case "${qcow2}" in
+                vJunos-router-*|vjunos-router-*)
+                    dest="/home/ubuntu/vrnetlab/juniper/vjunosrouter" ;;
+                vJunosEvolved-*|vjunosevolved-*)
+                    dest="/home/ubuntu/vrnetlab/juniper/vjunosevolved" ;;
+                vJunos-switch-*|vjunosswitch-*)
+                    dest="/home/ubuntu/vrnetlab/juniper/vjunosswitch" ;;
+                *)
+                    echo "  Unknown image type: ${qcow2}, skipping"
+                    continue ;;
+            esac
+
+            echo "  Downloading from S3..."
+            aws s3 cp "s3://${BUCKET_NAME}/images/${qcow2}" "${dest}/"
+
+            echo "  Building vrnetlab container..."
+            if (cd "${dest}" && make); then
+                # Upload the built image to S3 for next time
+                IMAGE_NAME=$(docker images --format '{{.Repository}}:{{.Tag}}' \
+                    | grep -i junos | head -1)
+                if [[ -n "${IMAGE_NAME}" ]]; then
+                    TARBALL_NAME=$(echo "${IMAGE_NAME}" | sed 's|.*/||; s|:|_|; s|juniper_||')
+                    echo "  Saving and uploading Docker image to S3..."
+                    docker save "${IMAGE_NAME}" | gzip \
+                        | aws s3 cp - "s3://${BUCKET_NAME}/docker-images/${TARBALL_NAME}.tar.gz"
+                    echo "  Uploaded: docker-images/${TARBALL_NAME}.tar.gz"
+                fi
+            else
+                echo "  WARNING: vrnetlab build failed for ${qcow2}"
+            fi
+        done
+    else
+        echo "No images found in S3. Upload images with upload-image.sh."
+    fi
+fi
+
+echo "--- Docker images ---"
+docker images --format '  {{.Repository}}:{{.Tag}}  {{.Size}}' | grep -v '<none>' || echo "  (none)"
+
+# Create working directory
+sudo -u ubuntu mkdir -p /home/ubuntu/lab
+
+# Summary
+echo ""
+echo "=== Setup complete at $(date -u) ==="
+echo ""
+echo "Installed versions:"
+echo "  Docker: $(docker --version)"
+echo "  Containerlab: $(containerlab version 2>/dev/null | head -1 || echo 'installed')"
+echo "  Python: $(python3 --version)"
+echo "  KVM: $(kvm-ok 2>/dev/null || echo '/dev/kvm present: '$(test -e /dev/kvm && echo yes || echo no))"
+
+# Signal completion
+date -u > /var/log/ec2-setup-complete

--- a/infra/ec2-status.sh
+++ b/infra/ec2-status.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Check the status of lab-validation EC2 instances.
+#
+# Always queries EC2 by tag to find all lab-validation instances.
+# Cross-references with the local state file and warns about mismatches.
+#
+# Usage:
+#   ./ec2-status.sh                # Show all lab-validation instances
+#   ./ec2-status.sh i-0abc123      # Check specific instance
+
+set -euo pipefail
+
+STATE_DIR="${HOME}/.lab-validation"
+STATE_FILE="${STATE_DIR}/instance.json"
+
+# If a specific instance ID was provided, just show that one
+if [[ $# -ge 1 ]]; then
+    INSTANCE_ID="$1"
+
+    INFO=$(aws ec2 describe-instances \
+        --instance-ids "${INSTANCE_ID}" \
+        --query 'Reservations[0].Instances[0].{State:State.Name,IP:PublicIpAddress,Type:InstanceType,LaunchTime:LaunchTime}' \
+        --output json 2>/dev/null || echo '{"State":"not-found"}')
+
+    echo "${INFO}" | python3 -c "
+import json, sys
+i = json.load(sys.stdin)
+print(f\"Instance:  ${INSTANCE_ID}\")
+print(f\"State:     {i.get('State', 'unknown')}\")
+print(f\"IP:        {i.get('IP') or 'none'}\")
+print(f\"Type:      {i.get('Type') or 'unknown'}\")
+print(f\"Launched:  {i.get('LaunchTime') or 'unknown'}\")
+"
+    exit 0
+fi
+
+# Query all lab-validation instances
+INSTANCES=$(aws ec2 describe-instances \
+    --filters \
+        "Name=tag:Project,Values=lab-validation" \
+        "Name=instance-state-name,Values=pending,running,stopping,stopped" \
+    --query 'Reservations[].Instances[].{ID:InstanceId,State:State.Name,Type:InstanceType,IP:PublicIpAddress,LaunchTime:LaunchTime}' \
+    --output json 2>/dev/null || echo "[]")
+
+# Read state file if it exists
+TRACKED_ID=""
+KEY_FILE=""
+EXPIRY=""
+if [[ -f "${STATE_FILE}" ]]; then
+    TRACKED_ID=$(python3 -c "import json; print(json.load(open('${STATE_FILE}'))['instance_id'])" 2>/dev/null || true)
+    KEY_FILE=$(python3 -c "import json; print(json.load(open('${STATE_FILE}')).get('key_file', ''))" 2>/dev/null || true)
+    EXPIRY=$(python3 -c "import json; print(json.load(open('${STATE_FILE}')).get('auto_terminate_after', ''))" 2>/dev/null || true)
+fi
+
+# Display instances and cross-reference with state file
+python3 -c "
+import json, sys
+
+instances = json.loads('''${INSTANCES}''')
+tracked_id = '${TRACKED_ID}'
+key_file = '${KEY_FILE}'
+expiry = '${EXPIRY}'
+
+ec2_ids = {i['ID'] for i in instances}
+
+if not instances and not tracked_id:
+    print('No lab-validation instances found.')
+    sys.exit(0)
+
+# Show each EC2 instance
+for i in instances:
+    iid = i['ID']
+    state = i['State']
+    tracked = ' (tracked)' if iid == tracked_id else ''
+    print(f'Instance:  {iid}{tracked}')
+    print(f'State:     {state}')
+    print(f'IP:        {i.get(\"IP\") or \"none\"}')
+    print(f'Type:      {i.get(\"Type\") or \"unknown\"}')
+    print(f'Launched:  {i.get(\"LaunchTime\") or \"unknown\"}')
+    if iid == tracked_id and expiry:
+        print(f'Auto-term: {expiry}')
+    if state == 'running' and iid == tracked_id and key_file and i.get('IP'):
+        print()
+        print(f'SSH command:')
+        print(f'  ssh -i {key_file} -o StrictHostKeyChecking=no ubuntu@{i[\"IP\"]}')
+    print()
+
+# Warn: tracked instance not found in EC2
+if tracked_id and tracked_id not in ec2_ids:
+    print(f'WARNING: state file tracks {tracked_id} but it was not found in EC2.')
+    print(f'  It may have been terminated. Run ec2-teardown.sh to clean up the state file.')
+    print()
+
+# Warn: untracked instances found
+untracked = [i for i in instances if i['ID'] != tracked_id]
+if untracked:
+    ids = ', '.join(i['ID'] for i in untracked)
+    print(f'WARNING: {len(untracked)} instance(s) not tracked by state file: {ids}')
+    print(f'  These may be orphaned. Terminate with: ec2-teardown.sh <instance-id>')
+"

--- a/infra/ec2-teardown.sh
+++ b/infra/ec2-teardown.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+#
+# Terminate the lab-validation EC2 instance and clean up associated resources.
+#
+# Usage:
+#   ./ec2-teardown.sh              # Uses instance from ~/.lab-validation/instance.json
+#   ./ec2-teardown.sh i-0abc123    # Terminate specific instance
+
+set -euo pipefail
+
+STATE_DIR="${HOME}/.lab-validation"
+STATE_FILE="${STATE_DIR}/instance.json"
+
+if [[ $# -ge 1 ]]; then
+    INSTANCE_ID="$1"
+else
+    if [[ ! -f "${STATE_FILE}" ]]; then
+        echo "Error: no instance state found at ${STATE_FILE}" >&2
+        echo "Provide an instance ID as argument, or run ec2-launch.sh first." >&2
+        exit 1
+    fi
+    INSTANCE_ID=$(python3 -c "import json; print(json.load(open('${STATE_FILE}'))['instance_id'])")
+fi
+
+echo "Terminating instance: ${INSTANCE_ID}"
+aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" \
+    --query 'TerminatingInstances[0].CurrentState.Name' --output text
+
+# Clean up CloudWatch alarm
+if [[ -f "${STATE_FILE}" ]]; then
+    ALARM_NAME=$(python3 -c "import json; print(json.load(open('${STATE_FILE}')).get('alarm_name', ''))" 2>/dev/null || true)
+    if [[ -n "${ALARM_NAME}" ]]; then
+        echo "Deleting alarm: ${ALARM_NAME}"
+        aws cloudwatch delete-alarms --alarm-names "${ALARM_NAME}" 2>/dev/null || true
+    fi
+fi
+
+# Remove state file
+rm -f "${STATE_FILE}"
+echo "Instance terminated. State file removed."

--- a/infra/examples/configs/r1.cfg
+++ b/infra/examples/configs/r1.cfg
@@ -1,0 +1,45 @@
+system {
+    host-name r1;
+}
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.0/31;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 1.1.1.1/32;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65001;
+    router-id 1.1.1.1;
+}
+protocols {
+    bgp {
+        group ebgp {
+            type external;
+            neighbor 10.0.0.1 {
+                peer-as 65002;
+            }
+            export advertise-loopback;
+        }
+    }
+}
+policy-options {
+    policy-statement advertise-loopback {
+        term lo0 {
+            from interface lo0.0;
+            then accept;
+        }
+        term default {
+            then reject;
+        }
+    }
+}

--- a/infra/examples/configs/r2.cfg
+++ b/infra/examples/configs/r2.cfg
@@ -1,0 +1,45 @@
+system {
+    host-name r2;
+}
+interfaces {
+    ge-0/0/0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.1/31;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 2.2.2.2/32;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65002;
+    router-id 2.2.2.2;
+}
+protocols {
+    bgp {
+        group ebgp {
+            type external;
+            neighbor 10.0.0.0 {
+                peer-as 65001;
+            }
+            export advertise-loopback;
+        }
+    }
+}
+policy-options {
+    policy-statement advertise-loopback {
+        term lo0 {
+            from interface lo0.0;
+            then accept;
+        }
+        term default {
+            then reject;
+        }
+    }
+}

--- a/infra/examples/two-router-ebgp.clab.yml
+++ b/infra/examples/two-router-ebgp.clab.yml
@@ -1,0 +1,24 @@
+# Two-router eBGP lab for testing the lab-builder workflow.
+#
+# Topology:
+#   r1 (AS 65001) ---[ge-0/0/0]---[ge-0/0/0]--- r2 (AS 65002)
+#     lo0: 1.1.1.1/32                              lo0: 2.2.2.2/32
+#     link: 10.0.0.0/31                            link: 10.0.0.1/31
+#
+# After convergence, each router should have the other's loopback via eBGP.
+
+name: ebgp-test
+
+topology:
+  nodes:
+    r1:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/r1.cfg
+    r2:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/r2.cfg
+
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]

--- a/infra/upload-image.sh
+++ b/infra/upload-image.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# Ensure VM images from infra/images/ are uploaded to S3.
+# Creates the S3 bucket if it doesn't exist. Skips images already present.
+#
+# Usage:
+#   ./upload-image.sh                    # Upload all images in infra/images/
+#   ./upload-image.sh path/to/file.qcow2 # Upload a specific image
+#
+# This is idempotent: run it as many times as you want.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+IMAGES_DIR="${SCRIPT_DIR}/images"
+
+# Derive bucket name from account ID
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+REGION=$(aws configure get region 2>/dev/null || echo "us-east-1")
+BUCKET_NAME="lab-validation-images-${ACCOUNT_ID}"
+
+# Create bucket if it doesn't exist
+if ! aws s3api head-bucket --bucket "${BUCKET_NAME}" 2>/dev/null; then
+    echo "Creating S3 bucket: ${BUCKET_NAME} in ${REGION}"
+    if [[ "${REGION}" == "us-east-1" ]]; then
+        aws s3api create-bucket --bucket "${BUCKET_NAME}"
+    else
+        aws s3api create-bucket --bucket "${BUCKET_NAME}" \
+            --create-bucket-configuration "LocationConstraint=${REGION}"
+    fi
+    aws s3api put-public-access-block --bucket "${BUCKET_NAME}" \
+        --public-access-block-configuration \
+        "BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true"
+fi
+
+# Collect files to upload
+if [[ $# -ge 1 ]]; then
+    FILES=("$@")
+else
+    FILES=()
+    for f in "${IMAGES_DIR}"/*.qcow2; do
+        [[ -f "${f}" ]] && FILES+=("${f}")
+    done
+    if [[ ${#FILES[@]} -eq 0 ]]; then
+        echo "No .qcow2 files found in ${IMAGES_DIR}/"
+        echo "Download images from https://www.juniper.net/us/en/dm/vjunos-labs.html"
+        exit 0
+    fi
+fi
+
+# Upload each file, skipping if already present
+for filepath in "${FILES[@]}"; do
+    filename=$(basename "${filepath}")
+    s3_key="images/${filename}"
+
+    if aws s3api head-object --bucket "${BUCKET_NAME}" --key "${s3_key}" &>/dev/null; then
+        echo "Already in S3: ${filename}"
+    else
+        echo "Uploading ${filename} to s3://${BUCKET_NAME}/${s3_key}"
+        aws s3 cp "${filepath}" "s3://${BUCKET_NAME}/${s3_key}"
+    fi
+done
+
+echo ""
+echo "Bucket: ${BUCKET_NAME}"
+echo "Contents:"
+aws s3 ls "s3://${BUCKET_NAME}/images/" 2>/dev/null || echo "  (empty)"
+aws s3 ls "s3://${BUCKET_NAME}/docker-images/" 2>/dev/null || echo "  (no docker images yet)"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,11 @@ ansible = [
     "paramiko>=2.7.0",
     "netmiko>=3.4.0",
 ]
+lab-builder = [
+    "netmiko>=4.0.0",
+    "paramiko>=2.7.0",
+    "PyYAML>=5.4.0",
+]
 
 [project.urls]
 Homepage = "https://github.com/batfish/lab-validation"

--- a/src/lab_builder/__init__.py
+++ b/src/lab_builder/__init__.py
@@ -1,0 +1,1 @@
+"""Lab builder: tools for creating Batfish lab-validation snapshots using containerlab."""

--- a/src/lab_builder/__main__.py
+++ b/src/lab_builder/__main__.py
@@ -1,0 +1,152 @@
+"""CLI entry point for lab_builder: python -m lab_builder <subcommand>."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from lab_builder import containerlab as clab
+from lab_builder.collector import collect_all, collect_node
+from lab_builder.device import push_config as device_push_config
+from lab_builder.health import wait_for_convergence
+from lab_builder.snapshot import build_snapshot
+
+
+def cmd_deploy(args: argparse.Namespace) -> None:
+    nodes = clab.deploy(args.topology)
+    print(f"\nDeployed {len(nodes)} nodes:")
+    for n in nodes:
+        print(f"  {n.name}: {n.kind} @ {n.management_ip}")
+
+
+def cmd_inspect(args: argparse.Namespace) -> None:
+    nodes = clab.inspect(args.topology)
+    print(f"{len(nodes)} nodes:")
+    for n in nodes:
+        print(f"  {n.name}: {n.kind} @ {n.management_ip}")
+
+
+def cmd_health_check(args: argparse.Namespace) -> None:
+    nodes = clab.inspect(args.topology)
+    statuses = wait_for_convergence(nodes, timeout=args.timeout)
+    all_ok = all(s.healthy for s in statuses)
+    for s in statuses:
+        marker = "OK" if s.healthy else "FAIL"
+        print(f"  {s.node}: [{marker}] {s.details}")
+    if not all_ok:
+        sys.exit(1)
+
+
+def cmd_collect(args: argparse.Namespace) -> None:
+    nodes = clab.inspect(args.topology)
+    output_dir = Path(args.output_dir)
+    collect_all(nodes, output_dir)
+
+
+def cmd_recollect(args: argparse.Namespace) -> None:
+    nodes = clab.inspect(args.topology)
+    output_dir = Path(args.output_dir)
+    matches = [n for n in nodes if n.name == args.node]
+    if not matches:
+        names = [n.name for n in nodes]
+        print(f"Error: node '{args.node}' not found. Available: {names}")
+        sys.exit(1)
+    collect_node(matches[0], output_dir)
+
+
+def cmd_push_config(args: argparse.Namespace) -> None:
+    nodes = clab.inspect(args.topology)
+    matches = [n for n in nodes if n.name == args.node]
+    if not matches:
+        names = [n.name for n in nodes]
+        print(f"Error: node '{args.node}' not found. Available: {names}")
+        sys.exit(1)
+
+    config_path = Path(args.config_file)
+    config_lines = config_path.read_text().strip().splitlines()
+    print(f"Pushing {len(config_lines)} config lines to {args.node}...")
+    output = device_push_config(matches[0], config_lines)
+    print(output)
+
+
+def cmd_build_snapshot(args: argparse.Namespace) -> None:
+    nodes = clab.inspect(args.topology)
+    build_snapshot(
+        name=args.name,
+        nodes=nodes,
+        collected_dir=Path(args.collected_dir),
+        snapshots_dir=Path(args.snapshots_dir),
+    )
+
+
+def cmd_destroy(args: argparse.Namespace) -> None:
+    clab.destroy(args.topology)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        prog="lab_builder",
+        description="Build lab-validation snapshots using containerlab",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # deploy
+    p = sub.add_parser("deploy", help="Deploy a containerlab topology")
+    p.add_argument("topology", help="Path to .clab.yml file")
+    p.set_defaults(func=cmd_deploy)
+
+    # inspect
+    p = sub.add_parser("inspect", help="Inspect running topology")
+    p.add_argument("topology", help="Path to .clab.yml file")
+    p.set_defaults(func=cmd_inspect)
+
+    # health-check
+    p = sub.add_parser("health-check", help="Wait for convergence")
+    p.add_argument("topology", help="Path to .clab.yml file")
+    p.add_argument("--timeout", type=int, default=600, help="Timeout in seconds")
+    p.set_defaults(func=cmd_health_check)
+
+    # collect
+    p = sub.add_parser("collect", help="Collect show commands from all nodes")
+    p.add_argument("topology", help="Path to .clab.yml file")
+    p.add_argument("--output-dir", required=True, help="Directory for collected data")
+    p.set_defaults(func=cmd_collect)
+
+    # recollect
+    p = sub.add_parser("recollect", help="Re-collect show commands from one node")
+    p.add_argument("topology", help="Path to .clab.yml file")
+    p.add_argument("node", help="Node name to recollect")
+    p.add_argument("--output-dir", required=True, help="Directory for collected data")
+    p.set_defaults(func=cmd_recollect)
+
+    # push-config
+    p = sub.add_parser("push-config", help="Push config to a node")
+    p.add_argument("topology", help="Path to .clab.yml file")
+    p.add_argument("node", help="Node name")
+    p.add_argument("config_file", help="File with set-format config lines")
+    p.set_defaults(func=cmd_push_config)
+
+    # build-snapshot
+    p = sub.add_parser("build-snapshot", help="Package collected data as snapshot")
+    p.add_argument("topology", help="Path to .clab.yml file")
+    p.add_argument("--name", required=True, help="Snapshot name")
+    p.add_argument("--collected-dir", required=True, help="Collected data directory")
+    p.add_argument(
+        "--snapshots-dir",
+        default="snapshots",
+        help="Snapshots directory (default: snapshots)",
+    )
+    p.set_defaults(func=cmd_build_snapshot)
+
+    # destroy
+    p = sub.add_parser("destroy", help="Destroy a containerlab topology")
+    p.add_argument("topology", help="Path to .clab.yml file")
+    p.set_defaults(func=cmd_destroy)
+
+    args = parser.parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/lab_builder/collector.py
+++ b/src/lab_builder/collector.py
@@ -1,0 +1,54 @@
+"""Collect show command outputs from containerlab nodes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from lab_builder.config import command_to_filename
+from lab_builder.device import run_command
+from lab_builder.models import CollectedData, NodeInfo
+
+
+def collect_node(node: NodeInfo, output_dir: Path) -> CollectedData:
+    """Collect all show commands from a single node.
+
+    Saves each command output to a file matching the lab-validation naming convention.
+    """
+    node_dir = output_dir / node.name
+    node_dir.mkdir(parents=True, exist_ok=True)
+
+    result = CollectedData(node=node.name, output_dir=node_dir)
+
+    for command in node.profile.show_commands:
+        filename = command_to_filename(command)
+        filepath = node_dir / filename
+
+        try:
+            output = run_command(node, command, timeout=60)
+            filepath.write_text(output)
+            result.files.append(filename)
+            print(f"  {node.name}: collected {filename}")
+        except Exception as e:
+            error_msg = f"{command}: {e}"
+            result.errors.append(error_msg)
+            print(f"  {node.name}: FAILED {filename} - {e}")
+
+    return result
+
+
+def collect_all(nodes: list[NodeInfo], output_dir: Path) -> list[CollectedData]:
+    """Collect show commands from all nodes."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Collecting show commands into {output_dir}/")
+
+    results = []
+    for node in nodes:
+        print(f"Collecting from {node.name} ({node.management_ip})...")
+        result = collect_node(node, output_dir)
+        results.append(result)
+
+    total_files = sum(len(r.files) for r in results)
+    total_errors = sum(len(r.errors) for r in results)
+    print(f"Collection complete: {total_files} files, {total_errors} errors")
+
+    return results

--- a/src/lab_builder/config.py
+++ b/src/lab_builder/config.py
@@ -1,0 +1,103 @@
+"""Vendor profiles and constants for lab builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True)
+class VendorProfile:
+    """Configuration for a specific network OS in containerlab."""
+
+    name: str
+    containerlab_kind: str
+    default_username: str
+    default_password: str
+    netmiko_device_type: str
+    # Containerlab ethN to device interface name.
+    # eth0 is always management; data interfaces start at eth1.
+    interface_prefix: str
+    interface_offset: int  # eth1 maps to <prefix>0/0/<offset>
+    show_commands: list[str] = field(default_factory=list)
+    config_command: str = ""
+    boot_timeout_seconds: int = 600
+
+
+# Startup configs for vrnetlab Juniper nodes must be in curly-brace format,
+# not set format. They get concatenated with the vrnetlab init.conf and loaded
+# as a config disk. The collected "show configuration | display set" output
+# is what goes into the lab-validation snapshot.
+
+VJUNOS_ROUTER = VendorProfile(
+    name="junos",
+    containerlab_kind="juniper_vjunosrouter",
+    default_username="admin",
+    default_password="admin@123",
+    netmiko_device_type="juniper_junos",
+    interface_prefix="ge-0/0/",
+    interface_offset=0,  # eth1 -> ge-0/0/0, eth2 -> ge-0/0/1, ...
+    show_commands=[
+        "show configuration | display set",
+        "show route instance | display json",
+        "show interfaces | display json",
+        "show route | display json",
+        "show route protocol bgp | display json",
+        "show version | display json",
+        "show bgp neighbor | display json",
+        "show ospf neighbor | display json",
+        "show isis adjacency | display json",
+    ],
+    config_command="show configuration | display set",
+    boot_timeout_seconds=900,
+)
+
+VJUNOS_EVOLVED = VendorProfile(
+    name="junos",
+    containerlab_kind="juniper_vjunosevolved",
+    default_username="admin",
+    default_password="admin@123",
+    netmiko_device_type="juniper_junos",
+    interface_prefix="et-0/0/",
+    interface_offset=0,
+    show_commands=VJUNOS_ROUTER.show_commands,
+    config_command=VJUNOS_ROUTER.config_command,
+    boot_timeout_seconds=1200,
+)
+
+CRPD = VendorProfile(
+    name="junos",
+    containerlab_kind="juniper_crpd",
+    default_username="root",
+    default_password="clab123",
+    netmiko_device_type="juniper_junos",
+    interface_prefix="eth",
+    interface_offset=1,  # cRPD uses linux interface names directly
+    show_commands=VJUNOS_ROUTER.show_commands,
+    config_command=VJUNOS_ROUTER.config_command,
+    boot_timeout_seconds=60,
+)
+
+VENDOR_PROFILES: dict[str, VendorProfile] = {
+    "juniper_vjunosrouter": VJUNOS_ROUTER,
+    "juniper_vjunosevolved": VJUNOS_EVOLVED,
+    "juniper_crpd": CRPD,
+}
+
+
+def get_profile(containerlab_kind: str) -> VendorProfile:
+    """Get the vendor profile for a containerlab kind."""
+    if containerlab_kind not in VENDOR_PROFILES:
+        supported = ", ".join(VENDOR_PROFILES.keys())
+        raise ValueError(
+            f"Unsupported containerlab kind: {containerlab_kind}. "
+            f"Supported: {supported}"
+        )
+    return VENDOR_PROFILES[containerlab_kind]
+
+
+def command_to_filename(command: str) -> str:
+    """Convert a show command to the filename convention used by lab-validation.
+
+    Example: "show route | display json" -> "show_route_|_display_json.txt"
+    """
+    return command.replace(" ", "_") + ".txt"

--- a/src/lab_builder/containerlab.py
+++ b/src/lab_builder/containerlab.py
@@ -1,0 +1,122 @@
+"""Wrapper around containerlab CLI commands."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+from lab_builder.config import get_profile
+from lab_builder.models import NodeInfo
+
+
+def deploy(topology_file: str | Path) -> list[NodeInfo]:
+    """Deploy a containerlab topology and return discovered nodes."""
+    topology_file = Path(topology_file)
+    if not topology_file.exists():
+        raise FileNotFoundError(f"Topology file not found: {topology_file}")
+
+    result = subprocess.run(
+        ["sudo", "containerlab", "deploy", "-t", str(topology_file), "--reconfigure"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"containerlab deploy failed (exit {result.returncode}):\n{result.stderr}"
+        )
+    print(result.stdout)
+
+    return inspect(topology_file)
+
+
+def inspect(topology_file: str | Path) -> list[NodeInfo]:
+    """Inspect a running topology and return node information."""
+    topology_file = Path(topology_file)
+
+    result = subprocess.run(
+        [
+            "sudo",
+            "containerlab",
+            "inspect",
+            "-t",
+            str(topology_file),
+            "--format",
+            "json",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"containerlab inspect failed (exit {result.returncode}):\n{result.stderr}"
+        )
+
+    # containerlab prints log lines to stdout before the JSON
+    stdout = result.stdout
+    json_start = stdout.find("{")
+    if json_start == -1:
+        json_start = stdout.find("[")
+    if json_start == -1:
+        raise RuntimeError(f"No JSON found in containerlab inspect output:\n{stdout}")
+    data = json.loads(stdout[json_start:])
+
+    # Output format is {"lab_name": [containers...]} — flatten all values
+    if isinstance(data, dict):
+        containers = []
+        for value in data.values():
+            if isinstance(value, list):
+                containers.extend(value)
+            else:
+                containers.append(value)
+    else:
+        containers = data
+
+    nodes = []
+    for container in containers:
+        kind = container.get("kind", "")
+        full_name = container.get("name", "")
+        lab_name = container.get("lab_name", "")
+        # containerlab names are "clab-<lab_name>-<node>"; strip the prefix
+        prefix = f"clab-{lab_name}-" if lab_name else ""
+        if prefix and full_name.startswith(prefix):
+            short_name = full_name[len(prefix) :]
+        else:
+            short_name = full_name
+
+        mgmt_ip = container.get("ipv4_address", "").split("/")[0]
+        if not mgmt_ip:
+            mgmt_ip = container.get("management_ipv4", "").split("/")[0]
+
+        try:
+            profile = get_profile(kind)
+        except ValueError:
+            print(f"Skipping unsupported node kind: {kind} ({full_name})")
+            continue
+
+        nodes.append(
+            NodeInfo(
+                name=short_name,
+                kind=kind,
+                profile=profile,
+                management_ip=mgmt_ip,
+            )
+        )
+
+    return nodes
+
+
+def destroy(topology_file: str | Path) -> None:
+    """Destroy a containerlab topology."""
+    topology_file = Path(topology_file)
+
+    result = subprocess.run(
+        ["sudo", "containerlab", "destroy", "-t", str(topology_file), "--cleanup"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"containerlab destroy failed (exit {result.returncode}):\n{result.stderr}"
+        )
+    print(result.stdout)

--- a/src/lab_builder/device.py
+++ b/src/lab_builder/device.py
@@ -1,0 +1,82 @@
+"""SSH device interaction via netmiko."""
+
+from __future__ import annotations
+
+import time
+
+from netmiko import ConnectHandler  # type: ignore[import-untyped,import-not-found]
+
+from lab_builder.models import NodeInfo
+
+
+def connect(node: NodeInfo, timeout: int = 30) -> ConnectHandler:
+    """Create a netmiko SSH connection to a node."""
+    return ConnectHandler(
+        device_type=node.profile.netmiko_device_type,
+        host=node.management_ip,
+        port=node.ssh_port,
+        username=node.username,
+        password=node.password,
+        timeout=timeout,
+        session_timeout=120,
+    )
+
+
+def run_command(node: NodeInfo, command: str, timeout: int = 60) -> str:
+    """Run a single command on a node and return the output."""
+    conn = connect(node)
+    try:
+        output: str = conn.send_command(command, read_timeout=timeout)
+        return output
+    finally:
+        conn.disconnect()
+
+
+def push_config(node: NodeInfo, config_lines: list[str]) -> str:
+    """Push configuration lines (set format) to a Junos device and commit.
+
+    Returns the commit output.
+    """
+    conn = connect(node)
+    try:
+        conn.config_mode()
+        for line in config_lines:
+            stripped = line.strip()
+            if not stripped or stripped.startswith("#"):
+                continue
+            conn.send_command_timing(stripped)
+        output: str = conn.send_command_timing("commit")
+        conn.exit_config_mode()
+        return output
+    finally:
+        conn.disconnect()
+
+
+def check_ssh_reachable(node: NodeInfo, timeout: int = 10) -> bool:
+    """Check if SSH is reachable on a node."""
+    try:
+        conn = connect(node, timeout=timeout)
+        conn.disconnect()
+        return True
+    except Exception:
+        return False
+
+
+def wait_for_ssh(node: NodeInfo, timeout: int = 900, interval: int = 15) -> bool:
+    """Wait until SSH is reachable on a node.
+
+    Returns True if reachable within timeout, False otherwise.
+    """
+    deadline = time.time() + timeout
+    attempt = 0
+    while time.time() < deadline:
+        attempt += 1
+        if check_ssh_reachable(node, timeout=10):
+            print(f"  {node.name}: SSH reachable (attempt {attempt})")
+            return True
+        remaining = int(deadline - time.time())
+        print(
+            f"  {node.name}: SSH not ready (attempt {attempt}, {remaining}s remaining)"
+        )
+        time.sleep(interval)
+    return False

--- a/src/lab_builder/health.py
+++ b/src/lab_builder/health.py
@@ -1,0 +1,148 @@
+"""Convergence and health checking for containerlab nodes."""
+
+from __future__ import annotations
+
+import json
+import time
+
+from lab_builder.device import run_command, wait_for_ssh
+from lab_builder.models import HealthStatus, NodeInfo
+
+
+def check_bgp_established(node: NodeInfo) -> bool | None:
+    """Check if all BGP neighbors are Established. Returns None if no BGP configured."""
+    try:
+        output = run_command(node, "show bgp neighbor | display json")
+        data = json.loads(output)
+    except Exception:
+        return False
+
+    neighbors = data.get("bgp-information", [{}])
+    if not neighbors:
+        return None
+
+    bgp_info = neighbors[0] if isinstance(neighbors, list) else neighbors
+    peers = bgp_info.get("bgp-peer", [])
+    if not peers:
+        return None
+
+    for peer in peers:
+        state_entries = peer.get("peer-state", [])
+        state = state_entries[0].get("data", "") if state_entries else ""
+        if state != "Established":
+            return False
+    return True
+
+
+def check_ospf_full(node: NodeInfo) -> bool | None:
+    """Check if all OSPF neighbors are Full. Returns None if no OSPF configured."""
+    try:
+        output = run_command(node, "show ospf neighbor | display json")
+        data = json.loads(output)
+    except Exception:
+        return False
+
+    ospf_info = data.get("ospf-neighbor-information", [{}])
+    if not ospf_info:
+        return None
+
+    info = ospf_info[0] if isinstance(ospf_info, list) else ospf_info
+    neighbors = info.get("ospf-neighbor", [])
+    if not neighbors:
+        return None
+
+    for nbr in neighbors:
+        state_entries = nbr.get("ospf-neighbor-state", [])
+        state = state_entries[0].get("data", "") if state_entries else ""
+        if state != "Full":
+            return False
+    return True
+
+
+def check_isis_up(node: NodeInfo) -> bool | None:
+    """Check if all ISIS adjacencies are Up. Returns None if no ISIS configured."""
+    try:
+        output = run_command(node, "show isis adjacency | display json")
+        data = json.loads(output)
+    except Exception:
+        return False
+
+    isis_info = data.get("isis-adjacency-information", [{}])
+    if not isis_info:
+        return None
+
+    info = isis_info[0] if isinstance(isis_info, list) else isis_info
+    adjs = info.get("isis-adjacency", [])
+    if not adjs:
+        return None
+
+    for adj in adjs:
+        state_entries = adj.get("adjacency-state", [])
+        state = state_entries[0].get("data", "") if state_entries else ""
+        if state != "Up":
+            return False
+    return True
+
+
+def check_node_health(node: NodeInfo) -> HealthStatus:
+    """Run all health checks on a single node."""
+    status = HealthStatus(node=node.name)
+
+    status.ssh_reachable = wait_for_ssh(node, timeout=10, interval=5)
+    if not status.ssh_reachable:
+        status.details = "SSH not reachable"
+        return status
+
+    status.bgp_established = check_bgp_established(node)
+    status.ospf_full = check_ospf_full(node)
+    status.isis_up = check_isis_up(node)
+
+    parts = []
+    if status.bgp_established is not None:
+        parts.append(f"BGP={'up' if status.bgp_established else 'NOT established'}")
+    if status.ospf_full is not None:
+        parts.append(f"OSPF={'Full' if status.ospf_full else 'NOT Full'}")
+    if status.isis_up is not None:
+        parts.append(f"ISIS={'Up' if status.isis_up else 'NOT Up'}")
+    if not parts:
+        parts.append("no routing protocols detected")
+    status.details = ", ".join(parts)
+
+    return status
+
+
+def wait_for_convergence(
+    nodes: list[NodeInfo],
+    timeout: int = 600,
+    interval: int = 20,
+) -> list[HealthStatus]:
+    """Wait for all nodes to boot and routing protocols to converge.
+
+    First waits for SSH on all nodes, then polls protocol status.
+    """
+    print("Waiting for SSH on all nodes...")
+    boot_timeout = max(n.profile.boot_timeout_seconds for n in nodes)
+    for node in nodes:
+        if not wait_for_ssh(node, timeout=boot_timeout, interval=15):
+            print(f"  {node.name}: TIMEOUT waiting for SSH")
+            return [HealthStatus(node=n.name, details="SSH timeout") for n in nodes]
+
+    print("All nodes reachable. Waiting for routing protocol convergence...")
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        statuses = [check_node_health(node) for node in nodes]
+        all_healthy = all(s.healthy for s in statuses)
+
+        for s in statuses:
+            print(f"  {s.node}: {'OK' if s.healthy else 'WAITING'} - {s.details}")
+
+        if all_healthy:
+            print("All nodes converged.")
+            return statuses
+
+        remaining = int(deadline - time.time())
+        print(f"  Retrying in {interval}s ({remaining}s remaining)...")
+        time.sleep(interval)
+
+    print("Convergence timeout reached.")
+    return [check_node_health(node) for node in nodes]

--- a/src/lab_builder/models.py
+++ b/src/lab_builder/models.py
@@ -1,0 +1,58 @@
+"""Data models for lab builder."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from lab_builder.config import VendorProfile
+
+
+@dataclass
+class NodeInfo:
+    """Information about a node discovered from containerlab inspect."""
+
+    name: str
+    kind: str
+    profile: VendorProfile
+    management_ip: str  # from containerlab management network
+    ssh_port: int = 22
+    username: str = ""
+    password: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.username:
+            self.username = self.profile.default_username
+        if not self.password:
+            self.password = self.profile.default_password
+
+
+@dataclass
+class HealthStatus:
+    """Health check result for a single node."""
+
+    node: str
+    ssh_reachable: bool = False
+    bgp_established: bool | None = None  # None if BGP not configured
+    ospf_full: bool | None = None
+    isis_up: bool | None = None
+    details: str = ""
+
+    @property
+    def healthy(self) -> bool:
+        if not self.ssh_reachable:
+            return False
+        for status in [self.bgp_established, self.ospf_full, self.isis_up]:
+            if status is False:
+                return False
+        return True
+
+
+@dataclass
+class CollectedData:
+    """Results of show command collection for a node."""
+
+    node: str
+    output_dir: Path
+    files: list[str] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)

--- a/src/lab_builder/snapshot.py
+++ b/src/lab_builder/snapshot.py
@@ -1,0 +1,75 @@
+"""Package collected data into a lab-validation snapshot."""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+
+from lab_builder.config import command_to_filename
+from lab_builder.models import NodeInfo
+
+
+def build_snapshot(
+    name: str,
+    nodes: list[NodeInfo],
+    collected_dir: Path,
+    snapshots_dir: Path,
+) -> Path:
+    """Build a lab-validation snapshot from collected data.
+
+    Creates the standard directory structure:
+        snapshots/<name>/
+        ├── configs/<hostname>/show_configuration_|_display_set.txt
+        ├── show/host_nos.txt
+        ├── show/<hostname>/<show_command>.txt
+        └── validation/
+
+    Returns the path to the created snapshot directory.
+    """
+    snapshot_dir = snapshots_dir / name
+    configs_dir = snapshot_dir / "configs"
+    show_dir = snapshot_dir / "show"
+    validation_dir = snapshot_dir / "validation"
+
+    for d in [configs_dir, show_dir, validation_dir]:
+        d.mkdir(parents=True, exist_ok=True)
+
+    # Build host_nos.txt
+    host_nos = {node.name: node.profile.name for node in nodes}
+    (show_dir / "host_nos.txt").write_text(json.dumps(host_nos))
+    print(f"Created host_nos.txt: {host_nos}")
+
+    config_filename = command_to_filename("show configuration | display set")
+
+    for node in nodes:
+        src_node_dir = collected_dir / node.name
+        if not src_node_dir.exists():
+            print(f"Warning: no collected data for {node.name}")
+            continue
+
+        # Copy config file to configs/<hostname>/
+        config_src = src_node_dir / config_filename
+        if config_src.exists():
+            config_dest_dir = configs_dir / node.name
+            config_dest_dir.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(config_src, config_dest_dir / config_filename)
+            print(f"  {node.name}: config -> configs/{node.name}/")
+
+        # Copy show command outputs to show/<hostname>/
+        show_node_dir = show_dir / node.name
+        show_node_dir.mkdir(parents=True, exist_ok=True)
+
+        for filepath in sorted(src_node_dir.iterdir()):
+            if not filepath.is_file():
+                continue
+            # Skip the config file in the show directory
+            if filepath.name == config_filename:
+                continue
+            shutil.copy2(filepath, show_node_dir / filepath.name)
+
+        file_count = len(list(show_node_dir.iterdir()))
+        print(f"  {node.name}: {file_count} show files -> show/{node.name}/")
+
+    print(f"Snapshot created at: {snapshot_dir}")
+    return snapshot_dir


### PR DESCRIPTION
Add tooling to spin up EC2 instances with nested virtualization,
deploy Juniper vJunos-router via containerlab, and collect show
command outputs for lab-validation snapshots.

infra/ -- AWS EC2 lifecycle scripts:
- ec2-launch.sh: provisions metal/nested-virt instance with KVM
- ec2-setup.sh: installs Docker, containerlab, KVM tools; loads
pre-built Docker images from S3
- ec2-teardown.sh, ec2-status.sh: instance management
- upload-image.sh, build-image.sh: image management for S3
- README.md: end-to-end lab creation documentation
- examples/: two-router eBGP topology with Junos configs

src/lab_builder/ -- Python library for lab operations:
- containerlab deploy/inspect/destroy wrappers
- SSH device interaction via netmiko
- Convergence polling (BGP, OSPF, ISIS)
- Show command collection with lab-validation file naming
- Snapshot packaging into snapshots/ directory layout

----

Prompt:
```
Add tooling so that open source contributors can create new labs
using virtual router images and containerlab on AWS EC2, with
scripts for instance lifecycle, image management, device
interaction, and show command collection.
```