### PR TITLE
JunosValidator: improve BGP RIB validation

### DIFF
--- a/snapshots/mix_vendor_bgp_vrf/validation/sickbay.yaml
+++ b/snapshots/mix_vendor_bgp_vrf/validation/sickbay.yaml
@@ -3,10 +3,6 @@ entries:
     test_name: test_bgp_rib_routes
   - hostname: D-Cumulus
     test_name: test_interface_properties
-  - hostname: D-JuniperJunos
-    test_name: test_bgp_rib_routes
-    skip:
-      reason: https://github.com/batfish/lab-validation/issues/40
   - hostname: D-AristaEOS
     test_name: test_bgp_rib_routes
     skip:

--- a/src/lab_validation/validators/JunosValidator.py
+++ b/src/lab_validation/validators/JunosValidator.py
@@ -73,6 +73,17 @@ class JunosValidator(VendorValidator):
     def validate_bgp_rib_routes(
         self, batfish_routes: Sequence[BgpRibRoute]
     ) -> dict[Any, Any]:
+        # Filter Batfish VRF BGP routes that don't appear in device's
+        # "show route protocol bgp": EVPN-leaked routes (ibgp in non-default
+        # VRF) and locally-originated routes from connected subnets.
+        batfish_routes = [
+            r
+            for r in batfish_routes
+            if not (
+                r.vrf != "default"
+                and (r.protocol == "ibgp" or r.origin_protocol == "connected")
+            )
+        ]
         return self._compare_all_bgp_routes(self._parse_bgp_routes(), batfish_routes)
 
     def validate_interface_properties(
@@ -247,17 +258,16 @@ class JunosValidator(VendorValidator):
         real_routes: Sequence[JunosBgpRoute],
         batfish_routes: Sequence[BgpRibRoute],
     ) -> dict[Any, Any]:
-        # Group real routes by that key.
+        # Group by (vrf, network). Don't include next_hop_ip in the key
+        # because Junos shows resolved next-hops while Batfish shows protocol
+        # next-hops, causing false mismatches for iBGP routes.
         real: defaultdict[tuple, MutableSet[JunosBgpRoute]] = defaultdict(set)
         for r in real_routes:
-            real[(r.vrf, r.network, r.next_hop_ip)].add(r)
+            real[(r.vrf, r.network)].add(r)
 
-        # Group Batfish routes by that key.
         batfish: defaultdict[tuple, MutableSet[BgpRibRoute]] = defaultdict(set)
         for bf_route in batfish_routes:
-            batfish[(bf_route.vrf, bf_route.network, bf_route.next_hop_ip)].add(
-                bf_route
-            )
+            batfish[(bf_route.vrf, bf_route.network)].add(bf_route)
 
         common_keys = real.keys() & batfish.keys()
         missing_keys = real.keys() - batfish.keys()
@@ -269,12 +279,13 @@ class JunosValidator(VendorValidator):
             if len(diff) != 0:
                 failures[k] = diff
         for k in missing_keys:
-            assert len(real[k]) == 1
-            for route in real[k]:
-                if route.is_active is False:
-                    # Batfish only returns active routes. Skipping inactive routes
-                    continue
-                failures[k] = f"Batfish is missing route: {real[k]}"
+            # is_active=False means BGP-best but inactive in the main RIB
+            # (lost to a lower-admin-distance protocol). Truly unresolvable
+            # or hidden routes never appear in "show route protocol bgp"
+            # brief output, so every route the parser produces is valid.
+            active_routes = [r for r in real[k] if r.is_active]
+            if active_routes:
+                failures[k] = f"Batfish is missing route: {active_routes}"
         for k in extra_keys:
             failures[k] = f"Batfish has extra route: {batfish[k]}"
         return failures
@@ -289,9 +300,12 @@ class JunosValidator(VendorValidator):
         diff: dict[str, str] = {}
         real_metric = 0 if real_route.metric is None else real_route.metric
 
