### PR TITLE
Add junos_evpn_type5 lab

### DIFF
--- a/infra/examples/evpn-type5/configs/edge1.cfg
+++ b/infra/examples/evpn-type5/configs/edge1.cfg
@@ -1,0 +1,98 @@
+version 23.4R2-S2.1;
+interfaces {
+    ge-0/0/1 {
+        description "to router1 - p2p link";
+        unit 0 {
+            family inet {
+                address 10.99.0.1/31;
+            }
+        }
+    }
+    ge-0/0/2 {
+        description "to client3 - LAN segment";
+        unit 0 {
+            family inet {
+                address 192.168.99.1/24;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.99.99.1/32;
+            }
+        }
+    }
+    fxp0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.15/24;
+            }
+            family inet6 {
+                address 2001:db8::2/64;
+            }
+        }
+    }
+}
+routing-instances {
+    mgmt_junos {
+        routing-options {
+            rib mgmt_junos.inet6.0 {
+                static {
+                    route ::/0 next-hop 2001:db8::1;
+                }
+            }
+            static {
+                route 0.0.0.0/0 next-hop 10.0.0.2;
+            }
+        }
+    }
+}
+routing-options {
+    router-id 10.99.99.1;
+    autonomous-system 65200;
+    static {
+        route 192.168.99.0/24 discard;
+    }
+}
+policy-options {
+    policy-statement export-to-fabric {
+        term client3-network {
+            from {
+                protocol [ direct static ];
+                route-filter 192.168.99.0/24 exact;
+            }
+            then accept;
+        }
+        term deny {
+            then reject;
+        }
+    }
+    policy-statement import-from-fabric {
+        term accept-all {
+            then accept;
+        }
+    }
+}
+protocols {
+    bgp {
+        group fabric {
+            type external;
+            family inet {
+                unicast;
+            }
+            export export-to-fabric;
+            import import-from-fabric;
+            neighbor 10.99.0.0 {
+                description router1;
+                peer-as 65100;
+            }
+        }
+        log-updown;
+        graceful-restart;
+    }
+    lldp {
+        port-id-subtype interface-name;
+        interface all;
+    }
+}

