### PR TITLE
Parsers: replace deprecated pyparsing camelCase API with snake_case

### DIFF
--- a/src/lab_validation/parsers/a10/commands/bgp.py
+++ b/src/lab_validation/parsers/a10/commands/bgp.py
@@ -26,7 +26,7 @@ def parse_show_ip_bgp(text: str) -> list[A10BgpRoute]:
     """Parses the output of `show ip bgp`."""
     if not text.strip():
         return []
-    parsed = show_ip_bgp().parseString(text)
+    parsed = show_ip_bgp().parse_string(text)
     routes: list[A10BgpRoute] = []
     for r in parsed["v4_routes"]:
         routes.append(_deserialize_route(r))
@@ -65,7 +65,7 @@ def _deserialize_route(r: ParseResults) -> A10BgpRoute:
 
 def show_ip_bgp() -> ParserElement:
     """Grammar for parsing output of 'show ip bgp'"""
-    return _header() + _routes_block() + SkipTo(stringEnd).setResultsName("padding")
+    return _header() + _routes_block() + SkipTo(stringEnd).set_results_name("padding")
 
 
 def _header() -> ParserElement:
@@ -73,13 +73,13 @@ def _header() -> ParserElement:
         Group(
             Literal("BGP Address Family IPv4 Unicast") + SkipTo(" Path") + to_eol + "\n"
         )
-        .leaveWhitespace()
-        .setResultsName("skipped")
+        .leave_whitespace()
+        .set_results_name("skipped")
     )
 
 
 def _routes_block() -> ParserElement:
-    return OneOrMore(_ip_v4_route_line()).setResultsName("v4_routes")
+    return OneOrMore(_ip_v4_route_line()).set_results_name("v4_routes")
 
 
 _origin_codes = [
@@ -99,21 +99,23 @@ _types = {
 def _ip_v4_route_line() -> ParserElement:
     """Parses a single route on a single line."""
     return Group(
-        Optional("*").setResultsName("valid")
-        + Optional(">").setResultsName("best")
+        Optional("*").set_results_name("valid")
+        + Optional(">").set_results_name("best")
         + White(" ", min=1, max=3)
-        + prefix.setResultsName("network")
+        + prefix.set_results_name("network")
         + White(" \n", min=1, max=21)
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + White(" ", min=1, max=19)
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + White(" ", min=1, max=8)
-        + Optional(dec.setResultsName("lp"))
+        + Optional(dec.set_results_name("lp"))
         + White(" ", min=1, max=8)
-        + dec.setResultsName("weight")
-        + printables_and_space(10).setResultsName("type")
-        + ZeroOrMore(dec + White(" ")).setResultsName("as_path")
-        + MatchFirst([Literal(code) for code in _origin_codes]).setResultsName("origin")
+        + dec.set_results_name("weight")
+        + printables_and_space(10).set_results_name("type")
+        + ZeroOrMore(dec + White(" ")).set_results_name("as_path")
+        + MatchFirst([Literal(code) for code in _origin_codes]).set_results_name(
+            "origin"
+        )
         + to_eol
         + "\n"
-    ).leaveWhitespace()
+    ).leave_whitespace()

--- a/src/lab_validation/parsers/a10/commands/routes.py
+++ b/src/lab_validation/parsers/a10/commands/routes.py
@@ -25,7 +25,7 @@ _IPv4_PATTERN = re.compile(r"\d+\.\d+\.\d+\.\d+")
 
 def parse_show_ip_route_acos(text: str) -> list[A10MainRibRoute]:
     """Parses the output of `show ip route acos`."""
-    parsed = show_ip_route_acos().parseString(text)
+    parsed = show_ip_route_acos().parse_string(text)
     routes: list[A10MainRibRoute] = []
     if "v4_routes" in parsed:
         for r in parsed["v4_routes"]:
@@ -53,7 +53,7 @@ def _deserialize_show_ip_route_acos_route(r: ParseResults) -> A10MainRibRoute:
 
 def parse_show_ip_route_all(text: str) -> list[A10MainRibRoute]:
     """Parses the output of `show ip route all`."""
-    parsed = show_ip_route_all().parseString(text)
+    parsed = show_ip_route_all().parse_string(text)
     routes: list[A10MainRibRoute] = []
     for r in parsed["v4_routes"]:
         routes.append(_deserialize_show_ip_route_all_route(r))
@@ -68,7 +68,7 @@ def parse_show_ip_route_all(text: str) -> list[A10MainRibRoute]:
 
 def parse_one_show_ip_route_all_route(text: str) -> A10MainRibRoute:
     """Parses one route line of show ip route all, for testing."""
-    parsed = _show_ip_route_all_ip_v4_route_line().parseString(text)
+    parsed = _show_ip_route_all_ip_v4_route_line().parse_string(text)
     return _deserialize_show_ip_route_all_route(parsed)
 
 
@@ -95,18 +95,18 @@ def show_ip_route_acos() -> ParserElement:
     return (
         _show_route_acos_codes()
         + _show_route_acos_routes_block()
-        + SkipTo(stringEnd).setResultsName("padding")
+        + SkipTo(stringEnd).set_results_name("padding")
     )
 
 
 def _show_route_acos_codes() -> ParserElement:
-    return Group(Literal("Codes:") + SkipTo("NAT Map") + to_eol).setResultsName(
+    return Group(Literal("Codes:") + SkipTo("NAT Map") + to_eol).set_results_name(
         "skipped"
     )
 
 
 def _show_route_acos_routes_block() -> ParserElement:
-    return ZeroOrMore(_show_ip_route_acos_ip_v4_route_line()).setResultsName(
+    return ZeroOrMore(_show_ip_route_acos_ip_v4_route_line()).set_results_name(
         "v4_routes"
     )
 
@@ -129,8 +129,8 @@ def _show_ip_route_acos_ip_v4_route_line() -> ParserElement:
     return Group(
         MatchFirst(
             [Literal(code) for code in _show_route_acos_protocol_codes]
-        ).setResultsName("protocol")
-        + prefix.setResultsName("network")
+        ).set_results_name("protocol")
+        + prefix.set_results_name("network")
     )
 
 
@@ -139,18 +139,20 @@ def show_ip_route_all() -> ParserElement:
     return (
         _show_ip_route_all_codes()
         + _show_ip_route_all_routes_block()
-        + SkipTo(stringEnd).setResultsName("padding")
+        + SkipTo(stringEnd).set_results_name("padding")
     )
 
 
 def _show_ip_route_all_codes() -> ParserElement:
     return Group(
         Literal("Codes:") + SkipTo("Gateway of last resort is") + to_eol
-    ).setResultsName("skipped")
+    ).set_results_name("skipped")
 
 
 def _show_ip_route_all_routes_block() -> ParserElement:
-    return OneOrMore(_show_ip_route_all_ip_v4_route_line()).setResultsName("v4_routes")
+    return OneOrMore(_show_ip_route_all_ip_v4_route_line()).set_results_name(
+        "v4_routes"
+    )
 
 
 _show_route_all_protocol_codes = [
@@ -182,13 +184,13 @@ def _show_ip_route_all_ip_v4_route_line() -> ParserElement:
     return Group(
         MatchFirst(
             [Literal(code) for code in _show_route_all_protocol_codes]
-        ).setResultsName("protocol")
-        + Optional("*").setResultsName("candidate_default")
-        + prefix.setResultsName("network")
+        ).set_results_name("protocol")
+        + Optional("*").set_results_name("candidate_default")
+        + prefix.set_results_name("network")
         + MatchFirst([_directly_connected(), _admin_via_nhip()])
-        + _interface_name().setResultsName("nh_iface")
+        + _interface_name().set_results_name("nh_iface")
         + Literal(",").suppress()
-        + _time.setResultsName("time")
+        + _time.set_results_name("time")
     )
 
 
@@ -201,11 +203,11 @@ def _admin_via_nhip() -> ParserElement:
     """Expect admin, metric, and next-hop IP."""
     return (
         "["
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "/"
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + "]"
         + "via"
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + ","
     )

--- a/src/lab_validation/parsers/arista/grammar/route.py
+++ b/src/lab_validation/parsers/arista/grammar/route.py
@@ -20,18 +20,18 @@ def show_ip_route_vrf_all() -> ParserElement:
 
 
 def _vrf_header() -> ParserElement:
-    return Literal("VRF:") + Word(printables).setResultsName("vrf")
+    return Literal("VRF:") + Word(printables).set_results_name("vrf")
 
 
 def _middle() -> ParserElement:
     to_skip = (
         Literal("Codes:") + SkipTo("Gateway of last resort is") + to_eol
-    ).setResultsName("skipped")
+    ).set_results_name("skipped")
     return Group(to_skip)
 
 
 def _routes_block_within_subnet() -> ParserElement:
-    return OneOrMore(Group(_ip_v4_route_line())).setResultsName("v4_routes")
+    return OneOrMore(Group(_ip_v4_route_line())).set_results_name("v4_routes")
 
 
 _protocol_codes = [
@@ -62,27 +62,27 @@ _protocol_codes = [
 
 def _ip_v4_route_line() -> ParserElement:
     return (
-        MatchFirst([Literal(code) for code in _protocol_codes]).setResultsName(
+        MatchFirst([Literal(code) for code in _protocol_codes]).set_results_name(
             "protocol"
         )
-        + prefix.setResultsName("network")
+        + prefix.set_results_name("network")
         + MatchFirst([_directly_connected_line(), _prefix_via_nhip_line()])
     )
 
 
 def _directly_connected_line() -> ParserElement:
-    return "is directly connected," + Word(printables).setResultsName("nh_iface")
+    return "is directly connected," + Word(printables).set_results_name("nh_iface")
 
 
 def _prefix_via_nhip_line() -> ParserElement:
     return (
         "["
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "/"
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + "]"
         + "via"
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + ", "
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
     )

--- a/src/lab_validation/parsers/checkpoint/commands/interfaces.py
+++ b/src/lab_validation/parsers/checkpoint/commands/interfaces.py
@@ -20,16 +20,16 @@ _state = MatchFirst([Literal("on"), Literal("off")])
 
 
 def _interface_block() -> ParserElement:
-    iface_line = "Interface" + Word(printables).setResultsName("name") + to_eol
-    state_line = "state" + _state.setResultsName("state") + to_eol
+    iface_line = "Interface" + Word(printables).set_results_name("name") + to_eol
+    state_line = "state" + _state.set_results_name("state") + to_eol
     mac_addr_line = "mac-addr" + to_eol
-    type_line = "type" + Word(printables).setResultsName("type") + to_eol
+    type_line = "type" + Word(printables).set_results_name("type") + to_eol
     link_state_line = "link-state" + to_eol
-    mtu_line = "mtu" + dec.setResultsName("mtu") + to_eol
+    mtu_line = "mtu" + dec.set_results_name("mtu") + to_eol
     auto_negotiation_line = "auto-negotiation" + to_eol
     speed_line = (
         "speed"
-        + MatchFirst([dec.setResultsName("speed_Mbps"), Literal("N/A")])
+        + MatchFirst([dec.set_results_name("speed_Mbps"), Literal("N/A")])
         + to_eol
     )
     ipv6_autoconfig_line = "ipv6-autoconfig" + to_eol
@@ -39,7 +39,7 @@ def _interface_block() -> ParserElement:
     comments_line = "comments" + to_eol
     ipv4_address_line = (
         "ipv4-address"
-        + MatchFirst([prefix.setResultsName("prefix"), Literal("Not")])
+        + MatchFirst([prefix.set_results_name("prefix"), Literal("Not")])
         + to_eol
     )
     ipv6_address_line = "ipv6-address" + to_eol
@@ -70,7 +70,7 @@ def _statistics_block() -> ParserElement:
 
 
 def parse_show_interfaces(text: str) -> Iterable[CheckpointInterface]:
-    all_parse_results = OneOrMore(Group(_interface_block())).scanString(text)
+    all_parse_results = OneOrMore(Group(_interface_block())).scan_string(text)
     results: list[CheckpointInterface] = []
 
     last_loc = 0

--- a/src/lab_validation/parsers/fortios/commands/interfaces.py
+++ b/src/lab_validation/parsers/fortios/commands/interfaces.py
@@ -10,7 +10,7 @@ from ..models.interfaces import FortiosInterface, FortiosPhysicalInterface
 
 def parse_get_system_interface(ifaces_text: str) -> Sequence[FortiosInterface]:
     logger = logging.getLogger(__name__)
-    all_logical_parse_results = OneOrMore(Group(interface_block())).scanString(
+    all_logical_parse_results = OneOrMore(Group(interface_block())).scan_string(
         ifaces_text
     )
     results: list[FortiosInterface] = []
@@ -36,7 +36,7 @@ def parse_get_system_interface_physical(
     logger = logging.getLogger(__name__)
     all_physical_parse_results = OneOrMore(
         Group(physical_interface_block())
-    ).scanString(ifaces_physical_text)
+    ).scan_string(ifaces_physical_text)
     results: list[FortiosPhysicalInterface] = []
 
     last_loc = 0

--- a/src/lab_validation/parsers/fortios/grammar/interface.py
+++ b/src/lab_validation/parsers/fortios/grammar/interface.py
@@ -17,31 +17,31 @@ _name_chars = alphanums + "."
 _iface_line = Literal("==") + Literal("[") + Word(_name_chars) + Literal("]")
 
 _physical_iface_line = (
-    Literal("==[") + Word(_name_chars).setResultsName("name") + Literal("]")
+    Literal("==[") + Word(_name_chars).set_results_name("name") + Literal("]")
 )
 
-_name = Literal("name:") + Word(_name_chars).setResultsName("name")
+_name = Literal("name:") + Word(_name_chars).set_results_name("name")
 
-_mode = Literal("mode:") + Word(alphanums).setResultsName("mode")
+_mode = Literal("mode:") + Word(alphanums).set_results_name("mode")
 
 _ip = (
     Literal("ip:")
-    + Word(nums + ".").setResultsName("ip_addr")
-    + Word(nums + ".").setResultsName("ip_mask")
+    + Word(nums + ".").set_results_name("ip_addr")
+    + Word(nums + ".").set_results_name("ip_mask")
 )
 
-_ipv6 = Literal("ipv6:") + Word(alphanums + "/" + ":").setResultsName("ipv6_addr")
+_ipv6 = Literal("ipv6:") + Word(alphanums + "/" + ":").set_results_name("ipv6_addr")
 
-_status = Literal("status:") + Word(alphanums).setResultsName("status")
+_status = Literal("status:") + Word(alphanums).set_results_name("status")
 
 _netbios_forward = Literal("netbios-forward:") + Word(alphas)
 
 _speed_set = (
     Literal("speed:")
-    + dec.setResultsName("speed")
-    + Optional(Word(alphas).setResultsName("bit_rate_unit"))
+    + dec.set_results_name("speed")
+    + Optional(Word(alphas).set_results_name("bit_rate_unit"))
     + Optional(
-        Literal("(Duplex:") + Word(alphas).setResultsName("duplex") + Literal(")")
+        Literal("(Duplex:") + Word(alphas).set_results_name("duplex") + Literal(")")
     )
 )
 
@@ -49,7 +49,7 @@ _speed_na = Literal("speed:") + Literal("n/a")
 
 _speed = MatchFirst([_speed_set, _speed_na])
 
-_type = Literal("type:").suppress() + Word(alphanums).setResultsName("type")
+_type = Literal("type:").suppress() + Word(alphanums).set_results_name("type")
 
 
 def interface_block() -> ParserElement:

--- a/src/lab_validation/parsers/frr/commands/interfaces.py
+++ b/src/lab_validation/parsers/frr/commands/interfaces.py
@@ -12,7 +12,7 @@ _state_code = ["up", "down"]
 
 def parse_show_interface(text: str) -> Sequence[FrrInterface]:
     logger = logging.getLogger(__name__)
-    all_parse_results = OneOrMore(Group(interface_block())).scanString(text)
+    all_parse_results = OneOrMore(Group(interface_block())).scan_string(text)
     results: list[FrrInterface] = []
 
     last_loc = 0

--- a/src/lab_validation/parsers/frr/commands/vrf.py
+++ b/src/lab_validation/parsers/frr/commands/vrf.py
@@ -4,7 +4,7 @@ from ..grammar.vrf import parse_vrf
 
 
 def get_show_vrf(text: str) -> dict:
-    parsed_result = OneOrMore(Group(parse_vrf())).parseString(text)
+    parsed_result = OneOrMore(Group(parse_vrf())).parse_string(text)
 
     vrf_result: dict = {}
     for record in parsed_result:

--- a/src/lab_validation/parsers/frr/grammar/interface.py
+++ b/src/lab_validation/parsers/frr/grammar/interface.py
@@ -35,12 +35,12 @@ def _get_iface_line() -> ParserElement:
 def _get_iface_line_admin_up() -> ParserElement:
     return (
         Literal("Interface").suppress()
-        + Word(printables).setResultsName("name")
+        + Word(printables).set_results_name("name")
         + Literal("is").suppress()
-        + Literal("up").setResultsName("admin_state")
+        + Literal("up").set_results_name("admin_state")
         + Literal(",").suppress()
         + Literal("line protocol is").suppress()
-        + _state.setResultsName("line_state")
+        + _state.set_results_name("line_state")
         + to_eol
     )
 
@@ -48,9 +48,9 @@ def _get_iface_line_admin_up() -> ParserElement:
 def _get_iface_line_admin_down() -> ParserElement:
     return (
         Literal("Interface").suppress()
-        + Word(printables).setResultsName("name")
+        + Word(printables).set_results_name("name")
         + Literal("is").suppress()
-        + Word(printables).setResultsName("admin_state")
+        + Word(printables).set_results_name("admin_state")
         + to_eol
     )
 
@@ -58,10 +58,10 @@ def _get_iface_line_admin_down() -> ParserElement:
 def _get_mtu_speed() -> ParserElement:
     return (
         Literal("mtu").suppress()
-        + dec.setResultsName("mtu")
+        + dec.set_results_name("mtu")
         # bit-rate unit for speed is mbps in FRR show interface
         + Literal("speed").suppress()
-        + dec.setResultsName("speed")
+        + dec.set_results_name("speed")
         + to_eol
     )
 
@@ -69,7 +69,7 @@ def _get_mtu_speed() -> ParserElement:
 def _get_bandwidth() -> ParserElement:
     return (
         Literal("bandwidth").suppress()
-        + dec.setResultsName("bandwidth")
-        + Word(printables).setResultsName("bit_rate_unit")
+        + dec.set_results_name("bandwidth")
+        + Word(printables).set_results_name("bit_rate_unit")
         + to_eol
     )

--- a/src/lab_validation/parsers/frr/grammar/vrf.py
+++ b/src/lab_validation/parsers/frr/grammar/vrf.py
@@ -4,9 +4,9 @@ from pyparsing import Literal, ParserElement, Word, nums, printables
 def parse_vrf() -> ParserElement:
     return (
         Literal("vrf").suppress()
-        + Word(printables).setResultsName("name")
+        + Word(printables).set_results_name("name")
         + Literal("id").suppress()
-        + Word(nums).setResultsName("id")
+        + Word(nums).set_results_name("id")
         + Literal("table").suppress()
-        + Word(nums).setResultsName("table_index")
+        + Word(nums).set_results_name("table_index")
     )

--- a/src/lab_validation/parsers/ios/commands/interfaces.py
+++ b/src/lab_validation/parsers/ios/commands/interfaces.py
@@ -23,10 +23,10 @@ _state = MatchFirst([Literal("up"), Literal("down")])
 
 def _get_iface_line() -> ParserElement:
     return (
-        Word(printables).setResultsName("name")
+        Word(printables).set_results_name("name")
         + _get_admin_line()
         + ", line protocol is"
-        + _state.setResultsName("line_protocol")
+        + _state.set_results_name("line_protocol")
         + to_eol
     )
 
@@ -35,24 +35,24 @@ def _get_admin_line() -> ParserElement:
     return (
         "is"
         + ParsingOptional("administratively")
-        + _state.setResultsName("admin_state")
+        + _state.set_results_name("admin_state")
     )
 
 
 def _get_mtu_bw_line() -> ParserElement:
     return (
         "MTU"
-        + dec.setResultsName("mtu")
+        + dec.set_results_name("mtu")
         + "bytes,"
         + "BW"
-        + dec.setResultsName("bw")
+        + dec.set_results_name("bw")
         + "Kbit/sec,"
         + to_eol
     )
 
 
 def _get_addr_line() -> ParserElement:
-    return "Internet address is" + prefix.setResultsName("prefix")
+    return "Internet address is" + prefix.set_results_name("prefix")
 
 
 def _interface_block() -> ParserElement:
@@ -71,7 +71,7 @@ def _interface_block() -> ParserElement:
 
 # TODO: this matches return values and signature of genie parsers. Write IosInterface model
 def parse_show_interfaces(text: str) -> dict[str, dict[str, Any]]:
-    all_parse_results = OneOrMore(Group(_interface_block())).scanString(text)
+    all_parse_results = OneOrMore(Group(_interface_block())).scan_string(text)
     results: dict[str, dict[str, Any]] = {}
 
     logger = logging.getLogger(__name__)

--- a/src/lab_validation/parsers/ios/commands/route.py
+++ b/src/lab_validation/parsers/ios/commands/route.py
@@ -32,7 +32,7 @@ _IPv4_PATTERN = re.compile(r"\d+\.\d+\.\d+\.\d+")
 def parse_show_ip_route(routes_output: str) -> Sequence[IosIpRoute]:
     """Parses show ip route output for IOS"""
     logger = logging.getLogger(__name__)
-    raw_parsed_results = show_route().scanString(routes_output)
+    raw_parsed_results = show_route().scan_string(routes_output)
     routes: list[IosIpRoute] = []
     last_loc = 0
     last_vrf = "default"  # the table for the default vrf will not have a vrf header

--- a/src/lab_validation/parsers/ios/commands/show_bgp_all.py
+++ b/src/lab_validation/parsers/ios/commands/show_bgp_all.py
@@ -59,7 +59,7 @@ def parse_show_bgp_all(bgp_output: str) -> Sequence[IosBgpAddressFamily]:
     """Parses IOS/XE 'show bgp all' output."""
     if bgp_output.strip() == "% BGP not active":
         return []
-    parsed_afs = OneOrMore(_bgp_address_family()).parseString(bgp_output)
+    parsed_afs = OneOrMore(_bgp_address_family()).parse_string(bgp_output)
     afs = []
     for record in parsed_afs:
         name = record["af"]
@@ -164,7 +164,9 @@ def _af_name() -> ParserElement:
 
 
 def _af_header() -> ParserElement:
-    return Literal("For address family: ").suppress() + _af_name().setResultsName("af")
+    return Literal("For address family: ").suppress() + _af_name().set_results_name(
+        "af"
+    )
 
 
 def _af_table() -> ParserElement:
@@ -176,7 +178,7 @@ def _af_table_header() -> ParserElement:
         Literal("BGP table version is").suppress()
         + dec.suppress()
         + Literal(", local router ID is").suppress()
-        + ip.setResultsName("router_id")
+        + ip.set_results_name("router_id")
     )
 
 
@@ -189,7 +191,7 @@ def _af_table_codes() -> ParserElement:
 def _af_table_routes() -> ParserElement:
     return _af_table_routes_header() + ZeroOrMore(
         MatchFirst([_af_table_routes_default_vrf(), _af_table_routes_vrf()])
-    ).setResultsName("vrfs")
+    ).set_results_name("vrfs")
 
 
 def _af_table_routes_header() -> ParserElement:
@@ -209,27 +211,27 @@ def _af_table_routes_default_vrf() -> ParserElement:
             MatchFirst(
                 [_af_table_routes_vrf_route(), _af_table_routes_vrf_multi_route()]
             )
-        ).setResultsName("routes")
+        ).set_results_name("routes")
     )
 
 
 def _af_table_routes_vrf() -> ParserElement:
     return Group(
-        _af_table_routes_vrf_rd().setResultsName("vrf_info")
-        + ZeroOrMore(_af_table_routes_vrf_route()).setResultsName("routes")
+        _af_table_routes_vrf_rd().set_results_name("vrf_info")
+        + ZeroOrMore(_af_table_routes_vrf_route()).set_results_name("routes")
     )
 
 
 def _af_table_routes_vrf_rd() -> ParserElement:
     return Group(
         Literal("Route Distinguisher:").suppress()
-        + route_distinguisher.setResultsName("rd")
+        + route_distinguisher.set_results_name("rd")
         + Literal("(default for vrf ").suppress()
-        + Word(alphanums + "-_").setResultsName("vrf_name")
+        + Word(alphanums + "-_").set_results_name("vrf_name")
         + MatchFirst(
             [
                 Literal(") VRF Router ID").suppress()
-                + ip.setResultsName("vrf_router_id"),
+                + ip.set_results_name("vrf_router_id"),
                 Literal(")").suppress(),
             ]
         )
@@ -240,29 +242,29 @@ def _af_table_routes_vrf_route() -> ParserElement:
     """
     parse route entry in bgp rib
     """
-    route_status = MatchFirst([Literal(code) for code in _STATUS_CODES]).setResultsName(
-        "status"
-    )
-    as_path = ZeroOrMore(dec + White(" ", exact=1)).setResultsName("as_path")
+    route_status = MatchFirst(
+        [Literal(code) for code in _STATUS_CODES]
+    ).set_results_name("status")
+    as_path = ZeroOrMore(dec + White(" ", exact=1)).set_results_name("as_path")
     origin_type = Literal("e") ^ Literal("i") ^ Literal("?")
     record = Group(
         White(min=1, max=2).suppress()
         + Optional(route_status)
         + Optional(White(" ", min=1).suppress())
-        + (ip ^ prefix).setResultsName("network")
+        + (ip ^ prefix).set_results_name("network")
         + Optional(White("\n", exact=1).suppress())
         + White(" ", min=1).suppress()
-        + printables_and_space(15).setResultsName("next_hop")
-        + printables_and_space(11).setResultsName("metric")
+        + printables_and_space(15).set_results_name("next_hop")
+        + printables_and_space(11).set_results_name("metric")
         # exact=7 in local_preference is set as per the current show data examples that we have.
         # It needs to be adjusted if we see the value beyond it. Technically it can go up to 10 char.
-        + printables_and_space(7).setResultsName("local_preference")
+        + printables_and_space(7).set_results_name("local_preference")
         + White(" ", min=1).suppress()
-        + dec.setResultsName("weight")
+        + dec.set_results_name("weight")
         + White(" ", min=1).suppress()
         + as_path
-        + origin_type.setResultsName("origin_type")
-    ).leaveWhitespace()
+        + origin_type.set_results_name("origin_type")
+    ).leave_whitespace()
     return record
 
 
@@ -270,26 +272,26 @@ def _af_table_routes_vrf_multi_route() -> ParserElement:
     """
     parse multi route entry in bgp rib. It may or may not be ecmp("*m") in bgp rib
     """
-    route_status = MatchFirst([Literal(code) for code in _STATUS_CODES]).setResultsName(
-        "status"
-    )
-    as_path = ZeroOrMore(dec + White(" ")).setResultsName("as_path")
+    route_status = MatchFirst(
+        [Literal(code) for code in _STATUS_CODES]
+    ).set_results_name("status")
+    as_path = ZeroOrMore(dec + White(" ")).set_results_name("as_path")
     origin_type = Literal("e") ^ Literal("i") ^ Literal("?")
     record = Group(
         White(min=1, max=2).suppress()
         + route_status
         + White(" ", min=1).suppress()
-        + printables_and_space(15).setResultsName("next_hop")
-        + printables_and_space(11).setResultsName("metric")
+        + printables_and_space(15).set_results_name("next_hop")
+        + printables_and_space(11).set_results_name("metric")
         # exact=7 in local_preference is set as per the current show data examples that we have.
         # It needs to be adjusted if we see the value beyond it. Technically it can go up to 10 char.
-        + printables_and_space(7).setResultsName("local_preference")
+        + printables_and_space(7).set_results_name("local_preference")
         + White(" ", min=1).suppress()
-        + dec.setResultsName("weight")
+        + dec.set_results_name("weight")
         + White(" ", min=1).suppress()
         + as_path
-        + origin_type.setResultsName("origin_type")
-    ).leaveWhitespace()
+        + origin_type.set_results_name("origin_type")
+    ).leave_whitespace()
     return record
 
 