-        if real_route.is_active is False:
-            # Batfish is reporting as active a route that is inactive
-            diff["Unexpected_inactive_route"] = f"Batfish: {batfish_route}"
+        # When Batfish shows ibgp and device shows BGP, the route was learned
+        # via overlay iBGP in Batfish but underlay eBGP on the device. AS path
+        # and origin_protocol will differ due to the dual-plane architecture.
+        protocol_mismatch = (
+            batfish_route.protocol == "ibgp" and real_route.origin_protocol == "BGP"
+        )
 
         if batfish_route.metric != real_metric:
             diff["metric"] = f"Batfish: {batfish_route.metric}, real: {real_metric}"
@@ -299,12 +313,16 @@ class JunosValidator(VendorValidator):
             diff["local_preference"] = (
                 f"Batfish: {batfish_route.local_preference}, real: {real_route.local_preference}"
             )
-        if batfish_route.as_path != real_route.as_path:
+        if not protocol_mismatch and batfish_route.as_path != real_route.as_path:
             diff["as_path"] = (
                 f"Batfish: {batfish_route.as_path}, real: {real_route.as_path}"
             )
         assert batfish_route.origin_protocol is not None
-        if batfish_route.origin_protocol.lower() != real_route.origin_protocol.lower():
+        if (
+            not protocol_mismatch
+            and batfish_route.origin_protocol.lower()
+            != real_route.origin_protocol.lower()
+        ):
             diff["origin_protocol"] = (
                 f"Batfish: {batfish_route.origin_protocol}, real: {real_route.origin_protocol}"
             )

--- a/tests/lab_validation/validators/test_junosValidator.py
+++ b/tests/lab_validation/validators/test_junosValidator.py
@@ -391,9 +391,7 @@ def test_compare_all_bgp_routes_mismatch_metric() -> None:
         )
     ]
     failures = JunosValidator("")._compare_all_bgp_routes(expected_routes, bf_routes)
-    assert failures == {
-        ("vrf", "1.1.1.0/24", "2.2.2.2"): {"metric": "Batfish: 0, real: 10"}
-    }
+    assert failures == {("vrf", "1.1.1.0/24"): {"metric": "Batfish: 0, real: 10"}}
 
 
 def test_compare_all_bgp_routes_mismatch_local_pref() -> None:
@@ -432,7 +430,7 @@ def test_compare_all_bgp_routes_mismatch_local_pref() -> None:
     ]
     failures = JunosValidator("")._compare_all_bgp_routes(expected_routes, bf_routes)
     assert failures == {
-        ("vrf", "1.1.1.0/24", "2.2.2.2"): {"local_preference": "Batfish: 100, real: 0"}
+        ("vrf", "1.1.1.0/24"): {"local_preference": "Batfish: 100, real: 0"}
     }
 
 
@@ -472,7 +470,7 @@ def test_compare_all_bgp_routes_mismatch_local_as_path() -> None:
     ]
     failures = JunosValidator("")._compare_all_bgp_routes(expected_routes, bf_routes)
     assert failures == {
-        ("vrf", "1.1.1.0/24", "2.2.2.2"): {
+        ("vrf", "1.1.1.0/24"): {
             "as_path": f"Batfish: {bf_routes[0].as_path}, real: {expected_routes[0].as_path}"
         }
     }
@@ -514,7 +512,7 @@ def test_compare_all_bgp_routes_mismatch_origin_protocol() -> None:
     ]
     failures = JunosValidator("")._compare_all_bgp_routes(expected_routes, bf_routes)
     assert failures == {
-        ("vrf", "1.1.1.0/24", "2.2.2.2"): {
+        ("vrf", "1.1.1.0/24"): {
             "origin_protocol": f"Batfish: {bf_routes[0].origin_protocol}, real: {expected_routes[0].origin_protocol}"
         }
     }
@@ -556,9 +554,7 @@ def test_compare_all_bgp_routes_mismatch_origin_type() -> None:
     ]
     failures = JunosValidator("")._compare_all_bgp_routes(expected_routes, bf_routes)
     assert failures == {
-        ("vrf", "1.1.1.0/24", "2.2.2.2"): {
-            "origin_type": "Batfish: incomplete, real: I"
-        }
+        ("vrf", "1.1.1.0/24"): {"origin_type": "Batfish: incomplete, real: I"}
     }
 
 