--- a/infra/examples/evpn-type5/configs/node1-1.cfg
+++ b/infra/examples/evpn-type5/configs/node1-1.cfg
@@ -1,0 +1,348 @@
+## ERB Design - Leaf1 (distributed L2/L3 gateway with EVPN Type 5)
+version 23.4R2-S2.1;
+interfaces {
+    ge-0/0/1 {
+        description "to node2-1 (spine1)";
+        mtu 9192;
+        unit 0 {
+            family inet {
+                address 172.16.254.0/31;
+            }
+        }
+    }
+    ge-0/0/2 {
+        description "to node2-2 (spine2)";
+        mtu 9192;
+        unit 0 {
+            family inet {
+                address 172.16.254.2/31;
+            }
+        }
+    }
+    ge-0/0/6 {
+        description "client1 access port";
+        unit 0 {
+            family ethernet-switching {
+                interface-mode trunk;
+                vlan {
+                    members [ VLAN100 VLAN300 ];
+                }
+            }
+        }
+    }
+    irb {
+        unit 100 {
+            family inet {
+                address 172.16.100.1/24 {
+                    virtual-gateway-address 172.16.100.100;
+                }
+            }
+        }
+        unit 200 {
+            family inet {
+                address 172.16.200.1/24 {
+                    virtual-gateway-address 172.16.200.100;
+                }
+            }
+        }
+        unit 300 {
+            family inet {
+                address 172.16.101.1/24 {
+                    virtual-gateway-address 172.16.101.100;
+                }
+            }
+        }
+        unit 400 {
+            family inet {
+                address 172.16.201.1/24 {
+                    virtual-gateway-address 172.16.201.100;
+                }
+            }
+        }
+    }
+    fxp0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.15/24;
+            }
+            family inet6 {
+                address 2001:db8::2/64;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 172.16.0.1/32;
+            }
+        }
+    }
+}
+forwarding-options {
+    storm-control-profiles default {
+        all;
+    }
+}
+policy-options {
+    policy-statement export-underlay {
+        term loopbacks {
+            from {
+                protocol direct;
+                route-filter 172.16.0.0/24 orlonger;
+            }
+            then accept;
+        }
+        term p2p {
+            from {
+                protocol direct;
+                route-filter 172.16.254.0/24 orlonger;
+            }
+            then accept;
+        }
+        term deny {
+            then reject;
+        }
+    }
+    policy-statement import-underlay {
+        term loopbacks {
+            from {
+                route-filter 172.16.0.0/24 orlonger;
+            }
+            then accept;
+        }
+        term p2p {
+            from {
+                route-filter 172.16.254.0/24 orlonger;
+            }
+            then accept;
+        }
+        term deny {
+            then reject;
+        }
+    }
+    policy-statement load-balance-per-flow {
+        then {
+            load-balance per-packet;
+        }
+    }
+    policy-statement TENANT-A-import {
+        term from-tenant-a {
+            from community TENANT-A-RT;
+            then accept;
+        }
+        term from-tenant-b {
+            from community TENANT-B-RT;
+            then accept;
+        }
+        term default {
+            then reject;
+        }
+    }
+    policy-statement TENANT-A-export {
+        term export {
+            then {
+                community add TENANT-A-RT;
+                accept;
+            }
+        }
+    }
+    policy-statement TENANT-A-ipr-import {
+        term 1 {
+            then {
+                tag 999;
+                accept;
+            }
+        }
+    }
+    policy-statement TENANT-B-import {
+        term from-tenant-b {
+            from community TENANT-B-RT;
+            then accept;
+        }
+        term from-tenant-a {
+            from community TENANT-A-RT;
+            then accept;
+        }
+        term default {
+            then reject;
+        }
+    }
+    policy-statement TENANT-B-export {
+        term export {
+            then {
+                community add TENANT-B-RT;
+                accept;
+            }
+        }
+    }
+    community TENANT-A-RT members target:65000:10000;
+    community TENANT-B-RT members target:65000:20000;
+}
+vlans {
+    VLAN100 {
+        vlan-id 100;
+        l3-interface irb.100;
+        vxlan {
+            vni 10100;
+        }
+    }
+    VLAN200 {
+        vlan-id 200;
+        l3-interface irb.200;
+        vxlan {
+            vni 10200;
+        }
+    }
+    VLAN300 {
+        vlan-id 300;
+        l3-interface irb.300;
+        vxlan {
+            vni 10300;
+        }
+    }
+    VLAN400 {
+        vlan-id 400;
+        l3-interface irb.400;
+        vxlan {
+            vni 10400;
+        }
+    }
+}
+routing-instances {
+    TENANT-A {
+        instance-type vrf;
+        routing-options {
+            multipath;
+            auto-export;
+        }
+        protocols {
+            evpn {
+                irb-symmetric-routing {
+                    vni 50000;
+                }
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation vxlan;
+                    vni 50000;
+                    import TENANT-A-ipr-import;
+                }
+            }
+        }
+        interface irb.100;
+        interface irb.200;
+        route-distinguisher 172.16.0.1:10000;
+        vrf-target target:65000:10000;
+        vrf-import TENANT-A-import;
+        vrf-export TENANT-A-export;
+        vrf-table-label;
+    }
+    TENANT-B {
+        instance-type vrf;
+        routing-options {
+            multipath;
+            auto-export;
+        }
+        protocols {
+            evpn {
+                irb-symmetric-routing {
+                    vni 50001;
+                }
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation vxlan;
+                    vni 50001;
+                }
+            }
+        }
+        interface irb.300;
+        interface irb.400;
+        route-distinguisher 172.16.0.1:20000;
+        vrf-target target:65000:20000;
+        vrf-import TENANT-B-import;
+        vrf-export TENANT-B-export;
+        vrf-table-label;
+    }
+    mgmt_junos {
+        routing-options {
+            rib mgmt_junos.inet6.0 {
+                static {
+                    route ::/0 next-hop 2001:db8::1;
+                }
+            }
+            static {
+                route 0.0.0.0/0 next-hop 10.0.0.2;
+            }
+        }
+    }
+}
+routing-options {
+    router-id 172.16.0.1;
+    autonomous-system 65001;
+    forwarding-table {
+        export load-balance-per-flow;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    evpn {
+        encapsulation vxlan;
+        default-gateway no-gateway-community;
+        extended-vni-list all;
+    }
+    bgp {
+        group underlay {
+            type external;
+            mtu-discovery;
+            import import-underlay;
+            family inet {
+                unicast;
+            }
+            export export-underlay;
+            local-as 65001;
+            multipath {
+                multiple-as;
+            }
+            bfd-liveness-detection {
+                minimum-interval 350;
+                multiplier 3;
+                session-mode single-hop;
+            }
+            neighbor 172.16.254.1 {
+                description node2-1;
+                peer-as 65011;
+            }
+            neighbor 172.16.254.3 {
+                description node2-2;
+                peer-as 65012;
+            }
+        }
+        group overlay {
+            type internal;
+            local-address 172.16.0.1;
+            mtu-discovery;
+            family evpn {
+                signaling;
+            }
+            local-as 65000;
+            multipath;
+            neighbor 172.16.0.11 {
+                description node2-1;
+            }
+            neighbor 172.16.0.12 {
+                description node2-2;
+            }
+            vpn-apply-export;
+        }
+        log-updown;
+        graceful-restart;
+    }
+    lldp {
+        port-id-subtype interface-name;
+        interface all;
+    }
+}
+switch-options {
+    vtep-source-interface lo0.0;
+    route-distinguisher 172.16.0.1:1;
+    vrf-target target:65000:9999;
+}

--- a/infra/examples/evpn-type5/configs/node2-1.cfg
+++ b/infra/examples/evpn-type5/configs/node2-1.cfg
@@ -1,0 +1,183 @@
+## CRB Design - Spine1 (IP underlay + EVPN route reflector only, no VXLAN)
+version 23.4R2-S2.1;
+interfaces {
+    ge-0/0/1 {
+        description "to node1-1 (leaf1)";
+        mtu 9192;
+        unit 0 {
+            family inet {
+                address 172.16.254.1/31;
+            }
+        }
+    }
+    ge-0/0/2 {
+        description "to node1-2 (leaf2)";
+        mtu 9192;
+        unit 0 {
+            family inet {
+                address 172.16.254.5/31;
+            }
+        }
+    }
+    ge-0/0/3 {
+        description "to router1 (gateway)";
+        mtu 9192;
+        unit 0 {
+            family inet {
+                address 172.16.254.9/31;
+            }
+        }
+    }
+    fxp0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.15/24;
+            }
+            family inet6 {
+                address 2001:db8::2/64;
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 172.16.0.11/32;
+            }
+        }
+    }
+}
+policy-options {
+    policy-statement export-underlay {
+        term loopbacks {
+            from {
+                protocol [ direct bgp ];
+                route-filter 172.16.0.0/24 orlonger;
+            }
+            then accept;
+        }
+        term p2p {
+            from {
+                protocol [ direct bgp ];
+                route-filter 172.16.254.0/24 orlonger;
+            }
+            then accept;
+        }
+        term deny {
+            then reject;
+        }
+    }
+    policy-statement import-underlay {
+        term loopbacks {
+            from {
+                route-filter 172.16.0.0/24 orlonger;
+            }
+            then accept;
+        }
+        term p2p {
+            from {
+                route-filter 172.16.254.0/24 orlonger;
+            }
+            then accept;
+        }
+        term default {
+            from {
+                route-filter 0.0.0.0/0 exact;
+            }
+            then accept;
+        }
+        term deny {
+            then reject;
+        }
+    }
+    policy-statement load-balance-per-flow {
+        then {
+            load-balance per-packet;
+        }
+    }
+}
+routing-instances {
+    mgmt_junos {
+        routing-options {
+            rib mgmt_junos.inet6.0 {
+                static {
+                    route ::/0 next-hop 2001:db8::1;
+                }
+            }
+            static {
+                route 0.0.0.0/0 next-hop 10.0.0.2;
+            }
+        }
+    }
+}
+routing-options {
+    router-id 172.16.0.11;
+    autonomous-system 65011;
+    forwarding-table {
+        export load-balance-per-flow;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    bgp {
+        group underlay {
+            type external;
+            mtu-discovery;
+            import import-underlay;
+            family inet {
+                unicast;
+            }
+            export export-underlay;
+            local-as 65011;
+            multipath {
+                multiple-as;
+            }
+            bfd-liveness-detection {
+                minimum-interval 350;
+                multiplier 3;
+                session-mode single-hop;
+            }
+            neighbor 172.16.254.0 {
+                description node1-1;
+                peer-as 65001;
+            }
+            neighbor 172.16.254.4 {
+                description node1-2;
+                peer-as 65002;
+            }
+            neighbor 172.16.254.8 {
+                description router1;
+                peer-as 65100;
+            }
+        }
+        group overlay {
+            type internal;
+            local-address 172.16.0.11;
+            mtu-discovery;
+            family evpn {
+                signaling;
+            }
+            cluster 172.16.0.255;
+            local-as 65000;
+            multipath;
+            neighbor 172.16.0.1 {
+                description node1-1;
+            }
+            neighbor 172.16.0.2 {
+                description node1-2;
+            }
+            neighbor 172.16.0.12 {
+                description node2-2;
+            }
+            neighbor 172.16.0.100 {
+                description router1;
+            }
+            vpn-apply-export;
+        }
+        log-updown;
+        graceful-restart;
+    }
+    lldp {
+        port-id-subtype interface-name;
+        interface all;
+    }
+}

--- a/infra/examples/evpn-type5/configs/router1.cfg
+++ b/infra/examples/evpn-type5/configs/router1.cfg
@@ -1,0 +1,377 @@
+## ERB Design - Service Node (centralized routing + distributed anycast gateway)
+version 23.4R2-S2.1;
+interfaces {
+    ge-0/0/1 {
+        description "to node2-1 (spine1)";
+        mtu 9192;
+        unit 0 {
+            family inet {
+                address 172.16.254.8/31;
+            }
+        }
+    }
+    ge-0/0/2 {
+        description "to node2-2 (spine2)";
+        mtu 9192;
+        unit 0 {
+            family inet {
+                address 172.16.254.10/31;
+            }
+        }
+    }
+    ge-0/0/3 {
+        description "to edge1 - p2p link";
+        unit 0 {
+            family inet {
+                address 10.99.0.0/31;
+            }
+        }
+    }
+    fxp0 {
+        unit 0 {
+            family inet {
+                address 10.0.0.15/24;
+            }
+            family inet6 {
+                address 2001:db8::2/64;
+            }
+        }
+    }
+    irb {
+        unit 100 {
+            family inet {
+                address 172.16.100.3/24 {
+                    virtual-gateway-address 172.16.100.100;
+                }
+            }
+        }
+        unit 200 {
+            family inet {
+                address 172.16.200.3/24 {
+                    virtual-gateway-address 172.16.200.100;
+                }
+            }
+        }
+        unit 300 {
+            family inet {
+                address 172.16.101.3/24 {
+                    virtual-gateway-address 172.16.101.100;
+                }
+            }
+        }
+        unit 400 {
+            family inet {
+                address 172.16.201.3/24 {
+                    virtual-gateway-address 172.16.201.100;
+                }
+            }
+        }
+    }
+    lo0 {
+        unit 0 {
+            family inet {
+                address 172.16.0.100/32;
+            }
+        }
+    }
+}
+forwarding-options {
+    storm-control-profiles default {
+        all;
+    }
+}
+policy-options {
+    policy-statement TENANT-A-export {
+        term default-route {
+            from {
+                protocol static;
+                route-filter 0.0.0.0/0 exact;
+            }
+            then {
+                community add TENANT-A-community;
+                community add gateway-community;
+                accept;
+            }
+        }
+        term evpn {
+            then {
+                community add TENANT-A-community;
+                accept;
+            }
+        }
+    }
+    policy-statement TENANT-A-import {
+        term evpn {
+            from community TENANT-A-community;
+            then accept;
+        }
+    }
+    policy-statement TENANT-B-export {
+        term default-route {
+            from {
+                protocol static;
+                route-filter 0.0.0.0/0 exact;
+            }
+            then {
+                community add TENANT-B-community;
+                community add gateway-community;
+                accept;
+            }
+        }
+        term evpn {
+            then {
+                community add TENANT-B-community;
+                accept;
+            }
+        }
+    }
+    policy-statement TENANT-B-import {
+        term evpn {
+            from community TENANT-B-community;
+            then accept;
+        }
+    }
+    policy-statement export-to-edge {
+        term tenant-a-subnets {
+            from protocol [ direct evpn bgp ];
+            then accept;
+        }
+        term deny {
+            then reject;
+        }
+    }
+    policy-statement export-underlay {
+        term loopbacks {
+            from {
+                protocol direct;
+                route-filter 172.16.0.0/24 orlonger;
+            }
+            then accept;
+        }
+        term p2p {
+            from {
+                protocol direct;
+                route-filter 172.16.254.0/24 orlonger;
+            }
+            then accept;
+        }
+        term default-route {
+            from {
+                protocol static;
+                route-filter 0.0.0.0/0 exact;
+            }
+            then accept;
+        }
+        term deny {
+            then reject;
+        }
+    }
+    policy-statement import-from-edge {
+        term accept-all {
+            then accept;
+        }
+    }
+    policy-statement import-underlay {
+        term loopbacks {
+            from {
+                route-filter 172.16.0.0/24 orlonger;
+            }
+            then accept;
+        }
+        term p2p {
+            from {
+                route-filter 172.16.254.0/24 orlonger;
+            }
+            then accept;
+        }
+        term deny {
+            then reject;
+        }
+    }
+    policy-statement load-balance-per-flow {
+        then {
+            load-balance per-packet;
+        }
+    }
+    community TENANT-A-community members target:65000:10000;
+    community TENANT-B-community members target:65000:20000;
+    community gateway-community members target:65000:99;
+}
+vlans {
+    VLAN100 {
+        vlan-id 100;
+        l3-interface irb.100;
+        vxlan {
+            vni 10100;
+        }
+    }
+    VLAN200 {
+        vlan-id 200;
+        l3-interface irb.200;
+        vxlan {
+            vni 10200;
+        }
+    }
+    VLAN300 {
+        vlan-id 300;
+        l3-interface irb.300;
+        vxlan {
+            vni 10300;
+        }
+    }
+    VLAN400 {
+        vlan-id 400;
+        l3-interface irb.400;
+        vxlan {
+            vni 10400;
+        }
+    }
+}
+routing-instances {
+    TENANT-A {
+        instance-type vrf;
+        routing-options {
+            multipath;
+            auto-export;
+        }
+        protocols {
+            bgp {
+                group edge {
+                    type external;
+                    import import-from-edge;
+                    family inet {
+                        unicast;
+                    }
+                    export export-to-edge;
+                    neighbor 10.99.0.1 {
+                        description edge1;
+                        peer-as 65200;
+                    }
+                }
+            }
+            evpn {
+                irb-symmetric-routing {
+                    vni 50000;
+                }
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation vxlan;
+                    vni 50000;
+                }
+            }
+        }
+        interface ge-0/0/3.0;
+        interface irb.100;
+        interface irb.200;
+        route-distinguisher 172.16.0.100:10000;
+        vrf-target target:65000:10000;
+        vrf-table-label;
+    }
+    TENANT-B {
+        instance-type vrf;
+        routing-options {
+            multipath;
+            auto-export;
+        }
+        protocols {
+            evpn {
+                irb-symmetric-routing {
+                    vni 50001;
+                }
+                ip-prefix-routes {
+                    advertise direct-nexthop;
+                    encapsulation vxlan;
+                    vni 50001;
+                }
+            }
+        }
+        interface irb.300;
+        interface irb.400;
+        route-distinguisher 172.16.0.100:20000;
+        vrf-target target:65000:20000;
+        vrf-table-label;
+    }
+    mgmt_junos {
+        routing-options {
+            rib mgmt_junos.inet6.0 {
+                static {
+                    route ::/0 next-hop 2001:db8::1;
+                }
+            }
+            static {
+                route 0.0.0.0/0 next-hop 10.0.0.2;
+            }
+        }
+    }
+}
+routing-options {
+    router-id 172.16.0.100;
+    autonomous-system 65100;
+    forwarding-table {
+        export load-balance-per-flow;
+        ecmp-fast-reroute;
+    }
+}
+protocols {
+    evpn {
+        encapsulation vxlan;
+        default-gateway no-gateway-community;
+        extended-vni-list all;
+    }
+    bgp {
+        group underlay {
+            type external;
+            mtu-discovery;
+            import import-underlay;
+            family inet {
+                unicast;
+            }
+            export export-underlay;
+            local-as 65100;
+            multipath {
+                multiple-as;
+            }
+            bfd-liveness-detection {
+                minimum-interval 350;
+                multiplier 3;
+                session-mode single-hop;
+            }
+            neighbor 172.16.254.9 {
+                description node2-1;
+                peer-as 65011;
+            }
+            neighbor 172.16.254.11 {
+                description node2-2;
+                peer-as 65012;
+            }
+        }
+        group overlay {
+            type internal;
+            local-address 172.16.0.100;
+            mtu-discovery;
+            family evpn {
+                signaling;
+            }
+            local-as 65000;
+            multipath;
+            neighbor 172.16.0.11 {
+                description node2-1;
+            }
+            neighbor 172.16.0.12 {
+                description node2-2;
+            }
+            vpn-apply-export;
+        }
+        log-updown;
+        graceful-restart;
+    }
+    lldp {
+        port-id-subtype interface-name;
+        interface all;
+    }
+}
+switch-options {
+    vtep-source-interface lo0.0;
+    route-distinguisher 172.16.0.100:1;
+    vrf-target target:65000:9999;
+}

