### PR TITLE
JunosValidator: implement EVPN RIB validation

### DIFF
--- a/src/lab_validation/parsers/junos/commands/routes.py
+++ b/src/lab_validation/parsers/junos/commands/routes.py
@@ -2,7 +2,7 @@ import json
 from collections.abc import Sequence
 from typing import Any
 
-from ..models.routes import JunosMainRibRoute
+from ..models.routes import JunosEvpnRoute, JunosMainRibRoute
 from .utils import _parse_table_header, remove_unused_lines
 
 # keys in the json object
@@ -108,6 +108,111 @@ def _get_routes(vrf: str, route_json_obj: list[Any]) -> list[JunosMainRibRoute]:
                 )
 
     return junos_routes
+
+
+def parse_show_route_evpn_display_json(text: str) -> Sequence[JunosEvpnRoute]:
+    """Parse EVPN routes from show route | display json output.
+
+    Only parses from bgp.evpn.0 table (the global EVPN RIB) to avoid
+    double-counting routes that appear in per-VRF evpn.0 tables.
+    """
+    json_obj = json.loads(remove_unused_lines(text))
+    assert ROUTE_INFORMATION in json_obj
+    evpn_routes: list[JunosEvpnRoute] = []
+    for rib in json_obj[ROUTE_INFORMATION]:
+        assert ROUTE_TABLE in rib
+        for table in rib[ROUTE_TABLE]:
+            assert TABLE_NAME in table
+            assert len(table[TABLE_NAME]) == 1
+            vrf, rib_name = _parse_table_header(table[TABLE_NAME][0][DATA])
+            if rib_name != "bgp.evpn.0":
+                continue
+            evpn_routes += _get_evpn_routes(table.get(RT, []))
+    return evpn_routes
+
+
+def _parse_evpn_type5_destination(dest: str) -> tuple[str, str] | None:
+    """Parse EVPN Type 5 destination into (RD, network).
+
+    Format: 5:<RD>::0::<prefix>::<len>
+    Example: 5:172.16.0.100:10000::0::192.168.99.0::24
+    Returns: ("172.16.0.100:10000", "192.168.99.0/24")
+    """
+    if not dest.startswith("5:"):
+        return None
+    parts = dest.split("::")
+    if len(parts) < 4:
+        return None
+    rd = parts[0][2:]  # strip "5:"
+    prefix = parts[2]
+    prefix_len = parts[3]
+    return rd, f"{prefix}/{prefix_len}"
+
+
+def _get_evpn_routes(route_json_obj: list[Any]) -> list[JunosEvpnRoute]:
+    evpn_routes: list[JunosEvpnRoute] = []
+    for route in route_json_obj:
+        assert RT_DESTINATION in route
+        assert len(route[RT_DESTINATION]) == 1
+        dest = route[RT_DESTINATION][0][DATA]
+        parsed = _parse_evpn_type5_destination(dest)
+        if parsed is None:
+            continue
+        rd, network = parsed
+
+        for entry in route[RT_ENTRY]:
+            assert ACTIVE_TAG in entry
+            assert PROTOCOL_NAME in entry
+            assert PREFERENCE in entry
+            active = convert_active(entry[ACTIVE_TAG][0].get(DATA, None))
+            if not active:
+                continue
+            protocol = entry[PROTOCOL_NAME][0][DATA]
+            admin = entry[PREFERENCE][0][DATA]
+            as_path_str = entry.get("as-path", [{}])[0].get(DATA, "")
+            as_path, origin_type = _parse_as_path_with_origin(as_path_str)
+
+            next_hop_ip = None
+            next_hop_int = None
+            if NH in entry:
+                for nh in entry[NH]:
+                    next_hop_ip = nh.get(TO, [{}])[0].get(DATA, None)
+                    via_key = VIA if VIA in nh else NH_LOCAL_INTERFACE
+                    if via_key in nh:
+                        next_hop_int = nh[via_key][0][DATA]
+
+            evpn_routes.append(
+                JunosEvpnRoute(
+                    network=network,
+                    route_distinguisher=rd,
+                    vrf="default",
+                    protocol=protocol,
+                    next_hop_ip=next_hop_ip,
+                    next_hop_int=next_hop_int,
+                    active=active,
+                    admin=admin,
+                    as_path=as_path,
+                    origin_type=origin_type,
+                )
+            )
+    return evpn_routes
+
+
+def _parse_as_path_with_origin(as_path_str: str) -> tuple[tuple[int, ...], str]:
+    """Parse AS path string containing both path and origin type."""
+    if not as_path_str.strip():
+        return ((), "I")
+    parts = as_path_str.split()
+    if parts and parts[-1] in ("I", "E", "?"):
+        origin = parts[-1]
+        as_nums = parts[:-1]
+    else:
+        origin = "I"
+        as_nums = parts
+    try:
+        return (tuple(int(x) for x in as_nums if x), origin)
+    except ValueError:
+        return ((), origin)
 
 
 def convert_active(active_tag: str | None) -> bool:

--- a/src/lab_validation/parsers/junos/models/routes.py
+++ b/src/lab_validation/parsers/junos/models/routes.py
@@ -22,6 +22,22 @@ class JunosMainRibRoute:
 
 
 @attr.s(frozen=True, auto_attribs=True, kw_only=True)
+class JunosEvpnRoute:
+    """EVPN Type 5 route parsed from Junos evpn.0 tables."""
+
+    network: str = attr.ib(converter=normalized_network)
+    route_distinguisher: str
+    vrf: str
+    protocol: str
+    next_hop_ip: str | None
+    next_hop_int: str | None
+    active: bool
+    admin: int = attr.ib(converter=int)
+    as_path: Sequence[int]
+    origin_type: str
+
+
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
 class JunosBgpRoute:
     vrf: str
     network: str = attr.ib(converter=normalized_network)

--- a/src/lab_validation/validators/JunosValidator.py
+++ b/src/lab_validation/validators/JunosValidator.py
@@ -19,13 +19,24 @@ from lab_validation.parsers.junos.commands.bgp_routes import (
     parse_show_route_protocol_bgp_display_json,
 )
 from lab_validation.parsers.junos.commands.interfaces import parse_show_interfaces_json
-from lab_validation.parsers.junos.commands.routes import parse_show_route_display_json
+from lab_validation.parsers.junos.commands.routes import (
+    parse_show_route_display_json,
+    parse_show_route_evpn_display_json,
+)
 from lab_validation.parsers.junos.models.interfaces import JunosInterface
-from lab_validation.parsers.junos.models.routes import JunosBgpRoute, JunosMainRibRoute
+from lab_validation.parsers.junos.models.routes import (
+    JunosBgpRoute,
+    JunosEvpnRoute,
+    JunosMainRibRoute,
+)
 from lab_validation.validators.batfish_models.interface_properties import (
     InterfaceProperties,
 )
-from lab_validation.validators.batfish_models.routes import BgpRibRoute, MainRibRoute
+from lab_validation.validators.batfish_models.routes import (
+    BgpRibRoute,
+    EvpnRibRoute,
+    MainRibRoute,
+)
 from lab_validation.validators.batfish_models.runtime_data import (
     InterfaceRuntimeData,
     NodeRuntimeData,
@@ -85,6 +96,16 @@ class JunosValidator(VendorValidator):
             )
         ]
         return self._compare_all_bgp_routes(self._parse_bgp_routes(), batfish_routes)