@@ -584,11 +580,7 @@ def test_compare_all_bgp_routes_extra() -> None:
     ]
     failures = JunosValidator("")._compare_all_bgp_routes(expected_routes, bf_routes)
     assert failures == {
-        (
-            "vrf",
-            "1.1.1.0/24",
-            "2.2.2.2",
-        ): f"Batfish has extra route: { ({bf_routes[0]}) }"
+        ("vrf", "1.1.1.0/24"): f"Batfish has extra route: { ({bf_routes[0]}) }"
     }
 
 
@@ -611,11 +603,7 @@ def test_compare_all_bgp_routes_missing() -> None:
     bf_routes = []
     failures = JunosValidator("")._compare_all_bgp_routes(expected_routes, bf_routes)
     assert failures == {
-        (
-            "vrf",
-            "1.1.1.0/24",
-            "2.2.2.2",
-        ): f"Batfish is missing route: { ({expected_routes[0]}) }"
+        ("vrf", "1.1.1.0/24"): f"Batfish is missing route: {[expected_routes[0]]}"
     }
 
 
@@ -1062,7 +1050,8 @@ def test_compare_routes_skip_inactive_route_bgprib() -> None:
 
 
 def test_compare_routes_batfish_inactive_route_bgprib() -> None:
-    # Check that batfish have inactive route
+    # Batfish reports BGP-best even when the route is inactive in the main
+    # RIB, so matching routes (even when device-side inactive) do not flag.
     junos_bgp_routes = [
         JunosBgpRoute(
             vrf="default",
@@ -1098,11 +1087,7 @@ def test_compare_routes_batfish_inactive_route_bgprib() -> None:
     ]
 
     result = JunosValidator("")._compare_all_bgp_routes(junos_bgp_routes, bf_bgp_routes)
-    assert result == {
-        ("default", "192.168.123.2/32", "10.12.2.2"): {
-            "Unexpected_inactive_route": f"Batfish: {bf_bgp_routes[0]}"
-        },
-    }
+    assert result == {}
 
 
 def test_filter_route() -> None:


### PR DESCRIPTION
Group routes by (vrf, network) instead of (vrf, network, next_hop_ip)
since Junos shows resolved underlay next-hops while Batfish shows
protocol next-hops, causing false mismatches for iBGP routes. Handle
multiple routes per key (e.g., eBGP multipath) by filtering inactive
routes instead of asserting one route per key.

Filter VRF BGP routes that don't appear in device's "show route
protocol bgp": EVPN-leaked routes (ibgp in non-default VRF) and
locally-originated connected routes.

Tolerate iBGP vs eBGP differences (AS path, origin_protocol) when a
route was learned via overlay iBGP in Batfish but underlay eBGP on
the device. Remove the inactive-route assertion since Batfish reports
BGP-best even when the route is inactive in the main RIB — inactive
here means the route lost to a lower-admin-distance protocol (e.g.,
connected), not that the next-hop is unresolvable. Junos "show route
protocol bgp" brief output excludes hidden/unresolvable routes
entirely, so every parsed route with is_active=False is a valid
resolved route.

Remove the mix_vendor_bgp_vrf sickbay entry for issue #40 (Junos BGP
RIB inactive route modeling) since the test now passes: the
10.10.50.0/24 route was flagged because the old code treated
"BGP-best but inactive in main RIB" as a Batfish error, when in fact
the BGP RIB correctly includes it.

Fixes #40

----

Prompt:
```
Improve JunosValidator BGP RIB validation to handle EVPN overlay
topologies where Batfish and Junos report different next-hops,
protocols, and route multiplicities for the same BGP routes.
```