### PR TITLE
PanOS parser: replace remaining deprecated setWhitespaceChars calls

### DIFF
--- a/src/lab_validation/parsers/panos/grammar/route.py
+++ b/src/lab_validation/parsers/panos/grammar/route.py
@@ -62,13 +62,13 @@ _flags = ZeroOrMore(
 _route_line = Group(
     prefix.set_results_name("destination")
     + ip.set_results_name("nexthop")
-    + Optional(dec).setWhitespaceChars(" ").set_results_name("metric")
-    + _flags.setWhitespaceChars(" ").set_results_name("flags")
-    + Optional(dec).setWhitespaceChars(" ").set_results_name("age")
+    + Optional(dec).set_whitespace_chars(" ").set_results_name("metric")
+    + _flags.set_whitespace_chars(" ").set_results_name("flags")
+    + Optional(dec).set_whitespace_chars(" ").set_results_name("age")
     + Optional(Word(alphas, printables))
-    .setWhitespaceChars(" ")
+    .set_whitespace_chars(" ")
     .set_results_name("interface")
-    + Optional(dec).setWhitespaceChars(" ").set_results_name("next-AS")
+    + Optional(dec).set_whitespace_chars(" ").set_results_name("next-AS")
     + to_eol.set_results_name("route_line_tail")
 )
 


### PR DESCRIPTION
0565c0b (#112) missed five setWhitespaceChars occurrences in the PanOS
route grammar. Replace with set_whitespace_chars to silence
PyparsingDeprecationWarning on pyparsing 3.3.x.

----

Prompt:
```
In a recent commit, we made many changes for newer pyparsing warnings
(you can find and review it).

Still seeing:
/Users/j/src/lab-validation/src/lab_validation/parsers/panos/grammar/route.py:67:
PyparsingDeprecationWarning: 'setWhitespaceChars' deprecated
- use 'set_whitespace_chars'

Can you confirm that's the last one, and fix it?
```