--- a/src/lab_validation/parsers/ios/grammar/route.py
+++ b/src/lab_validation/parsers/ios/grammar/route.py
@@ -25,15 +25,15 @@ def show_route() -> ParserElement:
     return (
         Optional(routing_table_line())
         + middle()
-        + ZeroOrMore(single_route()).setResultsName("v4_routes")
-        + SkipTo(MatchFirst([routing_table_line(), stringEnd])).setResultsName(
+        + ZeroOrMore(single_route()).set_results_name("v4_routes")
+        + SkipTo(MatchFirst([routing_table_line(), stringEnd])).set_results_name(
             "padding"
         )
     )
 
 
 def routing_table_line() -> ParserElement:
-    return "Routing Table: " + Word(printables).setResultsName("vrf") + to_eol
+    return "Routing Table: " + Word(printables).set_results_name("vrf") + to_eol
 
 
 def single_route() -> ParserElement:
@@ -41,8 +41,8 @@ def single_route() -> ParserElement:
     return Group(
         MatchFirst(
             [
-                _routes_block().setResultsName("v4_routes_block"),
-                _routes_block_within_subnet().setResultsName(
+                _routes_block().set_results_name("v4_routes_block"),
+                _routes_block_within_subnet().set_results_name(
                     "v4_routes_block_within_subnet"
                 ),
             ]
@@ -53,51 +53,53 @@ def single_route() -> ParserElement:
 def middle() -> ParserElement:
     return Group(
         Literal("Codes:") + SkipTo("Gateway of last resort is") + to_eol
-    ).setResultsName("skipped")
+    ).set_results_name("skipped")
 
 
 def _directly_connected_line() -> ParserElement:
     return (
         "is directly connected,"
         + Optional(_time + ",")
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
     )
 
 
 def _is_a_summary_line() -> ParserElement:
     return (
-        Literal("is a summary,").setResultsName("summary")
+        Literal("is a summary,").set_results_name("summary")
         + Optional(_time + ",")
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
     )
 
 
 def _prefix_via_nhip_line() -> ParserElement:
     return (
         "["
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "/"
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + "]"
         + "via"
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + Optional(
-            "(" + Word(printables, excludeChars=",)").setResultsName("source_vrf") + ")"
+            "("
+            + Word(printables, excludeChars=",)").set_results_name("source_vrf")
+            + ")"
         )
         + Optional("," + _time)
-        + Optional(", " + Word(printables).setResultsName("nh_iface"))
+        + Optional(", " + Word(printables).set_results_name("nh_iface"))
     )
 
 
 def _prefix_null_route_line() -> ParserElement:
     return (
         "["
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "/"
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + "]"
         + Optional("," + _time)
-        + Optional(", " + Literal("Null0").setResultsName("nh_iface"))
+        + Optional(", " + Literal("Null0").set_results_name("nh_iface"))
     )
 
 
@@ -106,7 +108,7 @@ def _routes_block_within_subnet() -> ParserElement:
 
 
 def _routes_block() -> ParserElement:
-    return OneOrMore(Group(_v4_route())).setResultsName("v4_routes_block")
+    return OneOrMore(Group(_v4_route())).set_results_name("v4_routes_block")
 
 
 def _v4_route() -> ParserElement:
@@ -122,8 +124,8 @@ def _v4_route() -> ParserElement:
                     Literal("D"),
                 ]
             )
-        ).setResultsName("protocol")
-        + Optional(Literal("*").setResultsName("candidate_default"))
+        ).set_results_name("protocol")
+        + Optional(Literal("*").set_results_name("candidate_default"))
         + Optional(
             MatchFirst(
                 [
@@ -134,9 +136,9 @@ def _v4_route() -> ParserElement:
                     Literal("N2"),
                 ]
             )
-        ).setResultsName("ospf_extensions")
-        + Optional(MatchFirst([Literal("EX")])).setResultsName("eigrp_extensions")
-        + Optional(MatchFirst([prefix, ip])).setResultsName("network")
+        ).set_results_name("ospf_extensions")
+        + Optional(MatchFirst([Literal("EX")])).set_results_name("eigrp_extensions")
+        + Optional(MatchFirst([prefix, ip])).set_results_name("network")
         + MatchFirst(
             [
                 _directly_connected_line(),
@@ -150,7 +152,7 @@ def _v4_route() -> ParserElement:
 
 def _prefix_is_subnetted_line() -> ParserElement:
     return (
-        prefix.setResultsName("subnet_prefix")
+        prefix.set_results_name("subnet_prefix")
         + "is"
         + Optional("variably")
         + "subnetted,"

--- a/src/lab_validation/parsers/iosxr/commands/interfaces.py
+++ b/src/lab_validation/parsers/iosxr/commands/interfaces.py
@@ -24,13 +24,13 @@ _state = MatchFirst([Literal("up"), Literal("down")])
 
 def _get_iface_line() -> ParserElement:
     return (
-        Word(printables).setResultsName("name")
+        Word(printables).set_results_name("name")
         + "is"
         + ParsingOptional("administratively")
-        + _state.setResultsName("admin_state")
+        + _state.set_results_name("admin_state")
         + ", line protocol is"
         + ParsingOptional("administratively")
-        + _state.setResultsName("line_protocol")
+        + _state.set_results_name("line_protocol")
         + to_eol
     )
 
@@ -38,17 +38,17 @@ def _get_iface_line() -> ParserElement:
 def _get_mtu_bw_line() -> ParserElement:
     return (
         "MTU"
-        + dec.setResultsName("mtu")
+        + dec.set_results_name("mtu")
         + "bytes,"
         + "BW"
-        + dec.setResultsName("bw")
+        + dec.set_results_name("bw")
         + "Kbit"
         + to_eol
     )
 
 
 def _get_addr_line() -> ParserElement:
-    return "Internet address is" + prefix.setResultsName("prefix")
+    return "Internet address is" + prefix.set_results_name("prefix")
 
 
 def _interface_block() -> ParserElement:
@@ -82,7 +82,7 @@ def _dampening() -> ParserElement:
 
 
 def parse_show_interfaces(text: str) -> list[IosXrInterface]:
-    all_parse_results = OneOrMore(Group(_interface_block())).scanString(text)
+    all_parse_results = OneOrMore(Group(_interface_block())).scan_string(text)
     results: list[IosXrInterface] = []
 
     logger = logging.getLogger(__name__)

--- a/src/lab_validation/parsers/iosxr/commands/route.py
+++ b/src/lab_validation/parsers/iosxr/commands/route.py
@@ -31,12 +31,12 @@ _IPv4_PREFIX_PATTERN = re.compile(r"\d+\.\d+\.\d+\.\d+/\d+")
 
 def parse_show_route(routes_output: str) -> Sequence[IosXrRoute]:
     """Parses show route output for IOS XR"""
-    return _parse_helper(routes_output, show_route().scanString(routes_output), True)
+    return _parse_helper(routes_output, show_route().scan_string(routes_output), True)
 
 
 def parse_show_route_vrf_all(routes_output: str) -> Sequence[IosXrRoute]:
     """Parses show route vrf all output for IOS XR"""
-    return _parse_helper(routes_output, show_route_vrf().scanString(routes_output))
+    return _parse_helper(routes_output, show_route_vrf().scan_string(routes_output))
 
 
 def _parse_helper(

--- a/src/lab_validation/parsers/iosxr/commands/show_bgp_all_all.py
+++ b/src/lab_validation/parsers/iosxr/commands/show_bgp_all_all.py
@@ -49,7 +49,7 @@ _STATUS_CODES = [
 def parse_show_bgp_all_all(bgp_output: str) -> Sequence[IosXrBgpAddressFamily]:
     """Parses IOS XR 'show bgp all all' output."""
     # TODO Handle show data for device with no active BGP
-    parsed_afs = OneOrMore(_bgp_address_family()).parseString(bgp_output)
+    parsed_afs = OneOrMore(_bgp_address_family()).parse_string(bgp_output)
     afs = []
     for record in parsed_afs:
         name = record["af"]
@@ -135,7 +135,7 @@ def _af_name() -> ParserElement:
 def _af_header() -> ParserElement:
     return (
         Literal("Address Family: ").suppress()
-        + _af_name().setResultsName("af")
+        + _af_name().set_results_name("af")
         + White("\n", exact=1).suppress()
         + OneOrMore(Literal("-")).suppress()
     )
@@ -153,9 +153,9 @@ def _af_table() -> ParserElement:
 def _af_table_header() -> ParserElement:
     return (
         Literal("BGP router identifier ").suppress()
-        + ip.setResultsName("router_id")
+        + ip.set_results_name("router_id")
         + Literal(", local AS number ").suppress()
-        + dec.setResultsName("local_as")
+        + dec.set_results_name("local_as")
     )
 
 
@@ -168,7 +168,7 @@ def _af_table_state_and_codes() -> ParserElement:
 def _af_table_routes() -> ParserElement:
     return _af_table_routes_header() + ZeroOrMore(
         MatchFirst([_af_table_routes_default_vrf(), _af_table_routes_vrf()])
-    ).setResultsName("vrfs")
+    ).set_results_name("vrfs")
 
 
 def _af_table_routes_header() -> ParserElement:
@@ -185,8 +185,8 @@ def _af_table_routes_header() -> ParserElement:
 
 def parse_route_data(route_data: str) -> dict[str, Any]:
     """Return the parsed route data. Includes next hop IP and (if present) metric, local pref, and weight."""
-    ip_parser = ip.setResultsName("next_hop") + to_eol
-    nhip = ip_parser.parseString(route_data)["next_hop"]
+    ip_parser = ip.set_results_name("next_hop") + to_eol
+    nhip = ip_parser.parse_string(route_data)["next_hop"]
     route_obj = {"next_hop": nhip}
     metric_str = route_data[len(nhip) + 1 : 26].strip()
     loc_prf_str = route_data[27:33].strip()
@@ -201,22 +201,22 @@ def parse_route_data(route_data: str) -> dict[str, Any]:
 
 
 def _af_table_routes_default_vrf() -> ParserElement:
-    return Group(OneOrMore(_af_table_routes_vrf_route()).setResultsName("routes"))
+    return Group(OneOrMore(_af_table_routes_vrf_route()).set_results_name("routes"))
 
 
 def _af_table_routes_vrf() -> ParserElement:
     return Group(
-        _af_table_routes_vrf_rd().setResultsName("vrf_info")
-        + ZeroOrMore(_af_table_routes_vrf_route()).setResultsName("routes")
+        _af_table_routes_vrf_rd().set_results_name("vrf_info")
+        + ZeroOrMore(_af_table_routes_vrf_route()).set_results_name("routes")
     )
 
 
 def _af_table_routes_vrf_rd() -> ParserElement:
     return Group(
         Literal("Route Distinguisher: ").suppress()
-        + route_distinguisher.setResultsName("rd")
+        + route_distinguisher.set_results_name("rd")
         + Literal("(default for vrf ").suppress()
-        + Word(alphanums + "-_").setResultsName("vrf_name")
+        + Word(alphanums + "-_").set_results_name("vrf_name")
         + Literal(")").suppress()
         + White("\n", exact=1).suppress()
     )
@@ -226,30 +226,30 @@ def _af_table_routes_vrf_route() -> ParserElement:
     """
     parse route entry in bgp rib
     """
-    route_status = MatchFirst([Literal(code) for code in _STATUS_CODES]).setResultsName(
-        "status"
-    )
+    route_status = MatchFirst(
+        [Literal(code) for code in _STATUS_CODES]
+    ).set_results_name("status")
     # Parse nhip, metric, locprf, weight as one big block to parse later.
     # Can't parse now because whitespace expectations aren't consistent:
     # if a route has no listed metric, there may be less whitespace between
     # nhip and locprf than another route has between nhip and metric,
     # depending on the length of the nhip.
-    route_data = printables_and_space(40).setResultsName("data")
-    as_path = ZeroOrMore(dec + White(" ")).setResultsName("as_path")
+    route_data = printables_and_space(40).set_results_name("data")
+    as_path = ZeroOrMore(dec + White(" ")).set_results_name("as_path")
     origin_type = Literal("e") ^ Literal("i") ^ Literal("?")
     record = Group(
         Optional(White(" ", max=1)).suppress()
         + Optional(route_status)
         + Optional(White(" ", max=1).suppress())
-        + Optional(prefix.setResultsName("network"))
+        + Optional(prefix.set_results_name("network"))
         + White(" ", min=1).suppress()
         + route_data
         + White(" ", min=1).suppress()
         + as_path
-        + origin_type.setResultsName("origin_type")
+        + origin_type.set_results_name("origin_type")
         + White("\n", exact=1).suppress()
     )
-    record.leaveWhitespace()
+    record.leave_whitespace()
     return record
 
 

--- a/src/lab_validation/parsers/iosxr/grammar/route.py
+++ b/src/lab_validation/parsers/iosxr/grammar/route.py
@@ -34,9 +34,9 @@ def routes_body() -> ParserElement:
     """Parses a non-empty routes table."""
     return (
         Literal("Codes:")
-        + SkipTo(single_route()).setResultsName("preamble")
-        + OneOrMore(single_route()).setResultsName("v4_routes")
-        + SkipTo(MatchFirst([vrf_line(), stringEnd])).setResultsName("padding")
+        + SkipTo(single_route()).set_results_name("preamble")
+        + OneOrMore(single_route()).set_results_name("v4_routes")
+        + SkipTo(MatchFirst([vrf_line(), stringEnd])).set_results_name("padding")
     )
 
 
@@ -46,7 +46,7 @@ def routes_body_empty() -> ParserElement:
 
 
 def vrf_line() -> ParserElement:
-    return "VRF: " + Word(printables).setResultsName("vrf") + to_eol
+    return "VRF: " + Word(printables).set_results_name("vrf") + to_eol
 
 
 def single_route() -> ParserElement:
@@ -54,71 +54,73 @@ def single_route() -> ParserElement:
     return Group(
         MatchFirst(
             [
-                _v4_ecmp_routes().setResultsName("v4_ecmp_routes"),
-                _v4_route().setResultsName("v4_route"),
+                _v4_ecmp_routes().set_results_name("v4_ecmp_routes"),
+                _v4_route().set_results_name("v4_route"),
             ]
         )
     )
 
 
 def _v4_ecmp_routes() -> ParserElement:
-    return _v4_route().setResultsName("v4_route") + OneOrMore(
+    return _v4_route().set_results_name("v4_route") + OneOrMore(
         Group(_route_suffix())
-    ).setResultsName("v4_ecmp_routes_block")
+    ).set_results_name("v4_ecmp_routes_block")
 
 
 def _directly_connected_line() -> ParserElement:
     return (
         "is directly connected,"
         + Optional(_time + ",")
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
         + Optional(_nh_in_vrf())
     )
 
 
 def _is_a_summary_line() -> ParserElement:
     return (
-        Literal("is a summary,").setResultsName("summary")
+        Literal("is a summary,").set_results_name("summary")
         + Optional(_time + ",")
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
     )
 
 
 def _prefix_via_nhip_line() -> ParserElement:
     return (
         "["
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "/"
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + "]"
         + "via"
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + Optional(_nh_in_vrf())
         + Optional(
-            "(" + Word(printables, excludeChars="!)").setResultsName("source_vrf") + ")"
+            "("
+            + Word(printables, excludeChars="!)").set_results_name("source_vrf")
+            + ")"
         )
         + Optional("," + _time)
-        + Optional(", " + Word(printables).setResultsName("nh_iface"))
-        + Optional(Literal("(!)").setResultsName("backup"))  # FRR backup indicator
+        + Optional(", " + Word(printables).set_results_name("nh_iface"))
+        + Optional(Literal("(!)").set_results_name("backup"))  # FRR backup indicator
     )
 
 
 def _prefix_null_route_line() -> ParserElement:
     return (
         "["
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "/"
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + "]"
         + Optional("," + _time)
-        + Optional(", " + (Regex(r"Null\d+")).setResultsName("nh_iface"))
+        + Optional(", " + (Regex(r"Null\d+")).set_results_name("nh_iface"))
     )
 
 
 def _nh_in_vrf() -> ParserElement:
     return (
         "(nexthop in vrf"
-        + Word(printables, excludeChars=")").setResultsName("nh_vrf")
+        + Word(printables, excludeChars=")").set_results_name("nh_vrf")
         + ")"
     )
 
@@ -136,8 +138,8 @@ def _v4_route() -> ParserElement:
                     Literal("D"),
                 ]
             )
-        ).setResultsName("protocol")
-        + Optional(Literal("*").setResultsName("candidate_default"))
+        ).set_results_name("protocol")
+        + Optional(Literal("*").set_results_name("candidate_default"))
         + Optional(
             MatchFirst(
                 [
@@ -148,9 +150,9 @@ def _v4_route() -> ParserElement:
                     Literal("N2"),
                 ]
             )
-        ).setResultsName("ospf_extensions")
-        + Optional(MatchFirst([Literal("EX")])).setResultsName("eigrp_extensions")
-        + Optional(prefix).setResultsName("network")
+        ).set_results_name("ospf_extensions")
+        + Optional(MatchFirst([Literal("EX")])).set_results_name("eigrp_extensions")
+        + Optional(prefix).set_results_name("network")
         + _route_suffix()
     )
 