--- a/infra/examples/evpn-type5/topology.clab.yml
+++ b/infra/examples/evpn-type5/topology.clab.yml
@@ -1,0 +1,45 @@
+# EVPN Type 5 lab: shared services VRF with route leaking
+#
+# Topology (from batfish/batfish PR #9843):
+#
+#   edge1 (CE, AS 65200)
+#     |  ge-0/0/1 ↔ ge-0/0/3
+#   router1 (Service PE, AS 65100)
+#     |  ge-0/0/1 ↔ ge-0/0/3
+#   node2-1 (Spine/RR, AS 65011)
+#     |  ge-0/0/1 ↔ ge-0/0/1
+#   node1-1 (Leaf/ERB, AS 65001)
+#
+# iBGP overlay (AS 65000) with EVPN signaling between node1-1, node2-1, router1
+# TENANT-A and TENANT-B VRFs with EVPN Type 5 ip-prefix-routes
+#
+# Interface mapping: containerlab ethN+1 = Junos ge-0/0/N
+
+name: evpn-type5
+
+topology:
+  nodes:
+    node1-1:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/node1-1.cfg
+    node2-1:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/node2-1.cfg
+    router1:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/router1.cfg
+    edge1:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/edge1.cfg
+
+  links:
+    # node1-1 ge-0/0/1 (eth2) ↔ node2-1 ge-0/0/1 (eth2)
+    - endpoints: ["node1-1:eth2", "node2-1:eth2"]
+    # node2-1 ge-0/0/3 (eth4) ↔ router1 ge-0/0/1 (eth2)
+    - endpoints: ["node2-1:eth4", "router1:eth2"]
+    # router1 ge-0/0/3 (eth4) ↔ edge1 ge-0/0/1 (eth2)
+    - endpoints: ["router1:eth4", "edge1:eth2"]

--- a/snapshots/junos_evpn_type5/configs/edge1/show_configuration_|_display_set.txt
+++ b/snapshots/junos_evpn_type5/configs/edge1/show_configuration_|_display_set.txt
@@ -1,0 +1,38 @@
+set version 25.4R1.12
+set system host-name edge1
+set system root-authentication encrypted-password "$6$B2Jxr63W$VZbaBhqZB5Z73IIi9z4Z.dCBvo1mT9oqZh6wSJocrv5zTLbHvJHq8UuuKRAMDoQU28yt5lMtdY.0hjcVUCXT3."
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$0rlDF/VY$aAmS2gNa4Kgak0tyUMbABxz2w6Ebz6ZOw2YaC.1erL7AWGt0hq2YvxUf9FHd5o/UsTwMorVipvaOA3YNpWDsY0"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/1 description "to router1 - p2p link"
+set interfaces ge-0/0/1 unit 0 family inet address 10.99.0.1/31
+set interfaces ge-0/0/2 description "to client3 - LAN segment"
+set interfaces ge-0/0/2 unit 0 family inet address 192.168.99.1/24
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 10.99.99.1/32
+set policy-options policy-statement export-to-fabric term client3-network from protocol direct
+set policy-options policy-statement export-to-fabric term client3-network from protocol static
+set policy-options policy-statement export-to-fabric term client3-network from route-filter 192.168.99.0/24 exact
+set policy-options policy-statement export-to-fabric term client3-network then accept
+set policy-options policy-statement export-to-fabric term deny then reject
+set policy-options policy-statement import-from-fabric term accept-all then accept
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 10.99.99.1
+set routing-options autonomous-system 65200
+set routing-options static route 192.168.99.0/24 discard
+set protocols bgp group fabric type external
+set protocols bgp group fabric import import-from-fabric
+set protocols bgp group fabric family inet unicast
+set protocols bgp group fabric export export-to-fabric
+set protocols bgp group fabric neighbor 10.99.0.0 description router1
+set protocols bgp group fabric neighbor 10.99.0.0 peer-as 65100
+set protocols bgp log-updown
+set protocols bgp graceful-restart
+set protocols lldp port-id-subtype interface-name
+set protocols lldp interface all

--- a/snapshots/junos_evpn_type5/configs/node1-1/show_configuration_|_display_set.txt
+++ b/snapshots/junos_evpn_type5/configs/node1-1/show_configuration_|_display_set.txt
@@ -1,0 +1,139 @@
+set version 25.4R1.12
+set system host-name node1-1
+set system root-authentication encrypted-password "$6$UUvvk5cM$HpBrVaaga681e6ebuif1mBS/KFvliLo5ghkwrm8cnu88J71BVZhs9Yr0ulvSR6U11uZryiBr30veLITh7dUyf."
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$8wEX9JnT$szIl7Ed7.MRyCfQGemK24mqwM67g.u7J/8M1CCv6s9Dv7k7RhTcuuiwci6fS4oUIXLVe3g5vwdyQ4Q0RyYEr0/"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/1 description "to node2-1 (spine1)"
+set interfaces ge-0/0/1 mtu 9192
+set interfaces ge-0/0/1 unit 0 family inet address 172.16.254.0/31
+set interfaces ge-0/0/2 description "to node2-2 (spine2)"
+set interfaces ge-0/0/2 mtu 9192
+set interfaces ge-0/0/2 unit 0 family inet address 172.16.254.2/31
+set interfaces ge-0/0/6 description "client1 access port"
+set interfaces ge-0/0/6 unit 0 family ethernet-switching interface-mode trunk
+set interfaces ge-0/0/6 unit 0 family ethernet-switching vlan members VLAN100
+set interfaces ge-0/0/6 unit 0 family ethernet-switching vlan members VLAN300
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces irb unit 100 family inet address 172.16.100.1/24 virtual-gateway-address 172.16.100.100
+set interfaces irb unit 200 family inet address 172.16.200.1/24 virtual-gateway-address 172.16.200.100
+set interfaces irb unit 300 family inet address 172.16.101.1/24 virtual-gateway-address 172.16.101.100
+set interfaces irb unit 400 family inet address 172.16.201.1/24 virtual-gateway-address 172.16.201.100
+set interfaces lo0 unit 0 family inet address 172.16.0.1/32
+set forwarding-options storm-control-profiles default all
+set policy-options policy-statement TENANT-A-export term export then community add TENANT-A-RT
+set policy-options policy-statement TENANT-A-export term export then accept
+set policy-options policy-statement TENANT-A-import term from-tenant-a from community TENANT-A-RT
+set policy-options policy-statement TENANT-A-import term from-tenant-a then accept
+set policy-options policy-statement TENANT-A-import term from-tenant-b from community TENANT-B-RT
+set policy-options policy-statement TENANT-A-import term from-tenant-b then accept
+set policy-options policy-statement TENANT-A-import term default then reject
+set policy-options policy-statement TENANT-A-ipr-import term 1 then tag 999
+set policy-options policy-statement TENANT-A-ipr-import term 1 then accept
+set policy-options policy-statement TENANT-B-export term export then community add TENANT-B-RT
+set policy-options policy-statement TENANT-B-export term export then accept
+set policy-options policy-statement TENANT-B-import term from-tenant-b from community TENANT-B-RT
+set policy-options policy-statement TENANT-B-import term from-tenant-b then accept
+set policy-options policy-statement TENANT-B-import term from-tenant-a from community TENANT-A-RT
+set policy-options policy-statement TENANT-B-import term from-tenant-a then accept
+set policy-options policy-statement TENANT-B-import term default then reject
+set policy-options policy-statement export-underlay term loopbacks from protocol direct
+set policy-options policy-statement export-underlay term loopbacks from route-filter 172.16.0.0/24 orlonger
+set policy-options policy-statement export-underlay term loopbacks then accept
+set policy-options policy-statement export-underlay term p2p from protocol direct
+set policy-options policy-statement export-underlay term p2p from route-filter 172.16.254.0/24 orlonger
+set policy-options policy-statement export-underlay term p2p then accept
+set policy-options policy-statement export-underlay term deny then reject
+set policy-options policy-statement import-underlay term loopbacks from route-filter 172.16.0.0/24 orlonger
+set policy-options policy-statement import-underlay term loopbacks then accept
+set policy-options policy-statement import-underlay term p2p from route-filter 172.16.254.0/24 orlonger
+set policy-options policy-statement import-underlay term p2p then accept
+set policy-options policy-statement import-underlay term deny then reject
+set policy-options policy-statement load-balance-per-flow then load-balance per-packet
+set policy-options community TENANT-A-RT members target:65000:10000
+set policy-options community TENANT-B-RT members target:65000:20000
+set routing-instances TENANT-A instance-type vrf
+set routing-instances TENANT-A routing-options multipath
+set routing-instances TENANT-A routing-options auto-export
+set routing-instances TENANT-A protocols evpn irb-symmetric-routing vni 50000
+set routing-instances TENANT-A protocols evpn ip-prefix-routes advertise direct-nexthop
+set routing-instances TENANT-A protocols evpn ip-prefix-routes encapsulation vxlan
+set routing-instances TENANT-A protocols evpn ip-prefix-routes vni 50000
+set routing-instances TENANT-A protocols evpn ip-prefix-routes import TENANT-A-ipr-import
+set routing-instances TENANT-A interface irb.100
+set routing-instances TENANT-A interface irb.200
+set routing-instances TENANT-A route-distinguisher 172.16.0.1:10000
+set routing-instances TENANT-A vrf-import TENANT-A-import
+set routing-instances TENANT-A vrf-export TENANT-A-export
+set routing-instances TENANT-A vrf-target target:65000:10000
+set routing-instances TENANT-A vrf-table-label
+set routing-instances TENANT-B instance-type vrf
+set routing-instances TENANT-B routing-options multipath
+set routing-instances TENANT-B routing-options auto-export
+set routing-instances TENANT-B protocols evpn irb-symmetric-routing vni 50001
+set routing-instances TENANT-B protocols evpn ip-prefix-routes advertise direct-nexthop
+set routing-instances TENANT-B protocols evpn ip-prefix-routes encapsulation vxlan
+set routing-instances TENANT-B protocols evpn ip-prefix-routes vni 50001
+set routing-instances TENANT-B interface irb.300
+set routing-instances TENANT-B interface irb.400
+set routing-instances TENANT-B route-distinguisher 172.16.0.1:20000
+set routing-instances TENANT-B vrf-import TENANT-B-import
+set routing-instances TENANT-B vrf-export TENANT-B-export
+set routing-instances TENANT-B vrf-target target:65000:20000
+set routing-instances TENANT-B vrf-table-label
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 172.16.0.1
+set routing-options autonomous-system 65001
+set routing-options forwarding-table export load-balance-per-flow
+set routing-options forwarding-table ecmp-fast-reroute
+set protocols bgp group underlay type external
+set protocols bgp group underlay mtu-discovery
+set protocols bgp group underlay import import-underlay
+set protocols bgp group underlay family inet unicast
+set protocols bgp group underlay export export-underlay
+set protocols bgp group underlay local-as 65001
+set protocols bgp group underlay multipath multiple-as
+set protocols bgp group underlay bfd-liveness-detection minimum-interval 350
+set protocols bgp group underlay bfd-liveness-detection multiplier 3
+set protocols bgp group underlay bfd-liveness-detection session-mode single-hop
+set protocols bgp group underlay neighbor 172.16.254.1 description node2-1
+set protocols bgp group underlay neighbor 172.16.254.1 peer-as 65011
+set protocols bgp group underlay neighbor 172.16.254.3 description node2-2
+set protocols bgp group underlay neighbor 172.16.254.3 peer-as 65012
+set protocols bgp group overlay type internal
+set protocols bgp group overlay local-address 172.16.0.1
+set protocols bgp group overlay mtu-discovery
+set protocols bgp group overlay family evpn signaling
+set protocols bgp group overlay local-as 65000
+set protocols bgp group overlay multipath
+set protocols bgp group overlay neighbor 172.16.0.11 description node2-1
+set protocols bgp group overlay neighbor 172.16.0.12 description node2-2
+set protocols bgp group overlay vpn-apply-export
+set protocols bgp log-updown
+set protocols bgp graceful-restart
+set protocols evpn encapsulation vxlan
+set protocols evpn default-gateway no-gateway-community
+set protocols evpn extended-vni-list all
+set protocols lldp port-id-subtype interface-name
+set protocols lldp interface all
+set switch-options vtep-source-interface lo0.0
+set switch-options route-distinguisher 172.16.0.1:1
+set switch-options vrf-target target:65000:9999
+set vlans VLAN100 vlan-id 100
+set vlans VLAN100 l3-interface irb.100
+set vlans VLAN100 vxlan vni 10100
+set vlans VLAN200 vlan-id 200
+set vlans VLAN200 l3-interface irb.200
+set vlans VLAN200 vxlan vni 10200
+set vlans VLAN300 vlan-id 300
+set vlans VLAN300 l3-interface irb.300
+set vlans VLAN300 vxlan vni 10300
+set vlans VLAN400 vlan-id 400
+set vlans VLAN400 l3-interface irb.400
+set vlans VLAN400 vxlan vni 10400

