### PR TITLE
Add junos_l3vpn lab

### DIFF
--- a/infra/examples/l3vpn/configs/pe1.cfg
+++ b/infra/examples/l3vpn/configs/pe1.cfg
@@ -1,0 +1,67 @@
+system {
+    host-name pe1;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.255.0.1/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "PE-PE link to pe2";
+        unit 0 {
+            family inet {
+                address 10.0.12.0/31;
+            }
+            family mpls;
+        }
+    }
+    ge-0/0/1 {
+        description "CE-facing interface in CUSTOMERS VRF";
+        unit 0 {
+            family inet {
+                address 10.100.1.1/24;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65000;
+    router-id 10.255.0.1;
+    static {
+        route 10.255.0.2/32 next-hop 10.0.12.1;
+    }
+}
+routing-instances {
+    CUSTOMERS {
+        instance-type vrf;
+        route-distinguisher 10.255.0.1:100;
+        vrf-target target:65000:100;
+        interface ge-0/0/1.0;
+        routing-options {
+            static {
+                route 10.100.1.0/24 discard;
+            }
+        }
+    }
+}
+protocols {
+    bgp {
+        group PE-MESH {
+            type internal;
+            local-address 10.255.0.1;
+            family inet-vpn {
+                unicast;
+            }
+            neighbor 10.255.0.2;
+        }
+    }
+    ldp {
+        interface ge-0/0/0.0;
+    }
+    mpls {
+        interface ge-0/0/0.0;
+    }
+}

--- a/infra/examples/l3vpn/configs/pe2.cfg
+++ b/infra/examples/l3vpn/configs/pe2.cfg
@@ -1,0 +1,67 @@
+system {
+    host-name pe2;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 10.255.0.2/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "PE-PE link to pe1";
+        unit 0 {
+            family inet {
+                address 10.0.12.1/31;
+            }
+            family mpls;
+        }
+    }
+    ge-0/0/1 {
+        description "CE-facing interface in CUSTOMERS VRF";
+        unit 0 {
+            family inet {
+                address 10.100.2.1/24;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65000;
+    router-id 10.255.0.2;
+    static {
+        route 10.255.0.1/32 next-hop 10.0.12.0;
+    }
+}
+routing-instances {
+    CUSTOMERS {
+        instance-type vrf;
+        route-distinguisher 10.255.0.2:100;
+        vrf-target target:65000:100;
+        interface ge-0/0/1.0;
+        routing-options {
+            static {
+                route 10.100.2.0/24 discard;
+            }
+        }
+    }
+}
+protocols {
+    bgp {
+        group PE-MESH {
+            type internal;
+            local-address 10.255.0.2;
+            family inet-vpn {
+                unicast;
+            }
+            neighbor 10.255.0.1;
+        }
+    }
+    ldp {
+        interface ge-0/0/0.0;
+    }
+    mpls {
+        interface ge-0/0/0.0;
+    }
+}

--- a/infra/examples/l3vpn/topology.clab.yml
+++ b/infra/examples/l3vpn/topology.clab.yml
@@ -1,0 +1,31 @@
+# L3VPN lab: inter-PE VPN-IPv4 route exchange
+#
+# Topology:
+#   pe1 (AS 65000) ---[ge-0/0/0]---[ge-0/0/0]--- pe2 (AS 65000)
+#     lo0: 10.255.0.1/32                           lo0: 10.255.0.2/32
+#     PE-PE link: 10.0.12.0/31
+#     VRF CUSTOMERS: ge-0/0/1, 10.100.1.0/24       VRF CUSTOMERS: ge-0/0/1, 10.100.2.0/24
+#
+# iBGP with family inet-vpn unicast between PE1 and PE2.
+# Each PE has a CUSTOMERS VRF with a static route.
+# After convergence, each PE's CUSTOMERS VRF should contain the other's
+# static route, leaked via VPN-IPv4.
+#
+# Interface mapping: containerlab ethN+1 = Junos ge-0/0/N
+
+name: l3vpn
+
+topology:
+  nodes:
+    pe1:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/pe1.cfg
+    pe2:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/pe2.cfg
+
+  links:
+    # pe1 ge-0/0/0 (eth1) <-> pe2 ge-0/0/0 (eth1)
+    - endpoints: ["pe1:eth1", "pe2:eth1"]

--- a/snapshots/junos_l3vpn/configs/pe1/show_configuration_|_display_set.txt
+++ b/snapshots/junos_l3vpn/configs/pe1/show_configuration_|_display_set.txt
@@ -1,0 +1,34 @@
+set version 25.4R1.12
+set system host-name pe1
+set system root-authentication encrypted-password "$6$Cz5G1E8L$Gdcvgg1vZbOWt2QqDeifCSzeUs38E6uQpVPoEqeGNyGkk22DTasOWPLjov2S8fWetwimK2Bf.P8Qb0Q67pgI2/"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$pO.fAtUE$bszrhdr1td5vykjvmUcHJfB9U6P5FlaFqbr7/yGOgPzwwqdDVA8nEuSDKPnCWwvu6b/C6z9Am53THXJoi6m.E1"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "PE-PE link to pe2"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.0/31
+set interfaces ge-0/0/0 unit 0 family mpls
+set interfaces ge-0/0/1 description "CE-facing interface in CUSTOMERS VRF"
+set interfaces ge-0/0/1 unit 0 family inet address 10.100.1.1/24
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 10.255.0.1/32
+set routing-instances CUSTOMERS instance-type vrf
+set routing-instances CUSTOMERS routing-options static route 10.100.1.0/24 discard
+set routing-instances CUSTOMERS interface ge-0/0/1.0
+set routing-instances CUSTOMERS route-distinguisher 10.255.0.1:100
+set routing-instances CUSTOMERS vrf-target target:65000:100
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 10.255.0.1
+set routing-options autonomous-system 65000
+set routing-options static route 10.255.0.2/32 next-hop 10.0.12.1
+set protocols bgp group PE-MESH type internal
+set protocols bgp group PE-MESH local-address 10.255.0.1
+set protocols bgp group PE-MESH family inet-vpn unicast
+set protocols bgp group PE-MESH neighbor 10.255.0.2
+set protocols ldp interface ge-0/0/0.0
+set protocols mpls interface ge-0/0/0.0

--- a/snapshots/junos_l3vpn/configs/pe2/show_configuration_|_display_set.txt
+++ b/snapshots/junos_l3vpn/configs/pe2/show_configuration_|_display_set.txt
@@ -1,0 +1,34 @@
+set version 25.4R1.12
+set system host-name pe2
+set system root-authentication encrypted-password "$6$Cz5G1E8L$Gdcvgg1vZbOWt2QqDeifCSzeUs38E6uQpVPoEqeGNyGkk22DTasOWPLjov2S8fWetwimK2Bf.P8Qb0Q67pgI2/"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$pO.fAtUE$bszrhdr1td5vykjvmUcHJfB9U6P5FlaFqbr7/yGOgPzwwqdDVA8nEuSDKPnCWwvu6b/C6z9Am53THXJoi6m.E1"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "PE-PE link to pe1"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.1/31
+set interfaces ge-0/0/0 unit 0 family mpls
+set interfaces ge-0/0/1 description "CE-facing interface in CUSTOMERS VRF"
+set interfaces ge-0/0/1 unit 0 family inet address 10.100.2.1/24
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 10.255.0.2/32
+set routing-instances CUSTOMERS instance-type vrf
+set routing-instances CUSTOMERS routing-options static route 10.100.2.0/24 discard
+set routing-instances CUSTOMERS interface ge-0/0/1.0
+set routing-instances CUSTOMERS route-distinguisher 10.255.0.2:100
+set routing-instances CUSTOMERS vrf-target target:65000:100
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 10.255.0.2
+set routing-options autonomous-system 65000
+set routing-options static route 10.255.0.1/32 next-hop 10.0.12.0
+set protocols bgp group PE-MESH type internal
+set protocols bgp group PE-MESH local-address 10.255.0.2
+set protocols bgp group PE-MESH family inet-vpn unicast
+set protocols bgp group PE-MESH neighbor 10.255.0.1
+set protocols ldp interface ge-0/0/0.0
+set protocols mpls interface ge-0/0/0.0

--- a/snapshots/junos_l3vpn/show/host_nos.txt
+++ b/snapshots/junos_l3vpn/show/host_nos.txt
@@ -1,0 +1,1 @@
+{"pe1": "junos", "pe2": "junos"}

--- a/snapshots/junos_l3vpn/show/pe1/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe1/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,505 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.255.0.2+57412"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.255.0.1+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "PE-MESH"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress AddressFamily Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-vpn-unicast"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "10.255.0.1"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "2:44", 
+                "attributes" : {"junos:seconds" : "164"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "10.255.0.2"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "10.255.0.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "local-ext-nh-color-nlri" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "bgp.l3vpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "CUSTOMERS.inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "30000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-vpn-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "27"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "27"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "164"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "291"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "228"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "CUSTOMERS.inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-vpn-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe1/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe1/show_interfaces_|_display_json.txt
@@ -1,0 +1,9464 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "PE-PE link to pe2"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:02:13:d3"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:02:13:d3"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:43 ago)", 
+                "attributes" : {"junos:seconds" : "163"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "272"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "94"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "95"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "mpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1488"
+                    }
+                    ], 
+                    "maximum-labels" : [
+                    {
+                        "data" : "3"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x10000000"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "CE-facing interface in CUSTOMERS VRF"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:43 ago)", 
+                "attributes" : {"junos:seconds" : "163"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.100.1/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.100.1.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.100.1.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:43 ago)", 
+                "attributes" : {"junos:seconds" : "163"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:43 ago)", 
+                "attributes" : {"junos:seconds" : "163"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:43 ago)", 
+                "attributes" : {"junos:seconds" : "163"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:43 ago)", 
+                "attributes" : {"junos:seconds" : "163"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:43 ago)", 
+                "attributes" : {"junos:seconds" : "163"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:43 ago)", 
+                "attributes" : {"junos:seconds" : "163"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:44 ago)", 
+                "attributes" : {"junos:seconds" : "164"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:44 ago)", 
+                "attributes" : {"junos:seconds" : "164"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:44 ago)", 
+                "attributes" : {"junos:seconds" : "164"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:55 UTC (00:02:44 ago)", 
+                "attributes" : {"junos:seconds" : "164"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "346"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:78:ad:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:ad:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:78:ad:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:06:27 UTC (00:04:12 ago)", 
+                "attributes" : {"junos:seconds" : "252"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "52991"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "96880"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "52443"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "96881"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:74:61:40:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:74:61:40:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:74:61:40:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:74:61:40:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:06:27 UTC (00:04:12 ago)", 
+                "attributes" : {"junos:seconds" : "252"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "3700"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "3759"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "3700"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "3797"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:74ff:fe61:4000"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:b4:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:78:b4:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:b4:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:78:b4:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "690"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "690"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.255.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "690"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "690"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:b4:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:78:b4:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:78:b4:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:78:b4:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe1/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe1/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe1/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe1/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe1/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe1/show_route_instance_|_display_json.txt
@@ -1,0 +1,325 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.3"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mpls.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "bgp.l3vpn.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "CUSTOMERS"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "vrf"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "CUSTOMERS.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe1/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe1/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,418 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "inet.3"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "CUSTOMERS.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.100.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:39", 
+                        "attributes" : {"junos:seconds" : "159"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "10.255.0.2"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Push 299792"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mpls.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.l3vpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.2:100:10.100.2.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:39", 
+                        "attributes" : {"junos:seconds" : "159"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "10.255.0.2"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Push 299792"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe1/show_route_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe1/show_route_|_display_json.txt
@@ -1,0 +1,1813 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:46", 
+                        "attributes" : {"junos:seconds" : "166"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:46", 
+                        "attributes" : {"junos:seconds" : "166"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:45", 
+                        "attributes" : {"junos:seconds" : "165"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "224.0.0.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "LDP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "9"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:46", 
+                        "attributes" : {"junos:seconds" : "166"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "MultiRecv"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "inet.3"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "LDP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "9"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:43", 
+                        "attributes" : {"junos:seconds" : "163"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:36", 
+                        "attributes" : {"junos:seconds" : "216"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "CUSTOMERS.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.100.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:36", 
+                        "attributes" : {"junos:seconds" : "216"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.100.1.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:45", 
+                        "attributes" : {"junos:seconds" : "165"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.100.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:39", 
+                        "attributes" : {"junos:seconds" : "159"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "10.255.0.2"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Push 299792"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mpls.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-table" : [
+                        {
+                            "data" : "inet.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0(S=0)"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-table" : [
+                        {
+                            "data" : "mpls.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Receive"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-table" : [
+                        {
+                            "data" : "inet6.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2(S=0)"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-table" : [
+                        {
+                            "data" : "mpls.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Receive"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "299776"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "LDP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "9"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:43", 
+                        "attributes" : {"junos:seconds" : "163"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Pop      "
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "299776(S=0)"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "LDP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "9"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:43", 
+                        "attributes" : {"junos:seconds" : "163"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Pop      "
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "299792"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "VPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:40", 
+                        "attributes" : {"junos:seconds" : "160"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.l3vpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.2:100:10.100.2.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:39", 
+                        "attributes" : {"junos:seconds" : "159"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "10.255.0.2"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Push 299792"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:36", 
+                        "attributes" : {"junos:seconds" : "216"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:74ff:fe61:4000/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:38", 
+                        "attributes" : {"junos:seconds" : "218"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe1/show_version_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe1/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "pe1"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe2/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe2/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,505 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.255.0.1+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.255.0.2+57412"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "PE-MESH"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "Internal"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "LocalAddress AddressFamily Rib-group Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "address-families" : [
+                {
+                    "data" : "inet-vpn-unicast"
+                }
+                ], 
+                "local-address" : [
+                {
+                    "data" : "10.255.0.2"
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "2:56", 
+                "attributes" : {"junos:seconds" : "176"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Accept"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "10.255.0.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "10.255.0.2"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65000"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "local-ext-nh-color-nlri" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "bgp.l3vpn.0"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "not advertising"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "CUSTOMERS.inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "30000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "vpn-rib-state" : [
+                {
+                    "data" : "VPN restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-vpn-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-vpn-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "2"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "176"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "310"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "228"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "CUSTOMERS.inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-vpn-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe2/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe2/show_interfaces_|_display_json.txt
@@ -1,0 +1,9464 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "PE-PE link to pe1"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:c1:e7:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:c1:e7:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:52 ago)", 
+                "attributes" : {"junos:seconds" : "172"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "296"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "91"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "101"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "mpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1488"
+                    }
+                    ], 
+                    "maximum-labels" : [
+                    {
+                        "data" : "3"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x10000000"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "CE-facing interface in CUSTOMERS VRF"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:53 ago)", 
+                "attributes" : {"junos:seconds" : "173"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-down" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.100.2/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.100.2.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.100.2.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:53 ago)", 
+                "attributes" : {"junos:seconds" : "173"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:53 ago)", 
+                "attributes" : {"junos:seconds" : "173"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:54 ago)", 
+                "attributes" : {"junos:seconds" : "174"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:54 ago)", 
+                "attributes" : {"junos:seconds" : "174"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:54 ago)", 
+                "attributes" : {"junos:seconds" : "174"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:54 ago)", 
+                "attributes" : {"junos:seconds" : "174"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:54 ago)", 
+                "attributes" : {"junos:seconds" : "174"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:54 ago)", 
+                "attributes" : {"junos:seconds" : "174"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:54 ago)", 
+                "attributes" : {"junos:seconds" : "174"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:07:56 UTC (00:02:54 ago)", 
+                "attributes" : {"junos:seconds" : "174"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "346"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:7a:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:7a:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:7a:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:06:27 UTC (00:04:23 ago)", 
+                "attributes" : {"junos:seconds" : "263"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "52565"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "96806"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "52005"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "96808"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:f6:be:d4:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:f6:be:d4:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:f6:be:d4:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:f6:be:d4:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-18 05:06:27 UTC (00:04:23 ago)", 
+                "attributes" : {"junos:seconds" : "263"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "4967"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "5126"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "5190"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "5210"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:f6ff:febe:d400"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:81:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:81:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:81:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:81:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "685"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "685"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.255.0.2"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "685"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "685"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:81:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:81:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:81:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:81:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe2/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe2/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe2/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe2/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe2/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe2/show_route_instance_|_display_json.txt
@@ -1,0 +1,325 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.3"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mpls.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "bgp.l3vpn.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "CUSTOMERS"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "vrf"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "CUSTOMERS.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe2/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe2/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,418 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "inet.3"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "CUSTOMERS.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.100.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:50", 
+                        "attributes" : {"junos:seconds" : "170"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "10.255.0.1"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Push 299792"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mpls.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.l3vpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.1:100:10.100.1.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:50", 
+                        "attributes" : {"junos:seconds" : "170"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "10.255.0.1"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Push 299792"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe2/show_route_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe2/show_route_|_display_json.txt
@@ -1,0 +1,1813 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:54", 
+                        "attributes" : {"junos:seconds" : "174"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:54", 
+                        "attributes" : {"junos:seconds" : "174"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:54", 
+                        "attributes" : {"junos:seconds" : "174"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:49", 
+                        "attributes" : {"junos:seconds" : "229"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "224.0.0.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "LDP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "9"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:55", 
+                        "attributes" : {"junos:seconds" : "175"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "MultiRecv"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "inet.3"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "LDP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "9"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:53", 
+                        "attributes" : {"junos:seconds" : "173"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:47", 
+                        "attributes" : {"junos:seconds" : "227"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:49", 
+                        "attributes" : {"junos:seconds" : "229"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:49", 
+                        "attributes" : {"junos:seconds" : "229"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "CUSTOMERS.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.100.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:49", 
+                        "attributes" : {"junos:seconds" : "169"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "10.255.0.1"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Push 299792"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.100.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:47", 
+                        "attributes" : {"junos:seconds" : "227"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.100.2.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:55", 
+                        "attributes" : {"junos:seconds" : "175"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Reject"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mpls.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-table" : [
+                        {
+                            "data" : "inet.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0(S=0)"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-table" : [
+                        {
+                            "data" : "mpls.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Receive"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-table" : [
+                        {
+                            "data" : "inet6.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2(S=0)"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-table" : [
+                        {
+                            "data" : "mpls.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "MPLS"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Receive"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "299776"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "LDP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "9"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:53", 
+                        "attributes" : {"junos:seconds" : "173"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Pop      "
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "299776(S=0)"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "LDP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "9"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:53", 
+                        "attributes" : {"junos:seconds" : "173"}
+                    }
+                    ], 
+                    "metric" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Pop      "
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "299792"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "VPN"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:51", 
+                        "attributes" : {"junos:seconds" : "171"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "bgp.l3vpn.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.255.0.1:100:10.100.1.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:49", 
+                        "attributes" : {"junos:seconds" : "169"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "learned-from" : [
+                    {
+                        "data" : "10.255.0.1"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "mpls-label" : [
+                        {
+                            "data" : "Push 299792"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:48", 
+                        "attributes" : {"junos:seconds" : "228"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:f6ff:febe:d400/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:50", 
+                        "attributes" : {"junos:seconds" : "230"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/show/pe2/show_version_|_display_json.txt
+++ b/snapshots/junos_l3vpn/show/pe2/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "pe2"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_l3vpn/validation/sickbay.yaml
+++ b/snapshots/junos_l3vpn/validation/sickbay.yaml
@@ -1,0 +1,9 @@
+entries:
+  - hostname: "pe1|pe2"
+    test_name: test_main_rib_routes
+    skip:
+      reason: https://github.com/batfish/batfish/issues/8098
+  - hostname: "pe1|pe2"
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: https://github.com/batfish/batfish/issues/8098


### PR DESCRIPTION
Two-PE L3VPN lab collected from vJunos-router 25.4R1.12 via
containerlab. PE1 and PE2 each have a CUSTOMERS VRF with a static
route, connected via a direct link with MPLS/LDP. iBGP with family
inet-vpn unicast exchanges VPN-IPv4 routes between VRFs.

Validates that VPN-IPv4 route leaking works: each PE's CUSTOMERS
VRF contains the other's static route via BGP with MPLS label push.

Sickbay: main RIB and BGP RIB tests xfailed on both PEs due to
batfish/batfish#8098 (VPNv4 address family not supported). Batfish
models the session as IPV4_UNICAST, so VRF routes are not exchanged.

----

Prompt:
```
Add a two-PE Junos L3VPN lab validating inter-PE VPN-IPv4 route
exchange over MPLS/LDP.
```