--- a/src/lab_validation/parsers/junos/grammar/bgp_route.py
+++ b/src/lab_validation/parsers/junos/grammar/bgp_route.py
@@ -32,12 +32,12 @@ def show_bgp_route() -> ParserElement:
     for the semantics of the output of the command
     """
     return OneOrMore(
-        Group(rib_meta_info() + _route_block().setResultsName("route_tables"))
+        Group(rib_meta_info() + _route_block().set_results_name("route_tables"))
     )
 
 
 def _route_block() -> ParserElement:
-    return _table_schema() + OneOrMore(Group(_bgp_route())).setResultsName("routes")
+    return _table_schema() + OneOrMore(Group(_bgp_route())).set_results_name("routes")
 
 
 def _table_schema() -> ParserElement:
@@ -60,25 +60,27 @@ def _bgp_route() -> ParserElement:
 
 def _bgp_route_line1() -> ParserElement:
     return (
-        Optional(MatchFirst([Literal("+"), Literal("-"), Literal("*")])).setResultsName(
-            "status"
-        )
+        Optional(
+            MatchFirst([Literal("+"), Literal("-"), Literal("*")])
+        ).set_results_name("status")
         + MatchFirst([Literal("V"), Literal("?")])
-        + prefix.setResultsName("network")
-        + MatchFirst([Literal(k) for k in protocol_abbr.keys()]).setResultsName(
+        + prefix.set_results_name("network")
+        + MatchFirst([Literal(k) for k in protocol_abbr.keys()]).set_results_name(
             "learn_from"
         )
-        + dec.setResultsName("pref")
-        + dec.setResultsName("metric_1")
-        + Optional(dec).setResultsName("metric_2")
-        + as_path.setResultsName("as_path")
-        + origin_type.setResultsName("origin_type")
+        + dec.set_results_name("pref")
+        + dec.set_results_name("metric_1")
+        + Optional(dec).set_results_name("metric_2")
+        + as_path.set_results_name("as_path")
+        + origin_type.set_results_name("origin_type")
     )
 
 
 def _bgp_route_line2() -> ParserElement:
     return (
-        MatchFirst([Literal("valid"), Literal("unverified")]).setResultsName("is_valid")
-        + Optional(">").setResultsName("is_selected")
-        + ip.setResultsName("next_hop")
+        MatchFirst([Literal("valid"), Literal("unverified")]).set_results_name(
+            "is_valid"
+        )
+        + Optional(">").set_results_name("is_selected")
+        + ip.set_results_name("next_hop")
     )

--- a/src/lab_validation/parsers/junos/grammar/interface.py
+++ b/src/lab_validation/parsers/junos/grammar/interface.py
@@ -13,7 +13,7 @@ from pyparsing import (
 
 from ...common.tokens import to_eol
 
-_state = MatchFirst([Literal("up"), Literal("down")]).setName("state")
+_state = MatchFirst([Literal("up"), Literal("down")]).set_name("state")
 _ip_or_ethernet_mtu = MatchFirst([Literal("IP MTU"), Literal("Ethernet MTU")])
 
 _physical_block_header = "Physical interface"
@@ -48,16 +48,16 @@ def _physical_record() -> ParserElement:
 
 def _physical_name_line() -> ParserElement:
     return (
-        Literal(_physical_block_header).setResultsName("type")
+        Literal(_physical_block_header).set_results_name("type")
         + ":"
-        + Word(_noncomma_printables).setResultsName("name")
+        + Word(_noncomma_printables).set_results_name("name")
         + ","
-        + MatchFirst([Literal("Enabled"), Literal("Disabled")]).setResultsName(
+        + MatchFirst([Literal("Enabled"), Literal("Disabled")]).set_results_name(
             "admin_state"
         )
         + ","
         + "Physical link is"
-        + MatchFirst([Literal("Up"), Literal("Down")]).setResultsName("line_state")
+        + MatchFirst([Literal("Up"), Literal("Down")]).set_results_name("line_state")
     )
 
 
@@ -66,9 +66,11 @@ def _physical_type_line() -> ParserElement:
         "Type:"
         + SkipTo("MTU")
         + "MTU:"
-        + Word(_noncomma_printables).setResultsName("mtu")
+        + Word(_noncomma_printables).set_results_name("mtu")
         + Optional(
-            Literal(",") + Literal("Speed:") + Word(printables).setResultsName("speed")
+            Literal(",")
+            + Literal("Speed:")
+            + Word(printables).set_results_name("speed")
         )
     )
 
@@ -77,19 +79,19 @@ def _logical_record() -> ParserElement:
     return (
         _logical_name_line()
         + "Flags:"
-        + Word(printables).setResultsName("admin_state")
+        + Word(printables).set_results_name("admin_state")
         + to_eol
-        + Optional("Bandwidth:" + Word(printables).setResultsName("bw"))
+        + Optional("Bandwidth:" + Word(printables).set_results_name("bw"))
         + SkipTo("MTU:")
         + "MTU:"
-        + Word(printables).setResultsName("mtu")
+        + Word(printables).set_results_name("mtu")
         + SkipTo(_interface_block_header | stringEnd)
     )
 
 
 def _logical_name_line() -> ParserElement:
     return (
-        Literal(_logical_block_header).setResultsName("type")
-        + Word(_noncomma_printables).setResultsName("name")
+        Literal(_logical_block_header).set_results_name("type")
+        + Word(_noncomma_printables).set_results_name("name")
         + to_eol
     )

--- a/src/lab_validation/parsers/junos/grammar/route.py
+++ b/src/lab_validation/parsers/junos/grammar/route.py
@@ -21,13 +21,16 @@ def show_route() -> ParserElement:
     """Grammar for parsing output of 'show route tblae'"""
     return OneOrMore(
         Group(
-            rib_meta_info() + OneOrMore(Group(_route_block())).setResultsName("routes")
+            rib_meta_info()
+            + OneOrMore(Group(_route_block())).set_results_name("routes")
         )
     )
 
 
 def _route_block() -> ParserElement:
-    return prefix.setResultsName("network") + _route_info_block().setResultsName("info")
+    return prefix.set_results_name("network") + _route_info_block().set_results_name(
+        "info"
+    )
 
 
 def _route_info_block() -> ParserElement:
@@ -35,7 +38,7 @@ def _route_info_block() -> ParserElement:
 
 
 def _status_route_info_block() -> ParserElement:
-    return Optional(Literal("+") | Literal("-") | Literal("*")).setResultsName(
+    return Optional(Literal("+") | Literal("-") | Literal("*")).set_results_name(
         "status"
     ) + (
         _direct_route_info_block()
@@ -51,15 +54,15 @@ def _status_route_info_block() -> ParserElement:
 def _local_route_info_block() -> ParserElement:
     return (
         "["
-        + Literal("Local").setResultsName("protocol")
+        + Literal("Local").set_results_name("protocol")
         + "/"
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "]"
         + uptime
         + newline
         + "Local"
         + "via"
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
         + newline
     )
 
@@ -67,15 +70,15 @@ def _local_route_info_block() -> ParserElement:
 def _direct_route_info_block() -> ParserElement:
     return (
         "["
-        + Literal("Direct").setResultsName("protocol")
+        + Literal("Direct").set_results_name("protocol")
         + "/"
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "]"
         + uptime
         + newline
         + ">"
         + "via"
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
         + newline
     )
 
@@ -83,9 +86,9 @@ def _direct_route_info_block() -> ParserElement:
 def _static_discard_route_info_block() -> ParserElement:
     return (
         "["
-        + Literal("Static").setResultsName("protocol")
+        + Literal("Static").set_results_name("protocol")
         + "/"
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "]"
         + uptime
         + newline
@@ -97,17 +100,17 @@ def _static_discard_route_info_block() -> ParserElement:
 def _static_route_info_block() -> ParserElement:
     return (
         "["
-        + Literal("Static").setResultsName("protocol")
+        + Literal("Static").set_results_name("protocol")
         + "/"
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "]"
         + uptime
         + newline
         + ">"
         + "to"
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + "via"
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
         + newline
     )
 
@@ -115,20 +118,20 @@ def _static_route_info_block() -> ParserElement:
 def _isis_route_info_block() -> ParserElement:
     return (
         "["
-        + Literal("IS-IS").setResultsName("protocol")
+        + Literal("IS-IS").set_results_name("protocol")
         + "/"
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "]"
         + uptime
         + ","
         + "metric"
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + newline
         + ">"
         + "to"
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + "via"
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
         + newline
     )
 
@@ -136,27 +139,27 @@ def _isis_route_info_block() -> ParserElement:
 def _bgp_route_info_block() -> ParserElement:
     return (
         "["
-        + Literal("BGP").setResultsName("protocol")
+        + Literal("BGP").set_results_name("protocol")
         + "/"
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "]"
         + uptime
         + ","
-        + Optional("MED" + dec.setResultsName("metric") + ",")
+        + Optional("MED" + dec.set_results_name("metric") + ",")
         + "localpref"
-        + dec.setResultsName("localpref")
+        + dec.set_results_name("localpref")
         + newline
         + "AS path:"
-        + as_path.setResultsName("as_path")
-        + origin_type.setResultsName("origin_type")
+        + as_path.set_results_name("as_path")
+        + origin_type.set_results_name("origin_type")
         + ","
         + "validation-state:"
         + (Literal("unverified") | Literal("valid"))
         + newline
         + "> to"
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + "via"
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
         + newline
     )
 
@@ -164,19 +167,19 @@ def _bgp_route_info_block() -> ParserElement:
 def _ospf_route_info_block() -> ParserElement:
     return (
         "["
-        + Literal("OSPF").setResultsName("protocol")
+        + Literal("OSPF").set_results_name("protocol")
         + "/"
-        + dec.setResultsName("admin")
+        + dec.set_results_name("admin")
         + "]"
         + uptime
         + ","
         + "metric"
-        + dec.setResultsName("metric")
+        + dec.set_results_name("metric")
         + newline
         + ">"
         + "to"
-        + ip.setResultsName("nh_ip")
+        + ip.set_results_name("nh_ip")
         + "via"
-        + Word(printables).setResultsName("nh_iface")
+        + Word(printables).set_results_name("nh_iface")
         + newline
     )

--- a/src/lab_validation/parsers/junos/grammar/utils.py
+++ b/src/lab_validation/parsers/junos/grammar/utils.py
@@ -15,15 +15,15 @@ from ...common.tokens import dec
 non_colon_printables = "".join(filter(lambda c: c != ":", printables))
 
 origin_type = MatchFirst([Literal("I"), Literal("E"), Literal("?")], savelist=False)
-as_set = dec.setResultsName("as_numbers") | (
-    Literal("(") + OneOrMore(dec).setResultsName("as_numbers") + Literal(")")
+as_set = dec.set_results_name("as_numbers") | (
+    Literal("(") + OneOrMore(dec).set_results_name("as_numbers") + Literal(")")
 )
 as_path = ZeroOrMore(Group(as_set))
 
 
 def rib_meta_info() -> ParserElement:
     return (
-        Word(non_colon_printables).setResultsName("vrf_ip_info")
+        Word(non_colon_printables).set_results_name("vrf_ip_info")
         + ":"
         + Regex(
             r"\d+ destinations, \d+ routes \(\d+ active, \d+ holddown, \d+ hidden\)"

--- a/src/lab_validation/parsers/nxos/commands/bgp_route.py
+++ b/src/lab_validation/parsers/nxos/commands/bgp_route.py
@@ -27,7 +27,7 @@ _IPv4_PATTERN = re.compile(r"\d+\.\d+\.\d+\.\d+")
 
 
 def parse_show_ip_bgp_all(text: str) -> Sequence[NxosBgpRoute]:
-    all_parse_results = OneOrMore(_vrf_af_routes()).parseString(text)
+    all_parse_results = OneOrMore(_vrf_af_routes()).parse_string(text)
     routes: list[NxosBgpRoute] = []
     network = ""
     for table in all_parse_results:
@@ -75,9 +75,9 @@ def _vrf_af_header() -> ParserElement:
     """The header for a BGP table for one VRF, one AF."""
     return (
         Literal("BGP routing table information for VRF ").suppress()
-        + Word(alphanums + "-_").setResultsName("vrf")
+        + Word(alphanums + "-_").set_results_name("vrf")
         + Literal(", address family ").suppress()
-        + _af_name().setResultsName("af")
+        + _af_name().set_results_name("af")
     )
 
 
@@ -98,39 +98,39 @@ def _vrf_af_routes() -> ParserElement:
         _vrf_af_header()
         + SkipTo(_af_table_routes_header())
         + _af_table_routes_header().suppress()
-        + OneOrMore(_get_record()).setResultsName("routes")
+        + OneOrMore(_get_record()).set_results_name("routes")
         # Next VRF or EOF. Save the skipped text as padding.
-        + SkipTo(MatchFirst([_vrf_af_header(), stringEnd])).setResultsName("padding")
+        + SkipTo(MatchFirst([_vrf_af_header(), stringEnd])).set_results_name("padding")
     )
 
 
 def _get_record() -> ParserElement:
     route_status = Combine(
         oneOf(["*", "s", " "]) + oneOf([">", "|", " "])
-    ).setResultsName("status")
+    ).set_results_name("status")
     path_type = MatchFirst(
         [Literal("e"), Literal("l"), Literal("i"), Literal("a"), Literal("r")]
     )
     origin_type = Regex(r"(e|i|\?)")
-    as_path = ZeroOrMore(dec + White(" ")).setResultsName("as_path")
+    as_path = ZeroOrMore(dec + White(" ")).set_results_name("as_path")
     record = Group(
         route_status
         + Optional(White(" ", max=1))
-        + path_type.setResultsName("path_type")
-        + Optional(prefix.setResultsName("network"))
+        + path_type.set_results_name("path_type")
+        + Optional(prefix.set_results_name("network"))
         + White(" ", min=1)
-        + ip.setResultsName("next_hop")
+        + ip.set_results_name("next_hop")
         + White(" ", min=1, max=18)
-        + Optional(dec).setResultsName("metric")
+        + Optional(dec).set_results_name("metric")
         + White(" ", min=1, max=9)
-        + Optional(dec).setResultsName("local_preference")
+        + Optional(dec).set_results_name("local_preference")
         + White(" ", min=1)
-        + dec.setResultsName("weight")
+        + dec.set_results_name("weight")
         + White(" ", min=1)
         + as_path
-        + origin_type.setResultsName("origin_type")
+        + origin_type.set_results_name("origin_type")
         + Optional(newline)
-    ).leaveWhitespace()
+    ).leave_whitespace()
     return record
 
 

--- a/src/lab_validation/parsers/nxos/commands/interfaces.py
+++ b/src/lab_validation/parsers/nxos/commands/interfaces.py
@@ -11,7 +11,7 @@ from lab_validation.parsers.nxos.models.interfaces import NxosInterface
 
 def parse_show_interface(text: str) -> Sequence[NxosInterface]:
     logger = logging.getLogger(__name__)
-    all_parse_results = OneOrMore(Group(interface_block())).scanString(text)
+    all_parse_results = OneOrMore(Group(interface_block())).scan_string(text)
     results: list[NxosInterface] = []
 
     last_loc = 0

--- a/src/lab_validation/parsers/nxos/commands/routes.py
+++ b/src/lab_validation/parsers/nxos/commands/routes.py
@@ -15,7 +15,7 @@ _IPv4_PATTERN = re.compile(r"\d+\.\d+\.\d+\.\d+")
 
 def parse_show_ip_route_vrf_all(text: str) -> Sequence[NxosMainRibRoute]:
     logger = logging.getLogger(__name__)
-    all_parse_results = Group(show_route()).scanString(text)
+    all_parse_results = Group(show_route()).scan_string(text)
     routes: list[NxosMainRibRoute] = []
     last_loc = 0
     for records, start_loc, end_loc in all_parse_results:

--- a/src/lab_validation/parsers/nxos/grammar/interface.py
+++ b/src/lab_validation/parsers/nxos/grammar/interface.py
@@ -42,42 +42,42 @@ def _get_iface_line() -> ParserElement:
         Combine(
             oneOf(["Ethernet", "loopback", "mgmt", "port-channel", "vasi", "Vlan"])
             + Word(printables)
-        ).setResultsName("name")
+        ).set_results_name("name")
         + "is"
         + Optional(
-            _state.setResultsName("admin_state")
+            _state.set_results_name("admin_state")
             + Optional(
                 MatchFirst(
                     [Literal(reason) for reason in port_status_reason]
-                ).setResultsName("port_status_reason")
+                ).set_results_name("port_status_reason")
             )
             + ", line protocol is"
         )
-        + _state.setResultsName("line_state")
+        + _state.set_results_name("line_state")
         + Optional(
             MatchFirst(
                 [Literal(reason) for reason in port_status_reason]
-            ).setResultsName("port_status_reason")
+            ).set_results_name("port_status_reason")
         )
         + to_eol
     )
 
 
 def _get_admin_line() -> ParserElement:
-    return "admin state is" + _state.setResultsName("admin_state") + to_eol
+    return "admin state is" + _state.set_results_name("admin_state") + to_eol
 
 
 def _get_mtu_bw_line() -> ParserElement:
     return (
         "MTU"
-        + dec.setResultsName("mtu")
+        + dec.set_results_name("mtu")
         + "bytes,"
         + "BW"
-        + dec.setResultsName("bw")
+        + dec.set_results_name("bw")
         + "Kbit,"
         + to_eol
     )
 
 
 def _get_port_mode_line() -> ParserElement:
-    return "Port mode is" + Word(printables).setResultsName("mode") + to_eol
+    return "Port mode is" + Word(printables).set_results_name("mode") + to_eol

--- a/src/lab_validation/parsers/nxos/grammar/route.py
+++ b/src/lab_validation/parsers/nxos/grammar/route.py
@@ -17,7 +17,9 @@ from pyparsing import (
 
 from lab_validation.parsers.common.tokens import dec, ip, prefix, to_eol
 
-_vrf_line = "IP Route Table for VRF" + QuotedString('"').setResultsName("vrf") + to_eol
+_vrf_line = (
+    "IP Route Table for VRF" + QuotedString('"').set_results_name("vrf") + to_eol
+)
 _vrf_header = (
     Literal("'*' denotes best ucast next-hop")
     + Literal("'**' denotes best mcast next-hop")
@@ -26,9 +28,9 @@ _vrf_header = (
 )
 _via = MatchFirst(
     [
-        Literal("*via").setResultsName("best_ucast"),
-        Literal("**via").setResultsName("best_mcast"),
-        Literal("via").setResultsName("not_best"),
+        Literal("*via").set_results_name("best_ucast"),
+        Literal("**via").set_results_name("best_mcast"),
+        Literal("via").set_results_name("not_best"),
     ]
 )
 _uptime_hours = Regex(r"\d+:\d+:\d+")
@@ -41,47 +43,51 @@ _uptime = MatchFirst(
 )
 _admin_and_metric = (
     Literal("[")
-    + dec.setResultsName("admin")
+    + dec.set_results_name("admin")
     + "/"
-    + dec.setResultsName("metric")
+    + dec.set_results_name("metric")
     + "]"
 )
-_bgp = Regex(r"bgp-\d+").setResultsName("process") + Optional(
+_bgp = Regex(r"bgp-\d+").set_results_name("process") + Optional(
     ","
-    + MatchFirst([Literal("internal"), Literal("external")]).setResultsName("extension")
+    + MatchFirst([Literal("internal"), Literal("external")]).set_results_name(
+        "extension"
+    )
 )
 _eigrp = (
-    Regex(r"eigrp-\d+").setResultsName("process")
+    Regex(r"eigrp-\d+").set_results_name("process")
     + ","
-    + MatchFirst([Literal("internal"), Literal("external")]).setResultsName("extension")
+    + MatchFirst([Literal("internal"), Literal("external")]).set_results_name(
+        "extension"
+    )
 )
 _ospf = (
-    Regex(r"ospf-\d+").setResultsName("process")
+    Regex(r"ospf-\d+").set_results_name("process")
     + ","
     + MatchFirst(
         [Literal("inter"), Literal("intra"), Literal("type-1"), Literal("type-2")]
-    ).setResultsName("extension")
+    ).set_results_name("extension")
 )
 _protocol = MatchFirst(
     [
-        _bgp.setResultsName("bgp"),
-        _eigrp.setResultsName("eigrp"),
-        Literal("am").setResultsName("am"),  # adjacency manager
-        Literal("direct").setResultsName("direct"),
-        Literal("hmm").setResultsName("hmm"),
-        Literal("hsrp").setResultsName("hsrp"),
-        Literal("local").setResultsName("local"),
-        _ospf.setResultsName("ospf"),
-        Literal("static").setResultsName("static"),
+        _bgp.set_results_name("bgp"),
+        _eigrp.set_results_name("eigrp"),
+        Literal("am").set_results_name("am"),  # adjacency manager
+        Literal("direct").set_results_name("direct"),
+        Literal("hmm").set_results_name("hmm"),
+        Literal("hsrp").set_results_name("hsrp"),
+        Literal("local").set_results_name("local"),
+        _ospf.set_results_name("ospf"),
+        Literal("static").set_results_name("static"),
     ]
 )
 
 _evpn = "(evpn)"
 _vxlan = (
     Literal("segid:")
-    + dec.setResultsName("segid")
+    + dec.set_results_name("segid")
     + Literal("tunnelid: 0x")
-    + Word(hexnums).setResultsName("tunnelid")
+    + Word(hexnums).set_results_name("tunnelid")
     + Literal("encap: VXLAN")
 )
 
@@ -94,57 +100,57 @@ def show_route() -> ParserElement:
         # The lines about flags ('*', '**', '[x/y]', '%', etc).
         + _vrf_header
         # Routes table may be empty.
-        + ZeroOrMore(Group(_v4_route_for_a_prefix())).setResultsName("v4_routes")
+        + ZeroOrMore(Group(_v4_route_for_a_prefix())).set_results_name("v4_routes")
         # Next VRF or EOF. Save the skipped text as padding.
-        + SkipTo(MatchFirst([_vrf_line, stringEnd])).setResultsName("padding")
+        + SkipTo(MatchFirst([_vrf_line, stringEnd])).set_results_name("padding")
     )
 
 
 def _v4_route_for_a_prefix() -> ParserElement:
     return _prefix_line() + OneOrMore(
         Group(MatchFirst([_next_hop_line(), _null_routed_line()]))
-    ).setResultsName("next_hops")
+    ).set_results_name("next_hops")
 
 
 def _prefix_line() -> ParserElement:
-    return prefix.setResultsName("network") + "," + to_eol
+    return prefix.set_results_name("network") + "," + to_eol
 
 
 def _next_hop_line() -> ParserElement:
     return (
         _via
-        + ip.setResultsName("nhip")
-        + Optional("%" + Word(alphanums + "/" + ".").setResultsName("nhvrf"))
+        + ip.set_results_name("nhip")
+        + Optional("%" + Word(alphanums + "/" + ".").set_results_name("nhvrf"))
         + ","
-        + Optional(Word(alphanums + "/" + ".").setResultsName("nhint") + ",")
+        + Optional(Word(alphanums + "/" + ".").set_results_name("nhint") + ",")
         + _admin_and_metric
         + ","
         + _uptime
         + ","
-        + _protocol.setResultsName("protocol")
-        + Optional(", tag" + dec.setResultsName("tag"))
+        + _protocol.set_results_name("protocol")
+        + Optional(", tag" + dec.set_results_name("tag"))
         # Sometimes, there is a stray comma after the tag
         + Optional(",")
-        + Optional(_evpn).setResultsName("evpn")
-        + Optional(_vxlan).setResultsName("vxlan")
+        + Optional(_evpn).set_results_name("evpn")
+        + Optional(_vxlan).set_results_name("vxlan")
     )
 
 
 def _null_routed_line() -> ParserElement:
     return (
         _via
-        + Literal("Null0").setResultsName("nhint")
+        + Literal("Null0").set_results_name("nhint")
         + ","
         + _admin_and_metric
         + ","
         + _uptime
         + ","
-        + _protocol.setResultsName("protocol")
+        + _protocol.set_results_name("protocol")
         + ","
         + "discard"
-        + Optional(", tag" + dec.setResultsName("tag"))
+        + Optional(", tag" + dec.set_results_name("tag"))
         # Sometimes, there is a stray comma after the tag
         + Optional(",")
-        + Optional(_evpn).setResultsName("evpn")
-        + Optional(_vxlan).setResultsName("vxlan")
+        + Optional(_evpn).set_results_name("evpn")
+        + Optional(_vxlan).set_results_name("vxlan")
     )

--- a/src/lab_validation/parsers/panos/commands/routes.py
+++ b/src/lab_validation/parsers/panos/commands/routes.py
@@ -18,7 +18,7 @@ def parse_show_routing_route(text: str) -> Sequence[PanosMainRibRoute]:
     A given file may contain more than one routing table.
     """
     logger = logging.getLogger(__name__)