--- a/snapshots/junos_evpn_type5/configs/node2-1/show_configuration_|_display_set.txt
+++ b/snapshots/junos_evpn_type5/configs/node2-1/show_configuration_|_display_set.txt
@@ -1,0 +1,77 @@
+set version 25.4R1.12
+set system host-name node2-1
+set system root-authentication encrypted-password "$6$de57gwkk$1j2vY7vKHYHjYoMFmCiAnDt3NVKGo6Ljh2qK1YW0shao.KnEclW0ALi5QqaPN5K5l6VrxoMAIIPPdLaw3VTx6/"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$dwUfMdeV$N8eE1oIR/wAlvOrPVemmrOWkJ0XwAt28irpVoEdT7IPWJyu9FNBdrqdlDhsFRMd1pWjxYaRskGkOVAyMHerxk1"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/1 description "to node1-1 (leaf1)"
+set interfaces ge-0/0/1 mtu 9192
+set interfaces ge-0/0/1 unit 0 family inet address 172.16.254.1/31
+set interfaces ge-0/0/2 description "to node1-2 (leaf2)"
+set interfaces ge-0/0/2 mtu 9192
+set interfaces ge-0/0/2 unit 0 family inet address 172.16.254.5/31
+set interfaces ge-0/0/3 description "to router1 (gateway)"
+set interfaces ge-0/0/3 mtu 9192
+set interfaces ge-0/0/3 unit 0 family inet address 172.16.254.9/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 172.16.0.11/32
+set policy-options policy-statement export-underlay term loopbacks from protocol direct
+set policy-options policy-statement export-underlay term loopbacks from protocol bgp
+set policy-options policy-statement export-underlay term loopbacks from route-filter 172.16.0.0/24 orlonger
+set policy-options policy-statement export-underlay term loopbacks then accept
+set policy-options policy-statement export-underlay term p2p from protocol direct
+set policy-options policy-statement export-underlay term p2p from protocol bgp
+set policy-options policy-statement export-underlay term p2p from route-filter 172.16.254.0/24 orlonger
+set policy-options policy-statement export-underlay term p2p then accept
+set policy-options policy-statement export-underlay term deny then reject
+set policy-options policy-statement import-underlay term loopbacks from route-filter 172.16.0.0/24 orlonger
+set policy-options policy-statement import-underlay term loopbacks then accept
+set policy-options policy-statement import-underlay term p2p from route-filter 172.16.254.0/24 orlonger
+set policy-options policy-statement import-underlay term p2p then accept
+set policy-options policy-statement import-underlay term default from route-filter 0.0.0.0/0 exact
+set policy-options policy-statement import-underlay term default then accept
+set policy-options policy-statement import-underlay term deny then reject
+set policy-options policy-statement load-balance-per-flow then load-balance per-packet
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 172.16.0.11
+set routing-options autonomous-system 65011
+set routing-options forwarding-table export load-balance-per-flow
+set routing-options forwarding-table ecmp-fast-reroute
+set protocols bgp group underlay type external
+set protocols bgp group underlay mtu-discovery
+set protocols bgp group underlay import import-underlay
+set protocols bgp group underlay family inet unicast
+set protocols bgp group underlay export export-underlay
+set protocols bgp group underlay local-as 65011
+set protocols bgp group underlay multipath multiple-as
+set protocols bgp group underlay bfd-liveness-detection minimum-interval 350
+set protocols bgp group underlay bfd-liveness-detection multiplier 3
+set protocols bgp group underlay bfd-liveness-detection session-mode single-hop
+set protocols bgp group underlay neighbor 172.16.254.0 description node1-1
+set protocols bgp group underlay neighbor 172.16.254.0 peer-as 65001
+set protocols bgp group underlay neighbor 172.16.254.4 description node1-2
+set protocols bgp group underlay neighbor 172.16.254.4 peer-as 65002
+set protocols bgp group underlay neighbor 172.16.254.8 description router1
+set protocols bgp group underlay neighbor 172.16.254.8 peer-as 65100
+set protocols bgp group overlay type internal
+set protocols bgp group overlay local-address 172.16.0.11
+set protocols bgp group overlay mtu-discovery
+set protocols bgp group overlay family evpn signaling
+set protocols bgp group overlay cluster 172.16.0.255
+set protocols bgp group overlay local-as 65000
+set protocols bgp group overlay multipath
+set protocols bgp group overlay neighbor 172.16.0.1 description node1-1
+set protocols bgp group overlay neighbor 172.16.0.2 description node1-2
+set protocols bgp group overlay neighbor 172.16.0.12 description node2-2
+set protocols bgp group overlay neighbor 172.16.0.100 description router1
+set protocols bgp group overlay vpn-apply-export
+set protocols bgp log-updown
+set protocols bgp graceful-restart
+set protocols lldp port-id-subtype interface-name
+set protocols lldp interface all