+
+    def validate_evpn_rib_routes(
+        self, batfish_routes: Sequence[EvpnRibRoute]
+    ) -> dict[Any, Any]:
+        if not batfish_routes:
+            return {}
+        real_routes = self._parse_evpn_routes()
+        if not real_routes:
+            return {}
+        return self._compare_evpn_routes(real_routes, batfish_routes)
 
     def validate_interface_properties(
         self, batfish_interfaces: Sequence[InterfaceProperties]
@@ -228,6 +249,55 @@ class JunosValidator(VendorValidator):
         with open(show_route_path) as fp:
             routes_text = fp.read()
         return parse_show_route_display_json(routes_text)
+
+    def _parse_evpn_routes(self) -> Sequence[JunosEvpnRoute]:
+        show_route_path = path.join(
+            self.device_path, JunosValidator.SHOW_ROUTE_FILENAME
+        )
+
+        if not path.isfile(show_route_path):
+            return []
+
+        with open(show_route_path) as fp:
+            routes_text = fp.read()
+        return parse_show_route_evpn_display_json(routes_text)
+
+    @staticmethod
+    def _compare_evpn_routes(
+        real_routes: Sequence[JunosEvpnRoute],
+        batfish_routes: Sequence[EvpnRibRoute],
+    ) -> dict[Any, Any]:
+        failures: dict[Any, Any] = {}
+
+        real_by_key: dict[tuple[str, str], JunosEvpnRoute] = {}
+        for real_rt in real_routes:
+            real_by_key[(real_rt.route_distinguisher, real_rt.network)] = real_rt
+
+        bf_by_key: dict[tuple[str, str], EvpnRibRoute] = {}
+        for bf_rt in batfish_routes:
+            bf_by_key[(bf_rt.route_distinguisher, bf_rt.network)] = bf_rt
+
+        for key in real_by_key.keys() - bf_by_key.keys():
+            failures[key] = f"Batfish is missing EVPN route: {real_by_key[key]}"
+
+        for key in bf_by_key.keys() - real_by_key.keys():
+            failures[key] = f"Batfish has extra EVPN route: {bf_by_key[key]}"
+
+        for key in real_by_key.keys() & bf_by_key.keys():
+            real = real_by_key[key]
+            bf = bf_by_key[key]
+            diff: dict[str, str] = {}
+
+            valid_origin_pairs = {("I", "igp"), ("E", "egp"), ("?", "incomplete")}
+            if (real.origin_type, bf.origin_type) not in valid_origin_pairs:
+                diff["origin_type"] = (
+                    f"Batfish: {bf.origin_type}, real: {real.origin_type}"
+                )
+
+            if diff:
+                failures[key] = diff
+
+        return failures
 
     def _parse_bgp_routes(self) -> Sequence[JunosBgpRoute]:
         show_route_path = path.join(

--- a/tests/lab_validation/parsers/junos/commands/test_routes.py
+++ b/tests/lab_validation/parsers/junos/commands/test_routes.py
@@ -1,8 +1,11 @@
 from lab_validation.parsers.junos.commands.routes import (
+    _parse_as_path_with_origin,
+    _parse_evpn_type5_destination,
     convert_active,
     parse_show_route_display_json,
+    parse_show_route_evpn_display_json,
 )
-from lab_validation.parsers.junos.models.routes import JunosMainRibRoute
+from lab_validation.parsers.junos.models.routes import JunosEvpnRoute, JunosMainRibRoute
 
 
 def test_show_route_display_json() -> None:
@@ -935,3 +938,307 @@ def test_convert_active_evpn_tags() -> None:
     assert convert_active("@") is True
     # # = forwarding use only
     assert convert_active("#") is True
+
+
+def test_parse_evpn_type5_destination() -> None:
+    # Standard Type 5 with RD and /24 prefix
+    assert _parse_evpn_type5_destination(
+        "5:172.16.0.100:10000::0::192.168.99.0::24"
+    ) == ("172.16.0.100:10000", "192.168.99.0/24")
+
+    # Type 5 with /31 prefix
+    assert _parse_evpn_type5_destination("5:172.16.0.100:10000::0::10.99.0.0::31") == (
+        "172.16.0.100:10000",
+        "10.99.0.0/31",
+    )
+
+    # Non-Type-5 destinations are skipped
+    assert _parse_evpn_type5_destination("2:172.16.0.100:1::00::0") is None
+    assert _parse_evpn_type5_destination("1:10.0.0.1:0::0011::0") is None
+
+    # Malformed (too few :: parts)
+    assert _parse_evpn_type5_destination("5:bad") is None
+
+
+def test_parse_as_path_with_origin() -> None:
+    # eBGP path with IGP origin
+    assert _parse_as_path_with_origin("65100 65200 I") == ((65100, 65200), "I")
+
+    # Empty path with IGP origin (locally originated)
+    assert _parse_as_path_with_origin("I") == ((), "I")
+
+    # EGP origin
+    assert _parse_as_path_with_origin("65001 E") == ((65001,), "E")
+
+    # Incomplete origin
+    assert _parse_as_path_with_origin("65001 65002 ?") == ((65001, 65002), "?")
+
+    # Empty string defaults to IGP
+    assert _parse_as_path_with_origin("") == ((), "I")
+
+    # Whitespace-only defaults to IGP
+    assert _parse_as_path_with_origin("   ") == ((), "I")
+
+
+def test_parse_show_route_evpn_display_json() -> None:
+    """Parse EVPN Type 5 routes from real node1-1 show route output.
+
+    Data from junos_evpn_type5 lab: node1-1 receives two EVPN routes
+    via iBGP from node2-1 (route reflector). The bgp.evpn.0 table
+    has two Type 5 routes with RD 172.16.0.100:10000, one with AS
+    path 65100 65200 and one locally originated (empty AS path).
+    The TENANT-A.evpn.0 table has the same routes but should be
+    skipped (only bgp.evpn.0 is parsed to avoid double-counting).
+    """
+    text = """{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"},
+        "route-table" : [
+        {
+            "table-name" : [{ "data" : "inet.0" }],
+            "rt" : [
+            {
+                "rt-destination" : [{ "data" : "172.16.0.1/32" }],
+                "rt-entry" : [{
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "BGP" }],
+                    "preference" : [{ "data" : "170" }],
+                    "nh" : [{ "to" : [{ "data" : "172.16.254.9" }], "via" : [{ "data" : "ge-0/0/1.0" }] }]
+                }]
+            }
+            ]
+        },
+        {
+            "table-name" : [{ "data" : "bgp.evpn.0" }],
+            "rt" : [
+            {
+                "rt-destination" : [{ "data" : "5:172.16.0.100:10000::0::192.168.99.0::24" }],
+                "rt-entry" : [{
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "BGP" }],
+                    "preference" : [{ "data" : "170" }],
+                    "as-path" : [{ "data" : "65100 65200 I" }],
+                    "nh" : [{
+                        "to" : [{ "data" : "172.16.254.1" }],
+                        "via" : [{ "data" : "ge-0/0/1.0" }]
+                    }]
+                }]
+            },
+            {
+                "rt-destination" : [{ "data" : "5:172.16.0.100:10000::0::10.99.0.0::31" }],
+                "rt-entry" : [{
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "BGP" }],
+                    "preference" : [{ "data" : "170" }],
+                    "as-path" : [{ "data" : "I" }],
+                    "nh" : [{
+                        "to" : [{ "data" : "172.16.254.1" }],
+                        "via" : [{ "data" : "ge-0/0/1.0" }]
+                    }]
+                }]
+            }
+            ]
+        },
+        {
+            "table-name" : [{ "data" : "TENANT-A.evpn.0" }],
+            "rt" : [
+            {
+                "rt-destination" : [{ "data" : "5:172.16.0.100:10000::0::192.168.99.0::24" }],
+                "rt-entry" : [{
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "EVPN" }],
+                    "preference" : [{ "data" : "170" }],
+                    "nh-type" : [{ "data" : "Fictitious" }]
+                }]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}
+    """
+
+    routes = parse_show_route_evpn_display_json(text)
+    assert routes == [
+        JunosEvpnRoute(
+            network="192.168.99.0/24",
+            route_distinguisher="172.16.0.100:10000",
+            vrf="default",
+            protocol="BGP",
+            next_hop_ip="172.16.254.1",
+            next_hop_int="ge-0/0/1.0",
+            active=True,
+            admin=170,
+            as_path=(65100, 65200),
+            origin_type="I",
+        ),
+        JunosEvpnRoute(
+            network="10.99.0.0/31",
+            route_distinguisher="172.16.0.100:10000",
+            vrf="default",
+            protocol="BGP",
+            next_hop_ip="172.16.254.1",
+            next_hop_int="ge-0/0/1.0",
+            active=True,
+            admin=170,
+            as_path=(),
+            origin_type="I",
+        ),
+    ]
+
+
+def test_parse_show_route_evpn_skips_inactive() -> None:
+    """Inactive EVPN routes (e.g., backup paths) are skipped."""
+    text = """{
+    "route-information" : [
+    {
+        "route-table" : [
+        {
+            "table-name" : [{ "data" : "bgp.evpn.0" }],
+            "rt" : [
+            {
+                "rt-destination" : [{ "data" : "5:172.16.0.100:10000::0::10.0.0.0::24" }],
+                "rt-entry" : [
+                {
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "BGP" }],
+                    "preference" : [{ "data" : "170" }],
+                    "as-path" : [{ "data" : "65001 I" }],
+                    "nh" : [{ "to" : [{ "data" : "10.0.0.1" }], "via" : [{ "data" : "ge-0/0/0.0" }] }]
+                },
+                {
+                    "active-tag" : [{}],
+                    "protocol-name" : [{ "data" : "BGP" }],
+                    "preference" : [{ "data" : "170" }],
+                    "as-path" : [{ "data" : "65002 I" }],
+                    "nh" : [{ "to" : [{ "data" : "10.0.0.2" }], "via" : [{ "data" : "ge-0/0/1.0" }] }]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}
+    """
+    routes = parse_show_route_evpn_display_json(text)
+    assert len(routes) == 1
+    assert routes[0].next_hop_ip == "10.0.0.1"
+
+
+def test_parse_show_route_evpn_skips_non_type5() -> None:
+    """Non-Type-5 EVPN routes (Type 2 MAC/IP) are skipped."""
+    text = """{
+    "route-information" : [
+    {
+        "route-table" : [
+        {
+            "table-name" : [{ "data" : "bgp.evpn.0" }],
+            "rt" : [
+            {
+                "rt-destination" : [{ "data" : "2:172.16.0.100:1::0::aa:bb:cc:00:11:22" }],
+                "rt-entry" : [{
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "BGP" }],
+                    "preference" : [{ "data" : "170" }],
+                    "as-path" : [{ "data" : "I" }],
+                    "nh" : [{ "to" : [{ "data" : "10.0.0.1" }], "via" : [{ "data" : "ge-0/0/0.0" }] }]
+                }]
+            },
+            {
+                "rt-destination" : [{ "data" : "5:172.16.0.100:10000::0::10.0.0.0::24" }],
+                "rt-entry" : [{
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "BGP" }],
+                    "preference" : [{ "data" : "170" }],
+                    "as-path" : [{ "data" : "65001 I" }],
+                    "nh" : [{ "to" : [{ "data" : "10.0.0.1" }], "via" : [{ "data" : "ge-0/0/0.0" }] }]
+                }]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}
+    """
+    routes = parse_show_route_evpn_display_json(text)
+    assert len(routes) == 1
+    assert routes[0].network == "10.0.0.0/24"
+
+
+def test_parse_show_route_evpn_no_evpn_table() -> None:
+    """Show route output with no bgp.evpn.0 table returns empty list."""
+    text = """{
+    "route-information" : [
+    {
+        "route-table" : [
+        {
+            "table-name" : [{ "data" : "inet.0" }],
+            "rt" : [
+            {
+                "rt-destination" : [{ "data" : "10.0.0.0/24" }],
+                "rt-entry" : [{
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "Direct" }],
+                    "preference" : [{ "data" : "0" }],
+                    "nh" : [{ "via" : [{ "data" : "ge-0/0/0.0" }] }]
+                }]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}
+    """
+    routes = parse_show_route_evpn_display_json(text)
+    assert routes == []
+
+
+def test_parse_show_route_evpn_locally_originated() -> None:
+    """Locally originated EVPN routes (protocol=EVPN, nh-type=Fictitious)
+    have no next-hop or AS path. These appear in bgp.evpn.0 on the
+    originating PE (e.g., router1 in junos_evpn_type5 lab).
+    """
+    text = """{
+    "route-information" : [
+    {
+        "route-table" : [
+        {
+            "table-name" : [{ "data" : "bgp.evpn.0" }],
+            "rt" : [
+            {
+                "rt-destination" : [{ "data" : "5:172.16.0.100:10000::0::192.168.99.0::24" }],
+                "rt-entry" : [{
+                    "active-tag" : [{ "data" : "*" }],
+                    "protocol-name" : [{ "data" : "EVPN" }],
+                    "preference" : [{ "data" : "170" }],
+                    "nh-type" : [{ "data" : "Fictitious" }]
+                }]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}
+    """
+    routes = parse_show_route_evpn_display_json(text)
+    assert routes == [
+        JunosEvpnRoute(
+            network="192.168.99.0/24",
+            route_distinguisher="172.16.0.100:10000",
+            vrf="default",
+            protocol="EVPN",
+            next_hop_ip=None,
+            next_hop_int=None,
+            active=True,
+            admin=170,
+            as_path=(),
+            origin_type="I",
+        ),
+    ]

--- a/tests/lab_validation/validators/test_junosValidator.py
+++ b/tests/lab_validation/validators/test_junosValidator.py
@@ -8,11 +8,19 @@ from lab_validation.parsers.junos.models.interfaces import (
     JunosInterface,
     JunosInterfaceState,
 )
-from lab_validation.parsers.junos.models.routes import JunosBgpRoute, JunosMainRibRoute
+from lab_validation.parsers.junos.models.routes import (
+    JunosBgpRoute,
+    JunosEvpnRoute,
+    JunosMainRibRoute,
+)
 from lab_validation.validators.batfish_models.interface_properties import (
     InterfaceProperties,
 )
-from lab_validation.validators.batfish_models.routes import BgpRibRoute, MainRibRoute
+from lab_validation.validators.batfish_models.routes import (
+    BgpRibRoute,
+    EvpnRibRoute,
+    MainRibRoute,
+)
 from lab_validation.validators.batfish_models.runtime_data import InterfaceRuntimeData
 from lab_validation.validators.JunosValidator import (
     JunosValidator,
@@ -1318,3 +1326,137 @@ def test_is_local_discard_host_route() -> None:
             tag=None,
         )
     )
+
+
+def _make_real_evpn_route(**kwargs: object) -> JunosEvpnRoute:
+    """Helper: builds a JunosEvpnRoute with sensible defaults from the
+    junos_evpn_type5 lab (node1-1 bgp.evpn.0 table).
+    """
+    defaults = dict(
+        network="192.168.99.0/24",
+        route_distinguisher="172.16.0.100:10000",
+        vrf="default",
+        protocol="BGP",
+        next_hop_ip="172.16.254.1",
+        next_hop_int="ge-0/0/1.0",
+        active=True,
+        admin=170,
+        as_path=(65100, 65200),
+        origin_type="I",
+    )
+    defaults.update(kwargs)
+    return JunosEvpnRoute(**defaults)
+
+
+def _make_bf_evpn_route(**kwargs: object) -> EvpnRibRoute:
+    """Helper: builds an EvpnRibRoute with sensible defaults matching
+    the real route above.
+    """
+    defaults = dict(
+        vrf="default",
+        network="192.168.99.0/24",
+        route_distinguisher="172.16.0.100:10000",
+        next_hop=NextHopIp(ip="172.16.0.100"),
+        next_hop_ip="172.16.0.100",
+        next_hop_int="dynamic",
+        protocol="bgp",
+        as_path="65100 65200",
+        metric=0,
+        local_preference=100,
+        communities=(),
+        origin_protocol="bgp",
+        origin_type="igp",
+        tag=0,
+    )
+    defaults.update(kwargs)
+    return EvpnRibRoute(**defaults)
+
+
+def test_compare_evpn_routes_matching() -> None:
+    """Matching routes with correct origin type mapping produce no failures."""
+    real = [_make_real_evpn_route()]
+    bf = [_make_bf_evpn_route()]
+    assert JunosValidator._compare_evpn_routes(real, bf) == {}
+
+
+def test_compare_evpn_routes_origin_igp() -> None:
+    """Device 'I' maps to Batfish 'igp'."""
+    real = [_make_real_evpn_route(origin_type="I")]
+    bf = [_make_bf_evpn_route(origin_type="igp")]
+    assert JunosValidator._compare_evpn_routes(real, bf) == {}
+
+
+def test_compare_evpn_routes_origin_egp() -> None:
+    """Device 'E' maps to Batfish 'egp'."""
+    real = [_make_real_evpn_route(origin_type="E")]
+    bf = [_make_bf_evpn_route(origin_type="egp")]
+    assert JunosValidator._compare_evpn_routes(real, bf) == {}
+
+
+def test_compare_evpn_routes_origin_incomplete() -> None:
+    """Device '?' maps to Batfish 'incomplete'."""
+    real = [_make_real_evpn_route(origin_type="?")]
+    bf = [_make_bf_evpn_route(origin_type="incomplete")]
+    assert JunosValidator._compare_evpn_routes(real, bf) == {}
+
+
+def test_compare_evpn_routes_origin_mismatch() -> None:
+    """Mismatched origin type produces a failure."""
+    real = [_make_real_evpn_route(origin_type="I")]
+    bf = [_make_bf_evpn_route(origin_type="egp")]
+    failures = JunosValidator._compare_evpn_routes(real, bf)
+    assert ("172.16.0.100:10000", "192.168.99.0/24") in failures
+    assert "origin_type" in failures[("172.16.0.100:10000", "192.168.99.0/24")]
+
+
+def test_compare_evpn_routes_missing_in_batfish() -> None:
+    """Device has a route that Batfish does not."""
+    real = [_make_real_evpn_route()]
+    bf: list[EvpnRibRoute] = []
+    failures = JunosValidator._compare_evpn_routes(real, bf)
+    key = ("172.16.0.100:10000", "192.168.99.0/24")
+    assert key in failures
+    assert "missing" in failures[key].lower()
+
+
+def test_compare_evpn_routes_extra_in_batfish() -> None:
+    """Batfish has a route that the device does not."""
+    real: list[JunosEvpnRoute] = []
+    bf = [_make_bf_evpn_route()]
+    failures = JunosValidator._compare_evpn_routes(real, bf)
+    key = ("172.16.0.100:10000", "192.168.99.0/24")
+    assert key in failures
+    assert "extra" in failures[key].lower()
+
+
+def test_compare_evpn_routes_multiple() -> None:
+    """Multiple routes: one matching, one extra in Batfish."""
+    real = [_make_real_evpn_route()]
+    bf = [
+        _make_bf_evpn_route(),
+        _make_bf_evpn_route(network="10.99.0.0/31"),
+    ]
+    failures = JunosValidator._compare_evpn_routes(real, bf)
+    assert ("172.16.0.100:10000", "192.168.99.0/24") not in failures
+    assert ("172.16.0.100:10000", "10.99.0.0/31") in failures
+
+
+def test_compare_evpn_routes_different_rd() -> None:
+    """Same network from different RDs are distinct routes."""
+    real = [_make_real_evpn_route(route_distinguisher="10.0.0.1:100")]
+    bf = [_make_bf_evpn_route(route_distinguisher="10.0.0.2:100")]
+    failures = JunosValidator._compare_evpn_routes(real, bf)
+    assert ("10.0.0.1:100", "192.168.99.0/24") in failures
+    assert ("10.0.0.2:100", "192.168.99.0/24") in failures
+
+
+def test_validate_evpn_rib_routes_empty_batfish() -> None:
+    """No Batfish EVPN routes -> skip validation (empty result)."""
+    result = JunosValidator("")._compare_evpn_routes([], [])
+    assert result == {}
+
+
+def test_validate_evpn_rib_routes_no_batfish_routes() -> None:
+    """validate_evpn_rib_routes returns {} when batfish_routes is empty."""
+    result = JunosValidator("").validate_evpn_rib_routes([])
+    assert result == {}


### PR DESCRIPTION
Parse EVPN Type 5 routes from bgp.evpn.0 table in show route output.
Decode Type 5 destinations (5:<RD>::0::<prefix>::<len>) into route
distinguisher and network prefix. Only parse from the global
bgp.evpn.0 to avoid double-counting routes in per-VRF evpn.0 tables.
Add JunosEvpnRoute dataclass for parsed routes.

Compare device bgp.evpn.0 routes against Batfish EVPN RIB by
(route_distinguisher, network) key. Validate origin type mapping
(device I/E/? to Batfish igp/egp/incomplete).

----

Prompt:
```
Implement EVPN RIB validation for Junos: parse EVPN Type 5 routes
from bgp.evpn.0 and compare against Batfish EVPN RIB.
```