### PR TITLE
Junos parsers: support EVPN/VRF table names and active tags

### DIFF
--- a/src/lab_validation/parsers/junos/commands/bgp_routes.py
+++ b/src/lab_validation/parsers/junos/commands/bgp_routes.py
@@ -37,8 +37,7 @@ def parse_show_route_protocol_bgp_display_json(text: str) -> Sequence[JunosBgpRo
             assert TABLE_NAME in table
             assert len(table[TABLE_NAME]) == 1
             vrf, rib = _parse_table_header(table[TABLE_NAME][0][DATA])
-            # skip ipv6
-            if rib == "inet6.0":
+            if rib not in ("inet.0",):
                 continue
             bgp_routes += _get_routes(vrf, table.get(RT, []))
 
@@ -102,11 +101,9 @@ def _get_as_path(as_path_str: str) -> tuple[Sequence[int], str]:
 
 
 def convert_active(active_tag: str | None) -> bool:
-    if active_tag == "*":
-        # active route will have tag *
+    if active_tag in ("*", "@", "#"):
         return True
     elif active_tag is None:
-        # inactive route will have tag None
         return False
     else:
         raise Exception(f"'{active_tag}' is not expected active tag")

--- a/src/lab_validation/parsers/junos/commands/routes.py
+++ b/src/lab_validation/parsers/junos/commands/routes.py
@@ -35,8 +35,7 @@ def parse_show_route_display_json(text: str) -> Sequence[JunosMainRibRoute]:
             assert TABLE_NAME in table
             assert len(table[TABLE_NAME]) == 1
             vrf, rib = _parse_table_header(table[TABLE_NAME][0][DATA])
-            # skip ipv6
-            if rib == "inet6.0":
+            if rib not in ("inet.0",):
                 continue
             junos_routes += _get_routes(vrf, table[RT])
 
@@ -112,11 +111,12 @@ def _get_routes(vrf: str, route_json_obj: list[Any]) -> list[JunosMainRibRoute]:
 
 
 def convert_active(active_tag: str | None) -> bool:
-    if active_tag == "*":
-        # active route will have tag *
+    # * = active for both routing and forwarding
+    # @ = routing use only (EVPN contributes to routing table but not FIB)
+    # # = forwarding use only
+    if active_tag in ("*", "@", "#"):
         return True
     elif active_tag is None:
-        # inactive route will have tag None
         return False
     else:
         raise Exception(f"'{active_tag}' is not expected active tag")

--- a/src/lab_validation/parsers/junos/commands/utils.py
+++ b/src/lab_validation/parsers/junos/commands/utils.py
@@ -13,13 +13,32 @@ def remove_unused_lines(text: str) -> str:
         return match["json_text"]
 
 
-# Table header includes optional VRF name and RIB
-_table_header = re.compile(r"((?P<vrf>.*)\.)?(?P<rib>inet6?\.0)")
+# Known Junos RIB suffixes. These appear as the tail of a table name.
+# Longest first so bgp.evpn.0 matches before evpn.0
+_KNOWN_RIBS = (
+    "bgp.evpn.0",
+    "inetflow.0",
+    "inet6.0",
+    "inet.0",
+    "evpn.0",
+    "mpls.0",
+)
 
 
-def _parse_table_header(vrf_ip_info: str) -> tuple[str, str]:
-    m = _table_header.fullmatch(vrf_ip_info)
-    assert m is not None
-    vrf = m.group("vrf") if m.group("vrf") else "default"
-    rib = m.group("rib")
-    return vrf, rib
+def _parse_table_header(table_name: str) -> tuple[str, str]:
+    """Parse a Junos routing table name into (vrf, rib).
+
+    Examples:
+        "inet.0" -> ("default", "inet.0")
+        "TENANT-A.inet.0" -> ("TENANT-A", "inet.0")
+        "bgp.evpn.0" -> ("default", "bgp.evpn.0")
+        "TENANT-A.evpn.0" -> ("TENANT-A", "evpn.0")
+        "mpls.0" -> ("default", "mpls.0")
+    """
+    for rib in _KNOWN_RIBS:
+        if table_name == rib:
+            return "default", rib
+        if table_name.endswith("." + rib):
+            vrf = table_name[: -(len(rib) + 1)]
+            return vrf, rib
+    return "default", table_name

--- a/tests/lab_validation/parsers/junos/commands/test_routes.py
+++ b/tests/lab_validation/parsers/junos/commands/test_routes.py
@@ -926,10 +926,12 @@ def test_show_route_display_json_multiple_routes() -> None:
 
 
 def test_convert_active() -> None:
-    active_tag = "*"
-    result = convert_active(active_tag)
-    assert result is True
+    assert convert_active("*") is True
+    assert convert_active(None) is False
 
-    active_tag = None
-    result = convert_active(active_tag)
-    assert result is False
+
+def test_convert_active_evpn_tags() -> None:
+    # @ = routing use only (EVPN routes contribute to routing but not FIB)
+    assert convert_active("@") is True
+    # # = forwarding use only
+    assert convert_active("#") is True

--- a/tests/lab_validation/parsers/junos/commands/test_utils.py
+++ b/tests/lab_validation/parsers/junos/commands/test_utils.py
@@ -43,3 +43,23 @@ def test_parse_table_header_vrf_ipv4() -> None:
 def test_parse_table_header_vrf_ipv6() -> None:
     vrf, ip_version = _parse_table_header("vrf.inet6.0")
     assert vrf == "vrf" and ip_version == "inet6.0"
+
+
+def test_parse_table_header_evpn() -> None:
+    vrf, rib = _parse_table_header("bgp.evpn.0")
+    assert vrf == "default" and rib == "bgp.evpn.0"
+
+
+def test_parse_table_header_vrf_evpn() -> None:
+    vrf, rib = _parse_table_header("TENANT-A.evpn.0")
+    assert vrf == "TENANT-A" and rib == "evpn.0"
+
+
+def test_parse_table_header_mpls() -> None:
+    vrf, rib = _parse_table_header("mpls.0")
+    assert vrf == "default" and rib == "mpls.0"
+
+
+def test_parse_table_header_mgmt_junos() -> None:
+    vrf, rib = _parse_table_header("mgmt_junos.inet.0")
+    assert vrf == "mgmt_junos" and rib == "inet.0"


### PR DESCRIPTION
Table header parsing: replace regex with explicit RIB suffix lookup to
correctly handle compound table names like bgp.evpn.0 (global EVPN
RIB) and VRF-scoped tables like TENANT-A.evpn.0, mpls.0, etc. The
old regex only matched inet.0 and inet6.0 patterns.

Route active tags: Junos uses @ (routing use only) and # (forwarding
use only) for EVPN routes in addition to * (both) and None (inactive).
Both route parsers now accept all three active variants.

Route table filtering: both route parsers now skip all non-inet.0
tables rather than crashing on unrecognized table names. This skips
evpn.0, mpls.0, bgp.evpn.0, and inet6.0 tables cleanly.

----

Prompt:
```
Update the Junos route parsers to handle EVPN and VRF table names
(bgp.evpn.0, TENANT-A.evpn.0, mpls.0) and EVPN active tags (@, #)
that cause crashes on labs with EVPN/L3VPN configurations.
```