--- a/snapshots/junos_evpn_type5/configs/router1/show_configuration_|_display_set.txt
+++ b/snapshots/junos_evpn_type5/configs/router1/show_configuration_|_display_set.txt
@@ -1,0 +1,151 @@
+set version 25.4R1.12
+set system host-name router1
+set system root-authentication encrypted-password "$6$6oSRD8vj$YXbSQaQuFB88ebJUgnRVphRiLOaFR6S1KznxVDOIUYaCbL2/ad.dVsb7WbQ/TvW2HhjKeAuz1slA/LGZEyPIH."
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$DuOvsvyO$YvhkHAij1BmfDUtXWASlpruvD2Z8f5mYDc1kIXq5i8/e47Tj7Kw6M6uer6t9E0GO2soF8rZiVnobsg0ATu18j/"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/1 description "to node2-1 (spine1)"
+set interfaces ge-0/0/1 mtu 9192
+set interfaces ge-0/0/1 unit 0 family inet address 172.16.254.8/31
+set interfaces ge-0/0/2 description "to node2-2 (spine2)"
+set interfaces ge-0/0/2 mtu 9192
+set interfaces ge-0/0/2 unit 0 family inet address 172.16.254.10/31
+set interfaces ge-0/0/3 description "to edge1 - p2p link"
+set interfaces ge-0/0/3 unit 0 family inet address 10.99.0.0/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces irb unit 100 family inet address 172.16.100.3/24 virtual-gateway-address 172.16.100.100
+set interfaces irb unit 200 family inet address 172.16.200.3/24 virtual-gateway-address 172.16.200.100
+set interfaces irb unit 300 family inet address 172.16.101.3/24 virtual-gateway-address 172.16.101.100
+set interfaces irb unit 400 family inet address 172.16.201.3/24 virtual-gateway-address 172.16.201.100
+set interfaces lo0 unit 0 family inet address 172.16.0.100/32
+set forwarding-options storm-control-profiles default all
+set policy-options policy-statement TENANT-A-export term default-route from protocol static
+set policy-options policy-statement TENANT-A-export term default-route from route-filter 0.0.0.0/0 exact
+set policy-options policy-statement TENANT-A-export term default-route then community add TENANT-A-community
+set policy-options policy-statement TENANT-A-export term default-route then community add gateway-community
+set policy-options policy-statement TENANT-A-export term default-route then accept
+set policy-options policy-statement TENANT-A-export term evpn then community add TENANT-A-community
+set policy-options policy-statement TENANT-A-export term evpn then accept
+set policy-options policy-statement TENANT-A-import term evpn from community TENANT-A-community
+set policy-options policy-statement TENANT-A-import term evpn then accept
+set policy-options policy-statement TENANT-B-export term default-route from protocol static
+set policy-options policy-statement TENANT-B-export term default-route from route-filter 0.0.0.0/0 exact
+set policy-options policy-statement TENANT-B-export term default-route then community add TENANT-B-community
+set policy-options policy-statement TENANT-B-export term default-route then community add gateway-community
+set policy-options policy-statement TENANT-B-export term default-route then accept
+set policy-options policy-statement TENANT-B-export term evpn then community add TENANT-B-community
+set policy-options policy-statement TENANT-B-export term evpn then accept
+set policy-options policy-statement TENANT-B-import term evpn from community TENANT-B-community
+set policy-options policy-statement TENANT-B-import term evpn then accept
+set policy-options policy-statement export-to-edge term tenant-a-subnets from protocol direct
+set policy-options policy-statement export-to-edge term tenant-a-subnets from protocol evpn
+set policy-options policy-statement export-to-edge term tenant-a-subnets from protocol bgp
+set policy-options policy-statement export-to-edge term tenant-a-subnets then accept
+set policy-options policy-statement export-to-edge term deny then reject
+set policy-options policy-statement export-underlay term loopbacks from protocol direct
+set policy-options policy-statement export-underlay term loopbacks from route-filter 172.16.0.0/24 orlonger
+set policy-options policy-statement export-underlay term loopbacks then accept
+set policy-options policy-statement export-underlay term p2p from protocol direct
+set policy-options policy-statement export-underlay term p2p from route-filter 172.16.254.0/24 orlonger
+set policy-options policy-statement export-underlay term p2p then accept
+set policy-options policy-statement export-underlay term default-route from protocol static
+set policy-options policy-statement export-underlay term default-route from route-filter 0.0.0.0/0 exact
+set policy-options policy-statement export-underlay term default-route then accept
+set policy-options policy-statement export-underlay term deny then reject
+set policy-options policy-statement import-from-edge term accept-all then accept
+set policy-options policy-statement import-underlay term loopbacks from route-filter 172.16.0.0/24 orlonger
+set policy-options policy-statement import-underlay term loopbacks then accept
+set policy-options policy-statement import-underlay term p2p from route-filter 172.16.254.0/24 orlonger
+set policy-options policy-statement import-underlay term p2p then accept
+set policy-options policy-statement import-underlay term deny then reject
+set policy-options policy-statement load-balance-per-flow then load-balance per-packet
+set policy-options community TENANT-A-community members target:65000:10000
+set policy-options community TENANT-B-community members target:65000:20000
+set policy-options community gateway-community members target:65000:99
+set routing-instances TENANT-A instance-type vrf
+set routing-instances TENANT-A routing-options multipath
+set routing-instances TENANT-A routing-options auto-export
+set routing-instances TENANT-A protocols bgp group edge type external
+set routing-instances TENANT-A protocols bgp group edge import import-from-edge
+set routing-instances TENANT-A protocols bgp group edge family inet unicast
+set routing-instances TENANT-A protocols bgp group edge export export-to-edge
+set routing-instances TENANT-A protocols bgp group edge neighbor 10.99.0.1 description edge1
+set routing-instances TENANT-A protocols bgp group edge neighbor 10.99.0.1 peer-as 65200
+set routing-instances TENANT-A protocols evpn irb-symmetric-routing vni 50000
+set routing-instances TENANT-A protocols evpn ip-prefix-routes advertise direct-nexthop
+set routing-instances TENANT-A protocols evpn ip-prefix-routes encapsulation vxlan
+set routing-instances TENANT-A protocols evpn ip-prefix-routes vni 50000
+set routing-instances TENANT-A interface ge-0/0/3.0
+set routing-instances TENANT-A interface irb.100
+set routing-instances TENANT-A interface irb.200
+set routing-instances TENANT-A route-distinguisher 172.16.0.100:10000
+set routing-instances TENANT-A vrf-target target:65000:10000
+set routing-instances TENANT-A vrf-table-label
+set routing-instances TENANT-B instance-type vrf
+set routing-instances TENANT-B routing-options multipath
+set routing-instances TENANT-B routing-options auto-export
+set routing-instances TENANT-B protocols evpn irb-symmetric-routing vni 50001
+set routing-instances TENANT-B protocols evpn ip-prefix-routes advertise direct-nexthop
+set routing-instances TENANT-B protocols evpn ip-prefix-routes encapsulation vxlan
+set routing-instances TENANT-B protocols evpn ip-prefix-routes vni 50001
+set routing-instances TENANT-B interface irb.300
+set routing-instances TENANT-B interface irb.400
+set routing-instances TENANT-B route-distinguisher 172.16.0.100:20000
+set routing-instances TENANT-B vrf-target target:65000:20000
+set routing-instances TENANT-B vrf-table-label
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 172.16.0.100
+set routing-options autonomous-system 65100
+set routing-options forwarding-table export load-balance-per-flow
+set routing-options forwarding-table ecmp-fast-reroute
+set protocols bgp group underlay type external
+set protocols bgp group underlay mtu-discovery
+set protocols bgp group underlay import import-underlay
+set protocols bgp group underlay family inet unicast
+set protocols bgp group underlay export export-underlay
+set protocols bgp group underlay local-as 65100
+set protocols bgp group underlay multipath multiple-as
+set protocols bgp group underlay bfd-liveness-detection minimum-interval 350
+set protocols bgp group underlay bfd-liveness-detection multiplier 3
+set protocols bgp group underlay bfd-liveness-detection session-mode single-hop
+set protocols bgp group underlay neighbor 172.16.254.9 description node2-1
+set protocols bgp group underlay neighbor 172.16.254.9 peer-as 65011
+set protocols bgp group underlay neighbor 172.16.254.11 description node2-2
+set protocols bgp group underlay neighbor 172.16.254.11 peer-as 65012
+set protocols bgp group overlay type internal
+set protocols bgp group overlay local-address 172.16.0.100
+set protocols bgp group overlay mtu-discovery
+set protocols bgp group overlay family evpn signaling
+set protocols bgp group overlay local-as 65000
+set protocols bgp group overlay multipath
+set protocols bgp group overlay neighbor 172.16.0.11 description node2-1
+set protocols bgp group overlay neighbor 172.16.0.12 description node2-2
+set protocols bgp group overlay vpn-apply-export
+set protocols bgp log-updown
+set protocols bgp graceful-restart
+set protocols evpn encapsulation vxlan
+set protocols evpn default-gateway no-gateway-community
+set protocols evpn extended-vni-list all
+set protocols lldp port-id-subtype interface-name
+set protocols lldp interface all
+set switch-options vtep-source-interface lo0.0
+set switch-options route-distinguisher 172.16.0.100:1
+set switch-options vrf-target target:65000:9999
+set vlans VLAN100 vlan-id 100
+set vlans VLAN100 l3-interface irb.100
+set vlans VLAN100 vxlan vni 10100
+set vlans VLAN200 vlan-id 200
+set vlans VLAN200 l3-interface irb.200
+set vlans VLAN200 vxlan vni 10200
+set vlans VLAN300 vlan-id 300
+set vlans VLAN300 l3-interface irb.300
+set vlans VLAN300 vxlan vni 10300
+set vlans VLAN400 vlan-id 400
+set vlans VLAN400 l3-interface irb.400
+set vlans VLAN400 vxlan vni 10400