-    all_parse_results = show_route().scanString(text)
+    all_parse_results = show_route().scan_string(text)
     routes: list[PanosMainRibRoute] = []
     last_loc = 0
     for vr_record, start_loc, end_loc in all_parse_results:

--- a/src/lab_validation/parsers/panos/grammar/route.py
+++ b/src/lab_validation/parsers/panos/grammar/route.py
@@ -17,7 +17,7 @@ from ...common.tokens import dec, ip, prefix, to_eol
 
 _vr_line_1 = (
     "VIRTUAL ROUTER: "
-    + SkipTo(" (id").setResultsName("vr")
+    + SkipTo(" (id").set_results_name("vr")
     + "(id "
     + dec
     + ")"
@@ -60,22 +60,22 @@ _flags = ZeroOrMore(
 
 # Inside of the route line, limit whitespace chars so it can't eat part of the next line
 _route_line = Group(
-    prefix.setResultsName("destination")
-    + ip.setResultsName("nexthop")
-    + Optional(dec).setWhitespaceChars(" ").setResultsName("metric")
-    + _flags.setWhitespaceChars(" ").setResultsName("flags")
-    + Optional(dec).setWhitespaceChars(" ").setResultsName("age")
+    prefix.set_results_name("destination")
+    + ip.set_results_name("nexthop")
+    + Optional(dec).setWhitespaceChars(" ").set_results_name("metric")
+    + _flags.setWhitespaceChars(" ").set_results_name("flags")
+    + Optional(dec).setWhitespaceChars(" ").set_results_name("age")
     + Optional(Word(alphas, printables))
     .setWhitespaceChars(" ")
-    .setResultsName("interface")
-    + Optional(dec).setWhitespaceChars(" ").setResultsName("next-AS")
-    + to_eol.setResultsName("route_line_tail")
+    .set_results_name("interface")
+    + Optional(dec).setWhitespaceChars(" ").set_results_name("next-AS")
+    + to_eol.set_results_name("route_line_tail")
 )
 
 
 def show_route() -> ParserElement:
     return (
         _vr
-        + ZeroOrMore(_route_line).setResultsName("routes")
-        + SkipTo(MatchFirst([_vr, stringEnd])).setResultsName("padding")
+        + ZeroOrMore(_route_line).set_results_name("routes")
+        + SkipTo(MatchFirst([_vr, stringEnd])).set_results_name("padding")
     )

--- a/tests/lab_validation/parsers/arista/grammar/test_route.py
+++ b/tests/lab_validation/parsers/arista/grammar/test_route.py
@@ -8,7 +8,7 @@ from lab_validation.parsers.arista.grammar.route import (
 
 
 def test_show_ip_route_vrf_all() -> None:
-    parsed_data = show_ip_route_vrf_all().parseString(
+    parsed_data = show_ip_route_vrf_all().parse_string(
         """
     VRF: default
 Codes: C - connected, S - static, K - kernel,
@@ -70,7 +70,7 @@ Gateway of last resort is not set
 
 
 def test_routes_block_within_subnet() -> None:
-    parsed_data = _routes_block_within_subnet().parseString(
+    parsed_data = _routes_block_within_subnet().parse_string(
         """
         C      10.10.30.0/24 is directly connected, Ethernet1
         B E    10.10.10.0/24 [200/0] via 10.10.30.1, Ethernet1
@@ -92,7 +92,7 @@ def test_routes_block_within_subnet() -> None:
 
 
 def test_ip_v4_route_line_direct() -> None:
-    parsed_data = _ip_v4_route_line().parseString(
+    parsed_data = _ip_v4_route_line().parse_string(
         "C      10.10.30.0/24 is directly connected, Ethernet1"
     )
     assert parsed_data.protocol == "C"
@@ -101,7 +101,7 @@ def test_ip_v4_route_line_direct() -> None:
 
 
 def test_ip_v4_route_line_not_direct() -> None:
-    parsed_data = _ip_v4_route_line().parseString(
+    parsed_data = _ip_v4_route_line().parse_string(
         "B E    10.10.10.0/24 [200/0] via 10.10.30.1, Ethernet1"
     )
     assert parsed_data.protocol == "B E"
@@ -113,14 +113,14 @@ def test_ip_v4_route_line_not_direct() -> None:
 
 
 def test_directly_connected_line() -> None:
-    parsed_data = _directly_connected_line().parseString(
+    parsed_data = _directly_connected_line().parse_string(
         "is directly connected, Ethernet1"
     )
     assert parsed_data.nh_iface == "Ethernet1"
 
 
 def test_prefix_via_nhip_line() -> None:
-    parsed_data = _prefix_via_nhip_line().parseString(
+    parsed_data = _prefix_via_nhip_line().parse_string(
         "[20/21] via 10.10.10.1, Ethernet1"
     )
     assert parsed_data.admin == 20

--- a/tests/lab_validation/parsers/common/test_tokens.py
+++ b/tests/lab_validation/parsers/common/test_tokens.py
@@ -5,39 +5,39 @@ from lab_validation.parsers.common.tokens import dec, ip, prefix
 
 
 def test_ip_parsing() -> None:
-    assert ip.parseString("1.1.1.1").asList() == ["1.1.1.1"]
-    assert ip.parseString("0.0.0.0").asList() == ["0.0.0.0"]
-    assert ip.parseString("255.255.255.255").asList() == ["255.255.255.255"]
-    assert ip.parseString("255.255.255.256").asList() == ["255.255.255.25"]
-    assert ip.parseString("1.2.3.4.5").asList() == ["1.2.3.4"]
+    assert ip.parse_string("1.1.1.1").asList() == ["1.1.1.1"]
+    assert ip.parse_string("0.0.0.0").asList() == ["0.0.0.0"]
+    assert ip.parse_string("255.255.255.255").asList() == ["255.255.255.255"]
+    assert ip.parse_string("255.255.255.256").asList() == ["255.255.255.25"]
+    assert ip.parse_string("1.2.3.4.5").asList() == ["1.2.3.4"]
     with pytest.raises(ParseException):
-        ip.parseString("355.255.255.255").asList()
+        ip.parse_string("355.255.255.255").asList()
     with pytest.raises(ParseException):
-        ip.parseString("1.2.3.4.5", parseAll=True).asList()
+        ip.parse_string("1.2.3.4.5", parseAll=True).asList()
     with pytest.raises(ParseException):
-        ip.parseString("1.1.1. 1").asList()
+        ip.parse_string("1.1.1. 1").asList()
     with pytest.raises(ParseException):
-        ip.parseString("1.1.1.").asList()
+        ip.parse_string("1.1.1.").asList()
 
 
 def test_prefix_parsing() -> None:
-    assert prefix.parseString("1.1.1.1/32", parseAll=True).asList() == ["1.1.1.1/32"]
-    assert prefix.parseString("14.0.0.0/8", parseAll=True).asList() == ["14.0.0.0/8"]
-    assert prefix.parseString("0.0.0.0/0", parseAll=True).asList() == ["0.0.0.0/0"]
+    assert prefix.parse_string("1.1.1.1/32", parseAll=True).asList() == ["1.1.1.1/32"]
+    assert prefix.parse_string("14.0.0.0/8", parseAll=True).asList() == ["14.0.0.0/8"]
+    assert prefix.parse_string("0.0.0.0/0", parseAll=True).asList() == ["0.0.0.0/0"]
     with pytest.raises(ParseException):
-        prefix.parseString("0.0.0.0/45", parseAll=True).asList()
+        prefix.parse_string("0.0.0.0/45", parseAll=True).asList()
     with pytest.raises(ParseException):
-        prefix.parseString("0.0.0/45", parseAll=True)
+        prefix.parse_string("0.0.0/45", parseAll=True)
     with pytest.raises(ParseException):
-        prefix.parseString("0/0", parseAll=True)
+        prefix.parse_string("0/0", parseAll=True)
     with pytest.raises(ParseException):
-        prefix.parseString("1.2.3.4.5/24", parseAll=True)
+        prefix.parse_string("1.2.3.4.5/24", parseAll=True)
     with pytest.raises(ParseException):
-        prefix.parseString("1.1.1.1/33", parseAll=True).asList()
+        prefix.parse_string("1.1.1.1/33", parseAll=True).asList()
 
 
 def test_dec_parsing() -> None:
-    assert dec.parseString("0").asList() == [0]
-    assert dec.parseString("004").asList() == [4]
+    assert dec.parse_string("0").asList() == [0]
+    assert dec.parse_string("004").asList() == [4]
     with pytest.raises(ParseException):
-        dec.parseString("-5").asList()
+        dec.parse_string("-5").asList()

--- a/tests/lab_validation/parsers/frr/grammar/test_interface.py
+++ b/tests/lab_validation/parsers/frr/grammar/test_interface.py
@@ -9,21 +9,21 @@ from lab_validation.parsers.frr.grammar.interface import (
 
 
 def test_interface_line() -> None:
-    result = _get_iface_line_admin_up().parseString(
+    result = _get_iface_line_admin_up().parse_string(
         "Interface lo is up, line protocol is up"
     )
     assert result.name == "lo"
     assert result.admin_state == "up"
     assert result.line_state == "up"
 
-    result = _get_iface_line_admin_up().parseString(
+    result = _get_iface_line_admin_up().parse_string(
         "Interface swp1 is up, line protocol is down"
     )
     assert result.name == "swp1"
     assert result.admin_state == "up"
     assert result.line_state == "down"
 
-    result = _get_iface_line_admin_down().parseString("Interface swp1 is down")
+    result = _get_iface_line_admin_down().parse_string("Interface swp1 is down")
     assert result.name == "swp1"
     assert result.admin_state == "down"
 
@@ -32,19 +32,19 @@ def test_interface_line() -> None:
     Interface swp1 is down
     Interface swp1 is up, line protocol is down
     """
-    result = _get_iface_line().parseString(input_text)
+    result = _get_iface_line().parse_string(input_text)
     assert result.name == "swp1"
     assert result.admin_state == "down"
 
 
 def test_get_mtu_speed() -> None:
-    result = _get_mtu_speed().parseString("mtu 1500 speed 1000")
+    result = _get_mtu_speed().parse_string("mtu 1500 speed 1000")
     assert result.mtu == 1500
     assert result.speed == 1000
 
 
 def test_get_bandwidth() -> None:
-    result = _get_bandwidth().parseString("bandwidth 100 Mbps")
+    result = _get_bandwidth().parse_string("bandwidth 100 Mbps")
     assert result.bandwidth == 100
     assert result.bit_rate_unit == "Mbps"
 
@@ -64,7 +64,7 @@ Interface swp1 is up, line protocol is up
   inet6 fe80::a00:27ff:fe01:7ac6/64
   Interface Type Other
     """
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "swp1"
     assert interface.admin_state == "up"
     assert interface.line_state == "up"
@@ -85,7 +85,7 @@ Interface swp6 is down
   HWaddr: 08:00:27:a9:5f:fe
   Interface Type Other
     """
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "swp6"
     assert interface.admin_state == "down"
     assert interface.mtu == 1500
@@ -109,7 +109,7 @@ Interface swp1 is up, line protocol is up
   inet6 fe80::a00:27ff:fe0f:c31c/64
   Interface Type Other
     """
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "swp1"
     assert interface.admin_state == "up"
     assert interface.mtu == 1500

--- a/tests/lab_validation/parsers/frr/grammar/test_vrf.py
+++ b/tests/lab_validation/parsers/frr/grammar/test_vrf.py
@@ -5,7 +5,7 @@ def test_parse_vrf() -> None:
     input_text = """
 vrf internet-vrf id 11 table 1002
     """
-    result = parse_vrf().parseString(input_text)
+    result = parse_vrf().parse_string(input_text)
     assert result.name == "internet-vrf"
     assert result.id == "11"
     assert result.table_index == "1002"

--- a/tests/lab_validation/parsers/ios/ios/commands/test_route.py
+++ b/tests/lab_validation/parsers/ios/ios/commands/test_route.py
@@ -19,7 +19,7 @@ from lab_validation.parsers.ios.models.routes import IosIpRoute
 def _parse_route_table_only(text: str, vrf: str = "default") -> list[IosIpRoute]:
     """Local utility function to just parse the routes section of a vrf's route table."""
     return _parse_routes_in_vrf(
-        OneOrMore(single_route()).parseString(text, parseAll=True), vrf
+        OneOrMore(single_route()).parse_string(text, parseAll=True), vrf
     )
 
 

--- a/tests/lab_validation/parsers/ios/ios/commands/test_show_bgp_all.py
+++ b/tests/lab_validation/parsers/ios/ios/commands/test_show_bgp_all.py
@@ -581,7 +581,7 @@ def test_af_table_routes_vrf() -> None:
 Route Distinguisher: 65003:1 (default for vrf d1_ce) VRF Router ID 192.168.123.31
  *>   10.13.11.0/30    0.0.0.0                  0         32768 ?
     """
-    parsed_output = _af_table_routes_vrf().parseString(input_text)
+    parsed_output = _af_table_routes_vrf().parse_string(input_text)
 
     assert parsed_output[0][0]["rd"] == "65003:1"
     assert parsed_output[0][0]["vrf_name"] == "d1_ce"
@@ -600,7 +600,7 @@ Route Distinguisher: 65003:1 (default for vrf d1_ce) VRF Router ID 192.168.123.3
 Route Distinguisher: 65003:1 (default for vrf d1_ce)
  *>   10.13.11.0/30    0.0.0.0                  0         32768 ?
     """
-    parsed_output = _af_table_routes_vrf().parseString(input_text)
+    parsed_output = _af_table_routes_vrf().parse_string(input_text)
 
     assert parsed_output[0][0]["rd"] == "65003:1"
     assert parsed_output[0][0]["vrf_name"] == "d1_ce"

--- a/tests/lab_validation/parsers/ios/ios/grammar/test_route.py
+++ b/tests/lab_validation/parsers/ios/ios/grammar/test_route.py
@@ -10,18 +10,18 @@ from lab_validation.parsers.ios.grammar.route import (
 def test_directly_connected_line() -> None:
     """Test if we can parse the directly connected portion of a route line"""
     input_text = "is directly connected, GigabitEthernet1/0"
-    parsed_data = _directly_connected_line().parseString(input_text)
+    parsed_data = _directly_connected_line().parse_string(input_text)
     assert parsed_data.nh_iface == "GigabitEthernet1/0"
 
     """Test directly connected routes in vrf leaking"""
     input_text = "is directly connected, 00:38:55, GigabitEthernet1"
-    parsed_data = _directly_connected_line().parseString(input_text)
+    parsed_data = _directly_connected_line().parse_string(input_text)
     assert parsed_data.nh_iface == "GigabitEthernet1"
 
 
 def test_prefix_via_nhip_line() -> None:
     """Test if we can parse the admin/metric and next hop portion of a route line"""
-    parsed_data = _prefix_via_nhip_line().parseString(
+    parsed_data = _prefix_via_nhip_line().parse_string(
         "[20/21] via 10.10.10.1, 00:02:50"
     )
     assert parsed_data.admin == 20
@@ -31,12 +31,12 @@ def test_prefix_via_nhip_line() -> None:
 
 def test_prefix_subnetted_line() -> None:
     """Test that we can parse subnetted/variably subnetted line"""
-    parsed_data = _prefix_is_subnetted_line().parseString(
+    parsed_data = _prefix_is_subnetted_line().parse_string(
         "15.0.0.0/24 is subnetted, 1 subnets", parseAll=True
     )
     assert parsed_data.subnet_prefix == "15.0.0.0/24"
 
-    parsed_data = _prefix_is_subnetted_line().parseString(
+    parsed_data = _prefix_is_subnetted_line().parse_string(
         "192.168.61.0/24 is variably subnetted, 7 subnets, 2 masks", parseAll=True
     )
     assert parsed_data.subnet_prefix == "192.168.61.0/24"
@@ -44,7 +44,7 @@ def test_prefix_subnetted_line() -> None:
 
 def test_v4_route_line() -> None:
     """Test single route without subnet block"""
-    parsed_data = _v4_route().parseString(
+    parsed_data = _v4_route().parse_string(
         "B     192.168.122.0/24 [20/0] via 10.12.11.1, 00:03:11", parseAll=True
     )
     assert parsed_data.protocol == "B"
@@ -56,7 +56,7 @@ def test_v4_route_line() -> None:
 
 def test_candidate_v4_route() -> None:
     """Test that we can parse a candidate default route line"""
-    parsed_data = _v4_route().parseString(
+    parsed_data = _v4_route().parse_string(
         "O*IA  0.0.0.0/0 [110/11] via 14.2.0.1, 00:31:32, Ethernet2/0", parseAll=True
     )
     assert parsed_data.protocol == "O"
@@ -70,7 +70,7 @@ def test_candidate_v4_route() -> None:
 
 def test_v4_route_ospf_summary() -> None:
     """Test that we can parse an OSPF summary route"""
-    parsed_data = _v4_route().parseString(
+    parsed_data = _v4_route().parse_string(
         "O        10.4.0.0/16 is a summary, 01:05:17, Null0", parseAll=True
     )
     assert parsed_data.protocol == "O"
@@ -81,7 +81,7 @@ def test_v4_route_ospf_summary() -> None:
 
 def test_v4_route_normal() -> None:
     """Test that we can parse a normal IP v4 route (which is not candidate default)"""
-    parsed_data = _v4_route().parseString(
+    parsed_data = _v4_route().parse_string(
         "C        192.168.61.0/24 is directly connected, Loopback61", parseAll=True
     )
     route = parsed_data
@@ -89,7 +89,7 @@ def test_v4_route_normal() -> None:
     assert route.network == "192.168.61.0/24"
     assert route.nh_iface == "Loopback61"
 
-    parsed_data = _v4_route().parseString(
+    parsed_data = _v4_route().parse_string(
         "O IA     192.168.61.1/32 [110/11] via 14.2.0.1, 00:31:32, Ethernet2/0",
         parseAll=True,
     )
@@ -103,7 +103,7 @@ def test_v4_route_normal() -> None:
     assert route.nh_iface == "Ethernet2/0"
 
     # test eigrp line
-    parsed_data = _v4_route().parseString(
+    parsed_data = _v4_route().parse_string(
         "D        172.16.1.2 [90/130816] via 10.12.11.2, 03:12:43, GigabitEthernet1",
         parseAll=True,
     )
@@ -117,7 +117,7 @@ def test_v4_route_normal() -> None:
     assert route.nh_iface == "GigabitEthernet1"
 
     # test eigrp external line
-    parsed_data = _v4_route().parseString(
+    parsed_data = _v4_route().parse_string(
         "D EX       172.16.1.2 [90/130816] via 10.12.11.2, 03:12:43, GigabitEthernet1",
         parseAll=True,
     )
@@ -133,7 +133,7 @@ def test_v4_route_normal() -> None:
 
 def test_routes_block_within_subnet() -> None:
     """Test that we can parse routes under a subnetted block"""
-    parsed_data = _routes_block_within_subnet().parseString(
+    parsed_data = _routes_block_within_subnet().parse_string(
         """192.168.61.0/24 is variably subnetted, 8 subnets, 2 masks
 O IA     192.168.61.3/32 [110/12] via 12.0.0.1, 00:29:31, GigabitEthernet0/0
 D EX     192.168.61.4/32 [90/13] via 12.0.0.2, 00:29:31, GigabitEthernet0/1"""

--- a/tests/lab_validation/parsers/ios/iosxe/commands/test_route.py
+++ b/tests/lab_validation/parsers/ios/iosxe/commands/test_route.py
@@ -19,7 +19,7 @@ from lab_validation.parsers.ios.models.routes import IosIpRoute
 def _parse_route_table_only(text: str, vrf: str = "default") -> list[IosIpRoute]:
     """Local utility function to just parse the routes section of a vrf's route table."""
     return _parse_routes_in_vrf(
-        OneOrMore(single_route()).parseString(text, parseAll=True), vrf
+        OneOrMore(single_route()).parse_string(text, parseAll=True), vrf
     )
 
 

--- a/tests/lab_validation/parsers/iosxr/commands/test_route.py
+++ b/tests/lab_validation/parsers/iosxr/commands/test_route.py
@@ -20,7 +20,7 @@ from lab_validation.parsers.iosxr.models.routes import IosXrRoute
 def _parse_route_table_only(text: str, vrf: str = "default") -> list[IosXrRoute]:
     """Local utility function to just parse the routes section of a vrf's route table."""
     return _parse_routes_in_vrf(
-        OneOrMore(single_route()).parseString(text, parseAll=True), vrf
+        OneOrMore(single_route()).parse_string(text, parseAll=True), vrf
     )
 
 

--- a/tests/lab_validation/parsers/iosxr/commands/test_show_bgp_all_all.py
+++ b/tests/lab_validation/parsers/iosxr/commands/test_show_bgp_all_all.py
@@ -256,7 +256,7 @@ Processed 1 prefixes, 1 paths
 
 def test_6152() -> None:
     """Test parsing of suppressed BGP routes with multiple status codes (e.g. 's i')"""
-    record = _af_table_routes_vrf_route().parseString(
+    record = _af_table_routes_vrf_route().parse_string(
         """s i210.171.104.0/24   10.169.6.153                  100      0 65240 i
 """
     )[0]

--- a/tests/lab_validation/parsers/iosxr/grammar/test_route.py
+++ b/tests/lab_validation/parsers/iosxr/grammar/test_route.py
@@ -6,10 +6,10 @@ from lab_validation.parsers.iosxr.grammar.route import _time
 
 def test_time() -> None:
     # valid ones don't raise
-    _time().parseString("01:05:49")
-    _time().parseString("2d02h")
-    _time().parseString("30w4d")
-    _time().parseString("2y12w")
+    _time().parse_string("01:05:49")
+    _time().parse_string("2d02h")
+    _time().parse_string("30w4d")
+    _time().parse_string("2y12w")
     # validate that invalid ones will
     with pytest.raises(ParseException):
-        _time().parseString("not-a-time")
+        _time().parse_string("not-a-time")

--- a/tests/lab_validation/parsers/junos/grammar/test_bgp_route.py
+++ b/tests/lab_validation/parsers/junos/grammar/test_bgp_route.py
@@ -8,7 +8,7 @@ from lab_validation.parsers.junos.grammar.bgp_route import (
 
 
 def test_show_bgp_route() -> None:
-    parsed_data = show_bgp_route().parseString(
+    parsed_data = show_bgp_route().parse_string(
         """
         inet.0: 13 destinations, 14 routes (13 active, 0 holddown, 0 hidden)
     + = Active Route, - = Last Active, * = Both
@@ -42,7 +42,7 @@ def test_show_bgp_route() -> None:
 
 
 def test_route_block() -> None:
-    parsed_data = _route_block().parseString(
+    parsed_data = _route_block().parse_string(
         """
     A V Destination        P Prf   Metric 1   Metric 2  Next hop        AS path
       V 10.12.11.0/24      B 170        100                             I
@@ -82,7 +82,7 @@ def test_route_block() -> None:
 
 
 def test_table_schema() -> None:
-    _table_schema().parseString(
+    _table_schema().parse_string(
         """
         A V Destination        P Prf   Metric 1   Metric 2  Next hop        AS path
         """
@@ -90,7 +90,7 @@ def test_table_schema() -> None:
 
 
 def test_bgp_route_not_active() -> None:
-    parsed_data = _bgp_route().parseString(
+    parsed_data = _bgp_route().parse_string(
         """
           V 10.12.11.0/24      B 170        100                             I
   valid                                            >10.12.11.2
@@ -110,7 +110,7 @@ def test_bgp_route_not_active() -> None:
 
 
 def test_bgp_route_not_valid() -> None:
-    parsed_data = _bgp_route().parseString(
+    parsed_data = _bgp_route().parse_string(
         """
           ? 10.12.11.0/24      B 170        100                             I
   unverified                                            >10.12.11.2
@@ -130,7 +130,7 @@ def test_bgp_route_not_valid() -> None:
 
 
 def test_bgp_route_metric2() -> None:
-    parsed_data = _bgp_route().parseString(
+    parsed_data = _bgp_route().parse_string(
         """
           V 10.12.11.0/24      B 170        100    101                         I
   valid                                            >10.12.11.2
@@ -150,7 +150,7 @@ def test_bgp_route_metric2() -> None:
 
 
 def test_bgp_route_active_no_as_path() -> None:
-    parsed_data = _bgp_route().parseString(
+    parsed_data = _bgp_route().parse_string(
         """
 * V 10.23.33.0/24      B 170        100                             I
   valid                                            >10.12.11.2
@@ -170,7 +170,7 @@ def test_bgp_route_active_no_as_path() -> None:
 
 
 def test_bgp_route_active_with_as_path() -> None:
-    parsed_data = _bgp_route().parseString(
+    parsed_data = _bgp_route().parse_string(
         """
 * V 10.34.11.0/24      B 170        100                             (65001 65002) 2 I
   valid                                            >10.12.11.2
@@ -192,7 +192,7 @@ def test_bgp_route_active_with_as_path() -> None:
 
 
 def test_bgp_route_line2_unverified() -> None:
-    parsed_data = _bgp_route_line2().parseString(
+    parsed_data = _bgp_route_line2().parse_string(
         """
   unverified                                            >10.12.11.2
         """
@@ -203,7 +203,7 @@ def test_bgp_route_line2_unverified() -> None:
 
 
 def test_bgp_route_line2_valid() -> None:
-    parsed_data = _bgp_route_line2().parseString(
+    parsed_data = _bgp_route_line2().parse_string(
         """
   valid                                            >10.12.11.2
         """

--- a/tests/lab_validation/parsers/junos/grammar/test_interface.py
+++ b/tests/lab_validation/parsers/junos/grammar/test_interface.py
@@ -9,7 +9,7 @@ from lab_validation.parsers.junos.grammar.interface import (
 
 
 def test_show_interface_coverage() -> None:
-    interfaces = show_interface().parseString(
+    interfaces = show_interface().parse_string(
         """
 Physical interface: gr-0/0/0, Enabled, Physical link is Up
   Interface index: 645, SNMP ifIndex: 504
@@ -396,7 +396,7 @@ Physical interface: vtep, Enabled, Physical link is Up
 
 
 def test_show_interface() -> None:
-    interfaces = show_interface().parseString(
+    interfaces = show_interface().parse_string(
         """
 Physical interface: jsrv, Enabled, Physical link is Up
   Interface index: 646, SNMP ifIndex: 508
@@ -440,7 +440,7 @@ Physical interface: jsrv, Enabled, Physical link is Up
 
 
 def test_physical_record() -> None:
-    result = _physical_record().parseString(
+    result = _physical_record().parse_string(
         """
         Physical interface: bme0, Enabled, Physical link is Up
       Interface index: 64, SNMP ifIndex: 37
@@ -462,7 +462,7 @@ def test_physical_record() -> None:
 
 
 def test_physical_record_no_link_level() -> None:
-    result = _physical_record().parseString(
+    result = _physical_record().parse_string(
         """
         Physical interface: dsc, Enabled, Physical link is Up
           Interface index: 5, SNMP ifIndex: 5
@@ -484,7 +484,7 @@ def test_physical_record_no_link_level() -> None:
 
 
 def test_physical_name_line() -> None:
-    result = _physical_name_line().parseString(
+    result = _physical_name_line().parse_string(
         "Physical interface: gr-0/0/0, Enabled, Physical link is Up"
     )
     assert result.name == "gr-0/0/0"
@@ -494,13 +494,13 @@ def test_physical_name_line() -> None:
 
 
 def test_physical_type_line() -> None:
-    result = _physical_type_line().parseString(
+    result = _physical_type_line().parse_string(
         "Type: GRE, Link-level type: GRE, MTU: Unlimited, Speed: 800mbps"
     )
     assert result.speed == "800mbps"
     assert result.mtu == "Unlimited"
 
-    result = _physical_type_line().parseString(
+    result = _physical_type_line().parse_string(
         "Type: GRE, Link-level type: GRE, MTU: 2000"
     )
     assert "speed" not in result
@@ -508,7 +508,7 @@ def test_physical_type_line() -> None:
 
 
 def test_logical_record_with_bw() -> None:
-    result = _logical_record().parseString(
+    result = _logical_record().parse_string(
         """Logical interface jsrv.1 (Index 548) (SNMP ifIndex 509)
     Flags: Up 0x24004000 Encapsulation: unknown
     Bandwidth: 1000mbps
@@ -526,7 +526,7 @@ def test_logical_record_with_bw() -> None:
 
 
 def test_logical_record_no_bw() -> None:
-    result = _logical_record().parseString(
+    result = _logical_record().parse_string(
         """
       Logical interface bme0.0 (Index 6) (SNMP ifIndex 220)
         Flags: Up 0x4000000 Encapsulation: ENET2
@@ -553,7 +553,7 @@ def test_logical_record_no_bw() -> None:
 
 
 def test_logical_record_admin_state_down() -> None:
-    result = _logical_record().parseString(
+    result = _logical_record().parse_string(
         """Logical interface jsrv.1 (Index 548) (SNMP ifIndex 509)
     Flags: Down 0x24004000 Encapsulation: unknown
     Bandwidth: 1000mbps
@@ -571,7 +571,7 @@ def test_logical_record_admin_state_down() -> None:
 
 
 def test_logical_name_line() -> None:
-    result = _logical_name_line().parseString(
+    result = _logical_name_line().parse_string(
         "Logical interface bme0.0 (Index 4) (SNMP ifIndex 220)\n"
     )
     assert result.name == "bme0.0"

--- a/tests/lab_validation/parsers/junos/grammar/test_route.py
+++ b/tests/lab_validation/parsers/junos/grammar/test_route.py
@@ -13,7 +13,7 @@ from lab_validation.parsers.junos.grammar.route import (
 
 
 def test_route_block() -> None:
-    parsed_data = _route_block().parseString(
+    parsed_data = _route_block().parse_string(
         """10.10.50.0/24      *[Direct/0] 01:48:58
                     > via em0.0
                     [BGP/170] 01:48:54, MED 0, localpref 100
@@ -30,7 +30,7 @@ def test_route_block() -> None:
 
 
 def test_route_info_block() -> None:
-    parsed_data = _route_info_block().parseString(
+    parsed_data = _route_info_block().parse_string(
         """[Direct/0] 01:48:58
             > via em0.0
            [BGP/170] 01:48:54, MED 0, localpref 100
@@ -46,7 +46,7 @@ def test_route_info_block() -> None:
 
 
 def test_route_info_block_no_med() -> None:
-    parsed_data = _route_info_block().parseString(
+    parsed_data = _route_info_block().parse_string(
         """*[Direct/0] 03:26:32
                 > via em3.0
                 [BGP/170] 01:08:18, localpref 100
@@ -62,28 +62,28 @@ def test_route_info_block_no_med() -> None:
 
 
 def test_status_route_info_block() -> None:
-    parsed_data = _status_route_info_block().parseString(
+    parsed_data = _status_route_info_block().parse_string(
         """*[Direct/0] 01:48:58
             > via em0.0
         """
     )
     assert parsed_data.status == "*"
 
-    parsed_data = _status_route_info_block().parseString(
+    parsed_data = _status_route_info_block().parse_string(
         """+[Direct/0] 01:48:58
             > via em0.0
         """
     )
     assert parsed_data.status == "+"
 
-    parsed_data = _status_route_info_block().parseString(
+    parsed_data = _status_route_info_block().parse_string(
         """-[Direct/0] 01:48:58
             > via em0.0
         """
     )
     assert parsed_data.status == "-"
 
-    parsed_data = _status_route_info_block().parseString(
+    parsed_data = _status_route_info_block().parse_string(
         """[Direct/0] 01:48:58
             > via em0.0
         """
@@ -92,7 +92,7 @@ def test_status_route_info_block() -> None:
 
 
 def test_local_route_info() -> None:
-    parsed_data = _local_route_info_block().parseString(
+    parsed_data = _local_route_info_block().parse_string(
         """[Local/0] 02:05:54
                       Local via em1.0
         """
@@ -106,7 +106,7 @@ def test_local_route_info() -> None:
 
 def test_direct_route_info() -> None:
     """Test if we can parse the direct route info block"""
-    parsed_data = _direct_route_info_block().parseString(
+    parsed_data = _direct_route_info_block().parse_string(
         """[Direct/0] 01:48:58
             > via em0.0
         """
@@ -120,7 +120,7 @@ def test_direct_route_info() -> None:
 
 def test_static_discard_route_info() -> None:
     """Test if we can parse the static discard route info block"""
-    parsed_data = _static_discard_route_info_block().parseString(
+    parsed_data = _static_discard_route_info_block().parse_string(
         """[Static/5] 00:08:11
         Discard
         """
@@ -130,7 +130,7 @@ def test_static_discard_route_info() -> None:
 
 def test_static_route_info() -> None:
     """Test if we can parse the static route info block"""
-    parsed_data = _static_route_info_block().parseString(
+    parsed_data = _static_route_info_block().parse_string(
         """[Static/5] 00:07:57
         > to 10.46.55.2 via em5.0
         """
@@ -145,7 +145,7 @@ def test_static_route_info() -> None:
 
 def test_isis_route_info() -> None:
     """Test if we can parse the is-is route info block"""
-    parsed_data = _isis_route_info_block().parseString(
+    parsed_data = _isis_route_info_block().parse_string(
         """[IS-IS/15] 00:07:47, metric 10
         > to 10.34.11.1 via em1.0
         """
@@ -161,7 +161,7 @@ def test_isis_route_info() -> None:
 
 def test_bgp_route_info() -> None:
     """Test if we can parse the bgp route info block"""
-    parsed_data = _bgp_route_info_block().parseString(
+    parsed_data = _bgp_route_info_block().parse_string(
         """[BGP/170] 01:48:54, MED 0, localpref 100
         AS path: 1 10 I, validation-state: unverified
         > to 10.10.50.1 via em0.0
@@ -182,7 +182,7 @@ def test_bgp_route_info() -> None:
 
 def test_bgp_route_info_no_as_path() -> None:
     """Test if we can parse the bgp route info where as path is empty"""
-    parsed_data = _bgp_route_info_block().parseString(
+    parsed_data = _bgp_route_info_block().parse_string(
         """[BGP/170] 04:14:18, localpref 100
                   AS path: I, validation-state: valid
                 > to 10.12.11.1 via em1.0
@@ -199,7 +199,7 @@ def test_bgp_route_info_no_as_path() -> None:
 
 
 def test_ospf_route_info() -> None:
-    parsed_data = _ospf_route_info_block().parseString(
+    parsed_data = _ospf_route_info_block().parse_string(
         """
         [OSPF/10] 02:12:38, metric 2
                     > to 10.16.63.2 via em1.0

--- a/tests/lab_validation/parsers/junos/grammar/test_util.py
+++ b/tests/lab_validation/parsers/junos/grammar/test_util.py
@@ -2,7 +2,7 @@ from lab_validation.parsers.junos.grammar.utils import rib_meta_info
 
 
 def test_table_header() -> None:
-    parsed_data = rib_meta_info().parseString(
+    parsed_data = rib_meta_info().parse_string(
         """vrf.inet.0: 21 destinations, 21 routes (21 active, 0 holddown, 0 hidden)
         + = Active Route, - = Last Active, * = Both
         """

--- a/tests/lab_validation/parsers/nxos/grammar/test_interface.py
+++ b/tests/lab_validation/parsers/nxos/grammar/test_interface.py
@@ -7,53 +7,53 @@ from lab_validation.parsers.nxos.grammar.interface import (
 
 
 def test_interface_line() -> None:
-    result = _get_iface_line().parseString("Ethernet1/1 is up")
+    result = _get_iface_line().parse_string("Ethernet1/1 is up")
     assert result.name == "Ethernet1/1"
     assert result.line_state == "up"
 
-    result = _get_iface_line().parseString("mgmt0 is up")
+    result = _get_iface_line().parse_string("mgmt0 is up")
     assert result.name == "mgmt0"
     assert result.line_state == "up"
 
-    result = _get_iface_line().parseString("Ethernet1/1 is down")
+    result = _get_iface_line().parse_string("Ethernet1/1 is down")
     assert result.name == "Ethernet1/1"
     assert result.line_state == "down"
 
-    result = _get_iface_line().parseString(
+    result = _get_iface_line().parse_string(
         "Ethernet1/4 is down (Administratively down)"
     )
     assert result.name == "Ethernet1/4"
     assert result.line_state == "down"
 
-    result = _get_iface_line().parseString("Ethernet1/3 is down (Link not connected)")
+    result = _get_iface_line().parse_string("Ethernet1/3 is down (Link not connected)")
     assert result.name == "Ethernet1/3"
     assert result.line_state == "down"
 
 
 def test_get_iface_line_vlan() -> None:
     """test iface vlan line parsing"""
-    result = _get_iface_line().parseString(
+    result = _get_iface_line().parse_string(
         "Vlan200 is up, line protocol is up, autostate enabled"
     )
     assert result.name == "Vlan200"
     assert result.admin_state == "up"
     assert result.line_state == "up"
 
-    result = _get_iface_line().parseString(
+    result = _get_iface_line().parse_string(
         "Vlan1 is down (Administratively down), line protocol is down, autostate enabled"
     )
     assert result.name == "Vlan1"
     assert result.admin_state == "down"
     assert result.line_state == "down"
 
-    result = _get_iface_line().parseString(
+    result = _get_iface_line().parse_string(
         "Vlan10 is down (VLAN/BD is down), line protocol is down, autostate enabled"
     )
     assert result.name == "Vlan10"
     assert result.admin_state == "down"
     assert result.line_state == "down"
 
-    result = _get_iface_line().parseString(
+    result = _get_iface_line().parse_string(
         "Vlan506 is down (VLAN/BD does not exist), line protocol is down, autostate enabled"
     )
     assert result.name == "Vlan506"
@@ -62,10 +62,10 @@ def test_get_iface_line_vlan() -> None:
 
 
 def test_admin_line() -> None:
-    result = _get_admin_line().parseString("admin state is up, Dedicated Interface")
+    result = _get_admin_line().parse_string("admin state is up, Dedicated Interface")
     assert result.admin_state == "up"
 
-    result = _get_admin_line().parseString("admin state is down, Dedicated Interface")
+    result = _get_admin_line().parse_string("admin state is down, Dedicated Interface")
     assert result.admin_state == "down"
 
 
@@ -90,7 +90,7 @@ admin state is up,
     284 output packets 0 unicast packets 284 multicast packets
     0 broadcast packets 61336 bytes
     """
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "mgmt0"
     assert interface.admin_state == "up"
     assert interface.line_state == "up"
@@ -140,7 +140,7 @@ admin state is up, Dedicated Interface
     0 output error  0 collision  0 deferred  0 late collision
     0 lost carrier  0 no carrier  0 babble  0 output discard
     0 Tx pause"""
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "Ethernet1/2"
     assert interface.admin_state == "up"
     assert interface.line_state == "up"
@@ -161,7 +161,7 @@ Ethernet1/1 is up
   Port mode is trunk
   full-duplex, 10 Gb/s, media type is 10G
     """
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "Ethernet1/1"
     assert interface.admin_state == ""
     assert interface.line_state == "up"
@@ -179,7 +179,7 @@ Ethernet1/4 is down (Administratively down)
   Port mode is access
   Full-duplex, 10 Gb/s, media type is 10G
     """
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "Ethernet1/4"
     assert interface.admin_state == ""
     assert interface.line_state == "down"
@@ -197,7 +197,7 @@ Ethernet1/8 is down (Link not connected)
   Port mode is trunk
   Full-duplex, 10 Gb/s, media type is 10G
     """
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "Ethernet1/8"
     assert interface.admin_state == ""
     assert interface.line_state == "down"
@@ -215,7 +215,7 @@ Ethernet1/16 is down (SFP not inserted)
   Port mode is access
   Full-duplex, 10 Gb/s
     """
-    interface = interface_block().parseString(input_text)
+    interface = interface_block().parse_string(input_text)
     assert interface.name == "Ethernet1/16"
     assert interface.admin_state == ""
     assert interface.line_state == "down"

--- a/tests/lab_validation/parsers/nxos/grammar/test_route.py
+++ b/tests/lab_validation/parsers/nxos/grammar/test_route.py
@@ -13,7 +13,7 @@ from lab_validation.parsers.nxos.grammar.route import (
 
 
 def test_show_route() -> None:
-    records = show_route().parseString(
+    records = show_route().parse_string(
         """
         IP Route Table for VRF "default"
             '*' denotes best ucast next-hop
@@ -33,7 +33,7 @@ def test_show_route() -> None:
 
 
 def test_v4_route_for_a_prefix() -> None:
-    result = _v4_route_for_a_prefix().parseString(
+    result = _v4_route_for_a_prefix().parse_string(
         """
         2.2.2.2/32, ubest/mbest: 2/0, attached
         *via 2.2.2.2, Lo0, [0/10], 01:05:49, local
@@ -57,7 +57,7 @@ def test_v4_route_for_a_prefix() -> None:
 
 
 def test_prefix_line() -> None:
-    result = _prefix_line().parseString(
+    result = _prefix_line().parse_string(
         """
         2.2.2.2/32, ubest/mbest: 2/0, attached
         """
@@ -66,7 +66,7 @@ def test_prefix_line() -> None:
 
 
 def test_null_routed_line() -> None:
-    result = _null_routed_line().parseString(
+    result = _null_routed_line().parse_string(
         """
         *via Null0, [220/0], 03:28:31, bgp-65114, discard, tag 65114
         """
@@ -81,7 +81,7 @@ def test_null_routed_line() -> None:
 
 
 def test_ebgp_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.10.100.1, [20/0], 01:03:27, bgp-65100, external, tag 65000
         """
@@ -96,7 +96,7 @@ def test_ebgp_next_hop_line() -> None:
 
 
 def test_ibgp_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.10.11.1, [200/0], 03:27:40, bgp-65001, internal, tag 65001
         """
@@ -111,7 +111,7 @@ def test_ibgp_next_hop_line() -> None:
 
 
 def test_eigrp_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.13.21.1, Eth1/1, [170/2585856], 01:32:31, eigrp-1, external
         """
@@ -125,7 +125,7 @@ def test_eigrp_next_hop_line() -> None:
 
 
 def test_eigrp_external_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.13.21.2, Eth1/2, [90/130816], 01:32:30, eigrp-1, internal
         """
@@ -142,7 +142,7 @@ def test_eigrp_external_next_hop_line() -> None:
 
 
 def test_evpn_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 2.2.2.2%default, [200/0], 02:35:20, bgp-65001, internal, tag 65200 (evpn) segid: 100333 tunnelid: 0x2020202 encap: VXLAN
         """
@@ -162,7 +162,7 @@ def test_evpn_next_hop_line() -> None:
 
 
 def test_vxlan_static_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.198.226.133, [1/0], 22w6d, static, tag 65333 segid: 3002 tunnelid: 0xac6e045 encap: VXLAN
         """
@@ -180,7 +180,7 @@ def test_vxlan_static_next_hop_line() -> None:
 
 
 def test_direct_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 192.168.10.1, Vlan10, [0/0], 03:31:02, direct
         """
@@ -193,7 +193,7 @@ def test_direct_next_hop_line() -> None:
 
 
 def test_hsrp_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.102.5.35, Vlan101, [0/0], 49w3d, hsrp
         """
@@ -207,18 +207,18 @@ def test_hsrp_next_hop_line() -> None:
 
 def test_uptime() -> None:
     # valid ones don't raise
-    _uptime().parseString("01:05:49")
-    _uptime().parseString("2d02h")
-    _uptime().parseString("30w4d")
-    _uptime().parseString("2y12w")
-    _uptime().parseString("0.000000")
+    _uptime().parse_string("01:05:49")
+    _uptime().parse_string("2d02h")
+    _uptime().parse_string("30w4d")
+    _uptime().parse_string("2y12w")
+    _uptime().parse_string("0.000000")
     # validate that invalid ones will
     with pytest.raises(ParseException):
-        _uptime().parseString("not-a-time")
+        _uptime().parse_string("not-a-time")
 
 
 def test_local_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 2.2.2.2, Lo0, [0/0], 01:05:49, local
         """
@@ -231,7 +231,7 @@ def test_local_next_hop_line() -> None:
 
 
 def test_ospf_next_hop_line_type5() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 15.1.1.1, Eth1/1, [110/41], 00:26:29, ospf-5, inter
         """
@@ -245,7 +245,7 @@ def test_ospf_next_hop_line_type5() -> None:
 
 
 def test_static_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.12.11.2, [1/0], 03:16:08, static
         """
@@ -257,7 +257,7 @@ def test_static_next_hop_line() -> None:
 
 
 def test_next_hop_line_subinterface() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.10.100.1, Eth1/2.313, [0/0], 23:53:40, direct
         """
@@ -271,22 +271,22 @@ def test_next_hop_line_subinterface() -> None:
 
 def test_protocol() -> None:
     # valid ones don't raise
-    _protocol().parseString("am")
-    _protocol().parseString("bgp-11111")
-    _protocol().parseString("eigrp-11111, internal")
-    _protocol().parseString("direct")
-    _protocol().parseString("hmm")
-    _protocol().parseString("hsrp")
-    _protocol().parseString("local")
-    _protocol().parseString("ospf-11111, inter")
-    _protocol().parseString("static")
+    _protocol().parse_string("am")
+    _protocol().parse_string("bgp-11111")
+    _protocol().parse_string("eigrp-11111, internal")
+    _protocol().parse_string("direct")
+    _protocol().parse_string("hmm")
+    _protocol().parse_string("hsrp")
+    _protocol().parse_string("local")
+    _protocol().parse_string("ospf-11111, inter")
+    _protocol().parse_string("static")
     # validate that invalid ones will barf
     with pytest.raises(ParseException):
-        _uptime().parseString("not-a-protocol")
+        _uptime().parse_string("not-a-protocol")
 
 
 def test_trailing_comma_next_hop_line() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.10.100.1, [20/0], 01:03:27, bgp-65100, external, tag 65000,
         """
@@ -301,7 +301,7 @@ def test_trailing_comma_next_hop_line() -> None:
 
 
 def test_trailing_comma_null_routed_line() -> None:
-    result = _null_routed_line().parseString(
+    result = _null_routed_line().parse_string(
         """
         *via Null0, [220/0], 03:28:31, bgp-65114, discard, tag 65114,
         """
@@ -316,14 +316,14 @@ def test_trailing_comma_null_routed_line() -> None:
 
 
 def test_best_status() -> None:
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         *via 10.198.226.165, [1/0], 28w1d, static, tag 65333 segid: 3002 tunnelid: 0xac6e048 encap: VXLAN
         """
     )
     assert result.best_ucast == "*via"
 
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         via 10.198.224.94%default, [20/0], 1y32w, bgp-65333, external, tag 65011 (evpn) segid: 3002 tunnelid: 0xac6e05e encap: VXLAN
         """
@@ -331,7 +331,7 @@ def test_best_status() -> None:
     assert result.not_best == "via"
 
     # unlike the previous two lines, this line is not from real data
-    result = _next_hop_line().parseString(
+    result = _next_hop_line().parse_string(
         """
         **via 10.198.224.94%default, [20/0], 1y32w, bgp-65333, external, tag 65011 (evpn) segid: 3002 tunnelid: 0xac6e05e encap: VXLAN
         """


### PR DESCRIPTION
pyparsing 3.3.x emits PyparsingDeprecationWarning for the legacy
camelCase method names. CI installs pyparsing>=3.0.0 and gets 3.3.2,
which produces hundreds of warnings. Replace all occurrences across
29 source files and 17 test files:

- setResultsName -> set_results_name
- leaveWhitespace -> leave_whitespace
- parseString -> parse_string
- scanString -> scan_string
- setName -> set_name

----

Prompt:
```
In CI, I'm seeing a ton of warnings like this. Is this a pyparsing
upgrade that we need to work with?

src/lab_validation/parsers/fortios/grammar/interface.py:20
PyparsingDeprecationWarning: 'setResultsName' deprecated
- use 'set_results_name'

If so, please repro locally and fix.
```