--- a/snapshots/junos_evpn_type5/show/edge1/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/edge1/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,491 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.99.0.0+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65100"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.99.0.1+63514"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65200"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "router1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "fabric"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-to-fabric"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-from-fabric"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-to-fabric"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-from-fabric"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LogUpDown AddressFamily PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "7:31", 
+                "attributes" : {"junos:seconds" : "451"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "10.99.0.0"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "10.99.99.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/1.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "541"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65100"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "15"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "454"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "20"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "457"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "19"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "393"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/edge1/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/edge1/show_interfaces_|_display_json.txt
@@ -1,0 +1,9418 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:56"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:56"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:49 UTC (00:07:13 ago)", 
+                "attributes" : {"junos:seconds" : "433"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "96"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "17"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to router1 - p2p link"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:e9:6c:f3"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:e9:6c:f3"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:49 UTC (00:07:16 ago)", 
+                "attributes" : {"junos:seconds" : "436"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "144"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "70"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "68"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.99.0.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.99.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to client3 - LAN segment"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:48 UTC (00:07:18 ago)", 
+                "attributes" : {"junos:seconds" : "438"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "192.168.99/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "192.168.99.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "192.168.99.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:48 UTC (00:07:20 ago)", 
+                "attributes" : {"junos:seconds" : "440"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:48 UTC (00:07:20 ago)", 
+                "attributes" : {"junos:seconds" : "440"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:48 UTC (00:07:21 ago)", 
+                "attributes" : {"junos:seconds" : "441"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:48 UTC (00:07:22 ago)", 
+                "attributes" : {"junos:seconds" : "442"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:48 UTC (00:07:22 ago)", 
+                "attributes" : {"junos:seconds" : "442"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:49 UTC (00:07:22 ago)", 
+                "attributes" : {"junos:seconds" : "442"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:49 UTC (00:07:22 ago)", 
+                "attributes" : {"junos:seconds" : "442"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:49 UTC (00:07:22 ago)", 
+                "attributes" : {"junos:seconds" : "442"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:49 UTC (00:07:23 ago)", 
+                "attributes" : {"junos:seconds" : "443"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:c0:bc:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:bc:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:c0:bc:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:28:37 UTC (00:10:35 ago)", 
+                "attributes" : {"junos:seconds" : "635"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "55069"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "101582"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "53888"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "101584"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:b1:40:60:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:b1:40:60:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:b1:40:60:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:b1:40:60:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:28:37 UTC (00:10:35 ago)", 
+                "attributes" : {"junos:seconds" : "635"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "7993"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "8024"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "7993"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "8034"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:b1ff:fe40:6000"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:c3:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:c0:c3:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:c3:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:c0:c3:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "1282"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "1282"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.99.99.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1282"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1282"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:c3:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:c0:c3:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:c0:c3:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:c0:c3:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/edge1/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/edge1/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/edge1/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/edge1/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/edge1/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/edge1/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/edge1/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/edge1/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,174 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.99.0.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:22", 
+                        "attributes" : {"junos:seconds" : "442"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.99.0.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/edge1/show_route_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/edge1/show_route_|_display_json.txt
@@ -1,0 +1,845 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.99.0.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:27", 
+                        "attributes" : {"junos:seconds" : "447"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:18", 
+                        "attributes" : {"junos:seconds" : "438"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.99.0.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.99.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:27", 
+                        "attributes" : {"junos:seconds" : "447"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.99.99.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:59", 
+                        "attributes" : {"junos:seconds" : "599"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "192.168.99.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:52", 
+                        "attributes" : {"junos:seconds" : "592"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "192.168.99.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:27", 
+                        "attributes" : {"junos:seconds" : "447"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:52", 
+                        "attributes" : {"junos:seconds" : "592"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:59", 
+                        "attributes" : {"junos:seconds" : "599"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:59", 
+                        "attributes" : {"junos:seconds" : "599"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:52", 
+                        "attributes" : {"junos:seconds" : "592"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:59", 
+                        "attributes" : {"junos:seconds" : "599"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:59", 
+                        "attributes" : {"junos:seconds" : "599"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:b1ff:fe40:6000/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:59", 
+                        "attributes" : {"junos:seconds" : "599"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/edge1/show_version_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/edge1/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "edge1"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/host_nos.txt
+++ b/snapshots/junos_evpn_type5/show/host_nos.txt
@@ -1,0 +1,1 @@
+{"edge1": "junos", "node1-1": "junos", "node2-1": "junos", "router1": "junos"}

--- a/snapshots/junos_evpn_type5/show/node1-1/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node1-1/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,1512 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.0.11+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.0.1+52331"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "overlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress LogUpDown AddressFamily Multipath LocalAS Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "VpnApplyExport MtuDiscovery"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "172.16.0.1"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65000"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65001"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "8:21", 
+                "attributes" : {"junos:seconds" : "501"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "172.16.0.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "local-ext-nh-color-nlri" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "30000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "default-switch.evpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "TENANT-A.evpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "TENANT-B.evpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "__default_evpn__.evpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "5"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "13"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "718"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "20"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "391"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "evpn"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.0.12"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.0.1"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-2"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "overlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Active"
+            }
+            ], 
+            "peer-flags" : [
+            {
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "Idle"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "Start"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress LogUpDown AddressFamily Multipath LocalAS Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "VpnApplyExport MtuDiscovery"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "172.16.0.1"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65000"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65001"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "11:12", 
+                "attributes" : {"junos:seconds" : "672"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.254.1+56197"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65011"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.254.0+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "underlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-underlay"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-underlay"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-underlay"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-underlay"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LogUpDown AddressFamily PeerAS Multipath LocalAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "MtuDiscovery MultipathAs BfdEnabled"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65001"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65001"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "8:25", 
+                "attributes" : {"junos:seconds" : "505"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "172.16.0.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "enabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "up"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/1.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "548"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65011"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "13"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "567"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "20"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "418"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.254.3"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65012"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "unspecified"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-2"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "underlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Idle"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "PeerInterfaceUnknown"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "NoState"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "NoEvent"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-underlay"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-underlay"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-underlay"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-underlay"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LogUpDown AddressFamily PeerAS Multipath LocalAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "MtuDiscovery MultipathAs BfdEnabled"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65001"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65001"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "11:12", 
+                "attributes" : {"junos:seconds" : "672"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node1-1/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node1-1/show_interfaces_|_display_json.txt
@@ -1,0 +1,10743 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:56"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:56"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:55 UTC (00:07:53 ago)", 
+                "attributes" : {"junos:seconds" : "473"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "104"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "17"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "529"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "534"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "532"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "533"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to node2-1 (spine1)"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "9200"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:65:2c:a3"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:65:2c:a3"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:55 UTC (00:07:55 ago)", 
+                "attributes" : {"junos:seconds" : "475"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "1408"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "1288"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1389"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1393"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "9178"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.254.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.254.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to node2-2 (spine2)"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "9200"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:54 UTC (00:07:57 ago)", 
+                "attributes" : {"junos:seconds" : "477"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "9178"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.254.2/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.254.2"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:54 UTC (00:07:57 ago)", 
+                "attributes" : {"junos:seconds" : "477"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "346"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:54 UTC (00:07:58 ago)", 
+                "attributes" : {"junos:seconds" : "478"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "347"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:54 UTC (00:07:59 ago)", 
+                "attributes" : {"junos:seconds" : "479"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "348"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "552"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "541"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "client1 access port"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:54 UTC (00:08:00 ago)", 
+                "attributes" : {"junos:seconds" : "480"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "349"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "553"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "542"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:54 UTC (00:08:00 ago)", 
+                "attributes" : {"junos:seconds" : "480"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "350"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "554"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "543"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:54 UTC (00:08:01 ago)", 
+                "attributes" : {"junos:seconds" : "481"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "351"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "555"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "544"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:55 UTC (00:08:01 ago)", 
+                "attributes" : {"junos:seconds" : "481"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "352"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "556"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "546"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:55 UTC (00:08:04 ago)", 
+                "attributes" : {"junos:seconds" : "484"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "353"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "557"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "547"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:31:55 UTC (00:08:05 ago)", 
+                "attributes" : {"junos:seconds" : "485"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "354"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "558"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:bc:d5:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:d5:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:bc:d5:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:28:34 UTC (00:11:26 ago)", 
+                "attributes" : {"junos:seconds" : "686"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "56696"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "103021"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "55470"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "103022"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:92:e4:55:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:92:e4:55:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:92:e4:55:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:92:e4:55:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:28:34 UTC (00:11:26 ago)", 
+                "attributes" : {"junos:seconds" : "686"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "10575"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "10660"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "10625"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "10701"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:92ff:fee4:5500"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:dc:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:bc:dc:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:dc:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:bc:dc:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "irb.100"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "524"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x4000"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.100/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.100.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "172.16.100.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "irb.200"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x4000"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.200/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.200.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "172.16.200.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "irb.300"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x4000"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.101/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.101.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "172.16.101.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "irb.400"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x4000"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.201/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.201.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "172.16.201.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "1377"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "1377"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1377"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1377"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lsi.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-point-to-point" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "LSI-NULL"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-none" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "iso"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lsi.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "523"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-point-to-point" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "LSI-NULL"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-none" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "iso"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:dc:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:bc:dc:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:bc:dc:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:bc:dc:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "vtep.32768"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "327"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "521"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "esi-value" : [
+                {
+                    "data" : "00:00:00:00:00:00:00:00:00:00"
+                }
+                ], 
+                "esi-mode" : [
+                {
+                    "data" : "single-homed"
+                }
+                ], 
+                "evpn-multihomed-status" : [
+                {
+                    "data" : "Forwarding"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "vtep-info" : [
+                {
+                    "vtep-type" : [
+                    {
+                        "data" : "Source"
+                    }
+                    ], 
+                    "vtep-address" : [
+                    {
+                        "data" : "172.16.0.1"
+                    }
+                    ], 
+                    "vtep-l2-routing-instance" : [
+                    {
+                        "data" : "default-switch"
+                    }
+                    ], 
+                    "vtep-l3-routing-instance" : [
+                    {
+                        "data" : "default"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node1-1/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node1-1/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node1-1/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node1-1/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node1-1/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node1-1/show_route_instance_|_display_json.txt
@@ -1,0 +1,407 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mpls.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "TENANT-A"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "vrf"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "TENANT-A.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "TENANT-A.evpn.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "TENANT-B"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "vrf"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "TENANT-B.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "TENANT-B.evpn.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__default_evpn__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "non-forwarding evpn"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "default-switch"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "evpn"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node1-1/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node1-1/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,1285 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.11/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:11", 
+                        "attributes" : {"junos:seconds" : "491"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.100/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:11", 
+                        "attributes" : {"junos:seconds" : "491"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:11", 
+                        "attributes" : {"junos:seconds" : "491"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.4/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:11", 
+                        "attributes" : {"junos:seconds" : "491"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.8/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:11", 
+                        "attributes" : {"junos:seconds" : "491"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.10/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:11", 
+                        "attributes" : {"junos:seconds" : "491"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-A.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-B.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mpls.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:02", 
+                        "attributes" : {"junos:seconds" : "482"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:02", 
+                        "attributes" : {"junos:seconds" : "482"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-A.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:02", 
+                        "attributes" : {"junos:seconds" : "482"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:02", 
+                        "attributes" : {"junos:seconds" : "482"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-B.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:02", 
+                        "attributes" : {"junos:seconds" : "482"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:02", 
+                        "attributes" : {"junos:seconds" : "482"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node1-1/show_route_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node1-1/show_route_|_display_json.txt
@@ -1,0 +1,3090 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.11/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:07", 
+                        "attributes" : {"junos:seconds" : "487"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.100/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:07", 
+                        "attributes" : {"junos:seconds" : "487"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:13", 
+                        "attributes" : {"junos:seconds" : "493"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:07", 
+                        "attributes" : {"junos:seconds" : "487"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:13", 
+                        "attributes" : {"junos:seconds" : "493"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:13", 
+                        "attributes" : {"junos:seconds" : "493"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.4/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:07", 
+                        "attributes" : {"junos:seconds" : "487"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.8/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:07", 
+                        "attributes" : {"junos:seconds" : "487"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.10/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:07", 
+                        "attributes" : {"junos:seconds" : "487"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-A.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.99.0.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "@"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "#"
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Multipath"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "255"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "metric2" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }, 
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.100.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:53", 
+                        "attributes" : {"junos:seconds" : "653"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.101.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:53", 
+                        "attributes" : {"junos:seconds" : "653"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.200.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:53", 
+                        "attributes" : {"junos:seconds" : "653"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.201.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:53", 
+                        "attributes" : {"junos:seconds" : "653"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "192.168.99.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "@"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "#"
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Multipath"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "255"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "metric2" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }, 
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-B.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.99.0.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "@"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "#"
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Multipath"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "255"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "metric2" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }, 
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.100.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:53", 
+                        "attributes" : {"junos:seconds" : "653"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.101.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:53", 
+                        "attributes" : {"junos:seconds" : "653"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.200.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:53", 
+                        "attributes" : {"junos:seconds" : "653"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.201.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:53", 
+                        "attributes" : {"junos:seconds" : "653"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "192.168.99.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "@"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "#"
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Multipath"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "255"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "metric2" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }, 
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mpls.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "VPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lsi.0 (TENANT-A)"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Pop      "
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "17"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "VPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lsi.1 (TENANT-B)"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Pop      "
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:92ff:fee4:5500/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:54", 
+                        "attributes" : {"junos:seconds" : "654"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-A.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-B.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:07:58", 
+                        "attributes" : {"junos:seconds" : "478"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.11"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node1-1/show_version_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node1-1/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "node1-1"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node2-1/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node2-1/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,2494 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.0.1+52331"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.0.11+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node1-1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "overlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "route-reflector-client" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress LogUpDown Cluster AddressFamily Multipath LocalAS Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "VpnApplyExport MtuDiscovery"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "172.16.0.11"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65000"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65011"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "9:05", 
+                "attributes" : {"junos:seconds" : "545"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "172.16.0.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "local-ext-nh-color-nlri" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "30000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "3"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "545"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "492"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "674"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "evpn"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.0.2"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node1-2"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "overlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "route-reflector-client" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Active"
+            }
+            ], 
+            "peer-flags" : [
+            {
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "Idle"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "Start"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress LogUpDown Cluster AddressFamily Multipath LocalAS Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "VpnApplyExport MtuDiscovery"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "172.16.0.11"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65000"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65011"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "12:31", 
+                "attributes" : {"junos:seconds" : "751"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.0.12"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-2"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "overlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "route-reflector-client" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Active"
+            }
+            ], 
+            "peer-flags" : [
+            {
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "Idle"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "Start"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress LogUpDown Cluster AddressFamily Multipath LocalAS Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "VpnApplyExport MtuDiscovery"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "172.16.0.11"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65000"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65011"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "12:31", 
+                "attributes" : {"junos:seconds" : "751"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.0.100+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.0.11+56051"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "router1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "overlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "route-reflector-client" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress LogUpDown Cluster AddressFamily Multipath LocalAS Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "VpnApplyExport MtuDiscovery"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "172.16.0.11"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65000"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65011"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "10:31", 
+                "attributes" : {"junos:seconds" : "631"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "172.16.0.100"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "local-ext-nh-color-nlri" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "30000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "632"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "27"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "766"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "24"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "467"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "evpn"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.254.0+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.254.1+56197"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65011"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node1-1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "underlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-underlay"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-underlay"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-underlay"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-underlay"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LogUpDown AddressFamily PeerAS Multipath LocalAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "MtuDiscovery MultipathAs BfdEnabled"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65011"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65011"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "9:10", 
+                "attributes" : {"junos:seconds" : "550"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "172.16.0.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "enabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "up"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/1.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "541"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "6"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "552"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "24"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "24"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "542"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.254.4+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.254.5"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65011"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node1-2"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "underlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Connect"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "TryConnect"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "Connect"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "ConnectRetry"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-underlay"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-underlay"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-underlay"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-underlay"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LogUpDown AddressFamily PeerAS Multipath LocalAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "MtuDiscovery MultipathAs BfdEnabled"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65011"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65011"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "12:31", 
+                "attributes" : {"junos:seconds" : "751"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.254.8+58316"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65100"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.254.9+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65011"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "router1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "underlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-underlay"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-underlay"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-underlay"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-underlay"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LogUpDown AddressFamily PeerAS Multipath LocalAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "MtuDiscovery MultipathAs BfdEnabled"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65011"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65011"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "10:35", 
+                "attributes" : {"junos:seconds" : "635"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "172.16.0.100"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "enabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "up"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/3.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "543"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65100"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "5"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "19"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "635"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "27"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "600"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "575"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node2-1/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node2-1/show_interfaces_|_display_json.txt
@@ -1,0 +1,9495 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:56"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:56"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:34 ago)", 
+                "attributes" : {"junos:seconds" : "634"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "88"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "22"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to node1-1 (leaf1)"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "9200"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:cd:5e:af"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:cd:5e:af"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:39 ago)", 
+                "attributes" : {"junos:seconds" : "639"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "1488"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "1352"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1561"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1570"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "9178"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.254.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.254.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to node1-2 (leaf2)"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "9200"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:57"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:57"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:39 ago)", 
+                "attributes" : {"junos:seconds" : "639"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "120"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "70"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "9178"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.254.4/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.254.5"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to router1 (gateway)"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "9200"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:43:95:1a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:43:95:1a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:40 ago)", 
+                "attributes" : {"junos:seconds" : "640"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "2288"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "1264"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1855"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1861"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "9178"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.254.8/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:40 ago)", 
+                "attributes" : {"junos:seconds" : "640"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:41 ago)", 
+                "attributes" : {"junos:seconds" : "641"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:44 ago)", 
+                "attributes" : {"junos:seconds" : "644"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:45 ago)", 
+                "attributes" : {"junos:seconds" : "645"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:45 ago)", 
+                "attributes" : {"junos:seconds" : "645"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:46 ago)", 
+                "attributes" : {"junos:seconds" : "646"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:46 ago)", 
+                "attributes" : {"junos:seconds" : "646"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:07 UTC (00:10:47 ago)", 
+                "attributes" : {"junos:seconds" : "647"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:13:16:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:16:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:13:16:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:27:59 UTC (00:12:55 ago)", 
+                "attributes" : {"junos:seconds" : "775"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "59411"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "106177"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "58155"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "106180"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:9a:37:84:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:9a:37:84:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:9a:37:84:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:9a:37:84:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:27:59 UTC (00:12:55 ago)", 
+                "attributes" : {"junos:seconds" : "775"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "7614"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "7685"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "7614"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "7687"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:9aff:fe37:8400"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:1d:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:13:1d:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:1d:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:13:1d:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "1511"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "1511"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.0.11"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1511"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1511"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:1d:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:13:1d:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:13:1d:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:13:1d:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node2-1/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node2-1/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node2-1/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node2-1/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node2-1/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node2-1/show_route_instance_|_display_json.txt
@@ -1,0 +1,245 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "10"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node2-1/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node2-1/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,681 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:58", 
+                        "attributes" : {"junos:seconds" : "538"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.100/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:23", 
+                        "attributes" : {"junos:seconds" : "623"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:58", 
+                        "attributes" : {"junos:seconds" : "538"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.8/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:23", 
+                        "attributes" : {"junos:seconds" : "623"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.10/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:23", 
+                        "attributes" : {"junos:seconds" : "623"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:00", 
+                        "attributes" : {"junos:seconds" : "540"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:21", 
+                        "attributes" : {"junos:seconds" : "621"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node2-1/show_route_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node2-1/show_route_|_display_json.txt
@@ -1,0 +1,1474 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:55", 
+                        "attributes" : {"junos:seconds" : "535"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.11/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:18", 
+                        "attributes" : {"junos:seconds" : "738"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.100/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:20", 
+                        "attributes" : {"junos:seconds" : "620"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:49", 
+                        "attributes" : {"junos:seconds" : "649"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:55", 
+                        "attributes" : {"junos:seconds" : "535"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:49", 
+                        "attributes" : {"junos:seconds" : "649"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.4/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:49", 
+                        "attributes" : {"junos:seconds" : "649"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/2.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.5/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:49", 
+                        "attributes" : {"junos:seconds" : "649"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/2.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.8/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:49", 
+                        "attributes" : {"junos:seconds" : "649"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:20", 
+                        "attributes" : {"junos:seconds" : "620"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.9/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:49", 
+                        "attributes" : {"junos:seconds" : "649"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.10/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:20", 
+                        "attributes" : {"junos:seconds" : "620"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:15", 
+                        "attributes" : {"junos:seconds" : "735"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:18", 
+                        "attributes" : {"junos:seconds" : "738"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:18", 
+                        "attributes" : {"junos:seconds" : "738"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:15", 
+                        "attributes" : {"junos:seconds" : "735"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:18", 
+                        "attributes" : {"junos:seconds" : "738"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:18", 
+                        "attributes" : {"junos:seconds" : "738"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:9aff:fe37:8400/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:18", 
+                        "attributes" : {"junos:seconds" : "738"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:08:57", 
+                        "attributes" : {"junos:seconds" : "537"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65100 65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:18", 
+                        "attributes" : {"junos:seconds" : "618"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "172.16.0.100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/node2-1/show_version_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/node2-1/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "node2-1"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/router1/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/router1/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,1999 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.99.0.1+63514"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65200"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.99.0.0+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65100"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "edge1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "edge"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "TENANT-A"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "TENANT-A"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-to-edge"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-from-edge"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-to-edge"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-from-edge"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "AddressFamily PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "10:02", 
+                "attributes" : {"junos:seconds" : "602"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "10.99.99.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "10.99.0.0"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/3.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "551"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65200"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "TENANT-A.inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "40000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "24"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "604"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "570"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "24"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "489"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "TENANT-A.inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.0.11+56051"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.0.100+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "overlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress LogUpDown AddressFamily Multipath LocalAS Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "VpnApplyExport MtuDiscovery"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "172.16.0.100"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65000"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65100"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "11:21", 
+                "attributes" : {"junos:seconds" : "681"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "172.16.0.100"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "local-ext-nh-color-nlri" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "30000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "default-switch.evpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "TENANT-A.evpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "TENANT-B.evpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "__default_evpn__.evpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "evpn"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "15"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "24"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "682"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "27"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "568"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "27"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "722"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "evpn"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.0.12"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.0.100"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-2"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "overlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Active"
+            }
+            ], 
+            "peer-flags" : [
+            {
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "Idle"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "Start"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress LogUpDown AddressFamily Multipath LocalAS Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "VpnApplyExport MtuDiscovery"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "evpn"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "172.16.0.100"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65000"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65100"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "13:06", 
+                "attributes" : {"junos:seconds" : "786"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.254.9+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65011"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.254.8+58316"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65100"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-1"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "underlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-underlay"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-underlay"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-underlay"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-underlay"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LogUpDown AddressFamily PeerAS Multipath LocalAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "MtuDiscovery MultipathAs BfdEnabled"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65100"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65100"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "11:24", 
+                "attributes" : {"junos:seconds" : "684"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "172.16.0.11"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "172.16.0.100"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "enabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "up"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/1.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "549"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65011"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "3"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "18"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "685"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "695"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "28"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "575"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "172.16.254.11+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65012"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "172.16.254.10"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65100"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "node2-2"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "underlay"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Connect"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "TryConnect"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "Connect"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "ConnectRetry"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "export-underlay"
+                }
+                ], 
+                "import-policy" : [
+                {
+                    "data" : "import-underlay"
+                }
+                ], 
+                "nlri-policy" : [
+                {
+                    "nlri-type" : [
+                    {
+                        "data" : "inet-unicast"
+                    }
+                    ], 
+                    "nlri-export-policy" : [
+                    {
+                        "data" : "export-underlay"
+                    }
+                    ], 
+                    "nlri-import-policy" : [
+                    {
+                        "data" : "import-underlay"
+                    }
+                    ]
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LogUpDown AddressFamily PeerAS Multipath LocalAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                    "data" : "MtuDiscovery MultipathAs BfdEnabled"
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "local-as" : [
+                {
+                    "data" : "65100"
+                }
+                ], 
+                "local-system-as" : [
+                {
+                    "data" : "65100"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "13:06", 
+                "attributes" : {"junos:seconds" : "786"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/router1/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/router1/show_interfaces_|_display_json.txt
@@ -1,0 +1,10802 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:56"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:56"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:10:57 ago)", 
+                "attributes" : {"junos:seconds" : "657"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "96"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "25"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "529"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "534"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "532"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "533"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to node2-1 (spine1)"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "9200"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:29:b8:7c"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:29:b8:7c"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:03 ago)", 
+                "attributes" : {"junos:seconds" : "663"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "1392"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "1352"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1988"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1987"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "9178"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.254.8/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.254.8"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to node2-2 (spine2)"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "9200"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:57"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:34:57"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:05 ago)", 
+                "attributes" : {"junos:seconds" : "665"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "120"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "346"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "75"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "9178"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.254.10/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.254.10"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "to edge1 - p2p link"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:7f:4f:57"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:7f:4f:57"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:05 ago)", 
+                "attributes" : {"junos:seconds" : "665"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "144"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "347"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "85"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "98"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.99.0.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.99.0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:06 ago)", 
+                "attributes" : {"junos:seconds" : "666"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:06 ago)", 
+                "attributes" : {"junos:seconds" : "666"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "348"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "552"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "541"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:06 ago)", 
+                "attributes" : {"junos:seconds" : "666"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "349"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "553"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "542"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:07 ago)", 
+                "attributes" : {"junos:seconds" : "667"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "350"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "554"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "543"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:07 ago)", 
+                "attributes" : {"junos:seconds" : "667"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "351"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "555"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "544"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:10 ago)", 
+                "attributes" : {"junos:seconds" : "670"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "352"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "556"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "545"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:10 ago)", 
+                "attributes" : {"junos:seconds" : "670"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "353"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "557"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "546"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:30:28 UTC (00:11:11 ago)", 
+                "attributes" : {"junos:seconds" : "671"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "354"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "558"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:43:42:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:42:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:43:42:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:28:11 UTC (00:13:28 ago)", 
+                "attributes" : {"junos:seconds" : "808"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "60778"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "107175"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "59469"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "107176"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:41:48:ce:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:41:48:ce:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:41:48:ce:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:41:48:ce:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 03:28:11 UTC (00:13:28 ago)", 
+                "attributes" : {"junos:seconds" : "808"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "7421"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "7496"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "7421"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "7498"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:41ff:fe48:ce00"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:49:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:43:49:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:49:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:43:49:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "irb.100"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x4000"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.100/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.100.3"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "172.16.100.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "irb.200"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "523"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x4000"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.200/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.200.3"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "172.16.200.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "irb.300"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "524"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x4000"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.101/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.101.3"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "172.16.101.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "irb.400"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x4000"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "172.16.201/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.201.3"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "172.16.201.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "1551"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "1551"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "172.16.0.100"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1551"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1551"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lsi.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-point-to-point" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "LSI-NULL"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-none" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "iso"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lsi.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-point-to-point" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "LSI-NULL"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-none" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "iso"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:49:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:43:49:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:43:49:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:43:49:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "vtep.32768"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "327"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "521"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "esi-value" : [
+                {
+                    "data" : "00:00:00:00:00:00:00:00:00:00"
+                }
+                ], 
+                "esi-mode" : [
+                {
+                    "data" : "single-homed"
+                }
+                ], 
+                "evpn-multihomed-status" : [
+                {
+                    "data" : "Forwarding"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "vtep-info" : [
+                {
+                    "vtep-type" : [
+                    {
+                        "data" : "Source"
+                    }
+                    ], 
+                    "vtep-address" : [
+                    {
+                        "data" : "172.16.0.100"
+                    }
+                    ], 
+                    "vtep-l2-routing-instance" : [
+                    {
+                        "data" : "default-switch"
+                    }
+                    ], 
+                    "vtep-l3-routing-instance" : [
+                    {
+                        "data" : "default"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/router1/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/router1/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/router1/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/router1/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/router1/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/router1/show_route_instance_|_display_json.txt
@@ -1,0 +1,385 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mpls.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "bgp.evpn.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "TENANT-A"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "vrf"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "TENANT-A.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "TENANT-A.evpn.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "TENANT-B"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "vrf"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "TENANT-B.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__default_evpn__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "non-forwarding evpn"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "default-switch"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "evpn"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/router1/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/router1/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,721 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:49", 
+                        "attributes" : {"junos:seconds" : "589"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.11/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:14", 
+                        "attributes" : {"junos:seconds" : "674"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:14", 
+                        "attributes" : {"junos:seconds" : "674"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.4/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:14", 
+                        "attributes" : {"junos:seconds" : "674"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.8/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:14", 
+                        "attributes" : {"junos:seconds" : "674"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-A.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "192.168.99.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:53", 
+                        "attributes" : {"junos:seconds" : "593"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.99.0.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-B.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mpls.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-A.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/router1/show_route_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/router1/show_route_|_display_json.txt
@@ -1,0 +1,2064 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:46", 
+                        "attributes" : {"junos:seconds" : "586"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.11/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:11", 
+                        "attributes" : {"junos:seconds" : "671"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.0.100/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:54", 
+                        "attributes" : {"junos:seconds" : "774"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:11", 
+                        "attributes" : {"junos:seconds" : "671"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.4/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:11", 
+                        "attributes" : {"junos:seconds" : "671"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.8/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:19", 
+                        "attributes" : {"junos:seconds" : "679"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:11", 
+                        "attributes" : {"junos:seconds" : "671"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65011 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "172.16.254.9"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.8/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:19", 
+                        "attributes" : {"junos:seconds" : "679"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.10/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:19", 
+                        "attributes" : {"junos:seconds" : "679"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/2.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.254.10/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:19", 
+                        "attributes" : {"junos:seconds" : "679"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/2.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:45", 
+                        "attributes" : {"junos:seconds" : "765"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:54", 
+                        "attributes" : {"junos:seconds" : "774"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:54", 
+                        "attributes" : {"junos:seconds" : "774"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-A.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.99.0.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:19", 
+                        "attributes" : {"junos:seconds" : "679"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.99.0.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:19", 
+                        "attributes" : {"junos:seconds" : "679"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.100.3/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:48", 
+                        "attributes" : {"junos:seconds" : "768"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.200.3/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:48", 
+                        "attributes" : {"junos:seconds" : "768"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "192.168.99.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:50", 
+                        "attributes" : {"junos:seconds" : "590"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65200 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.99.0.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/3.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-B.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.101.3/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:45", 
+                        "attributes" : {"junos:seconds" : "765"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief-mpls-fwd"}, 
+                "rt-destination" : [
+                {
+                    "data" : "172.16.201.3/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:45", 
+                        "attributes" : {"junos:seconds" : "765"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mpls.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "VPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:45", 
+                        "attributes" : {"junos:seconds" : "765"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lsi.0 (TENANT-A)"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Pop      "
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "17"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "VPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:45", 
+                        "attributes" : {"junos:seconds" : "765"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lsi.1 (TENANT-B)"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Pop      "
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:45", 
+                        "attributes" : {"junos:seconds" : "765"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:54", 
+                        "attributes" : {"junos:seconds" : "774"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:54", 
+                        "attributes" : {"junos:seconds" : "774"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:41ff:fe48:ce00/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:54", 
+                        "attributes" : {"junos:seconds" : "774"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:50", 
+                        "attributes" : {"junos:seconds" : "590"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Fictitious"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:19", 
+                        "attributes" : {"junos:seconds" : "679"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Fictitious"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "TENANT-A.evpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::192.168.99.0::24"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:09:50", 
+                        "attributes" : {"junos:seconds" : "590"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Fictitious"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "5:172.16.0.100:10000::0::10.99.0.0::31"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "248", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "EVPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:19", 
+                        "attributes" : {"junos:seconds" : "679"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Fictitious"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/show/router1/show_version_|_display_json.txt
+++ b/snapshots/junos_evpn_type5/show/router1/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "router1"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_evpn_type5/validation/sickbay.yaml
+++ b/snapshots/junos_evpn_type5/validation/sickbay.yaml
@@ -1,0 +1,13 @@
+entries:
+  - hostname: "edge1|node1-1|router1"
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/115; https://github.com/batfish/lab-validation/issues/116; https://github.com/batfish/lab-validation/issues/117
+  - hostname: edge1
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/116
+  - hostname: "node1-1|node2-1|router1"
+    test_name: test_evpn_rib_routes
+    skip:
+      reason: https://github.com/batfish/lab-validation/issues/114; https://github.com/batfish/lab-validation/issues/116


### PR DESCRIPTION
4-node EVPN Type 5 lab collected from vJunos-router 25.4R1.12 via
containerlab. Topology: CE (edge1) -> service PE (router1) ->
spine/RR (node2-1) -> leaf/ERB (node1-1). Demonstrates EVPN Type 5
ip-prefix-routes with shared services VRF pattern, route leaking
between tenants, and eBGP-sourced routes distributed via EVPN
overlay.

Related to batfish/batfish#9843.

----

Prompt:
```
Add an EVPN Type 5 lab with shared services VRF topology, related
to batfish/batfish#9843.
```

---

**Stack**:
- #119
- #113 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*