### PR TITLE
Junos parser: handle iff-hardware-down and iff-device-down flags

### DIFF
--- a/src/lab_validation/parsers/junos/commands/interfaces.py
+++ b/src/lab_validation/parsers/junos/commands/interfaces.py
@@ -68,7 +68,11 @@ def _get_line(line_status: str) -> bool:
 def _get_admin_logical(
     admin_status: dict, admin: bool, line: bool
 ) -> tuple[bool, bool]:
-    if "iff-up" in admin_status:
+    if "iff-hardware-down" in admin_status:
+        return True, False
+    elif "iff-device-down" in admin_status:
+        return True, False
+    elif "iff-up" in admin_status:
         return True, True
     elif "iff-down" in admin_status:
         return False, False

--- a/tests/lab_validation/parsers/junos/commands/test_interfaces.py
+++ b/tests/lab_validation/parsers/junos/commands/test_interfaces.py
@@ -1558,6 +1558,67 @@ def test_get_admin_logical() -> None:
     assert _get_admin_logical(text, admin_physical, line_physical) == (False, False)
 
     """
+    Testing logical admin and line with value "iff-hardware-down" (e.g., IRB with no bridge members)
+    """
+
+    text = """
+    {
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ],
+                    "iff-hardware-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ],
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+    }
+    """
+    admin_physical = True
+    line_physical = True
+    text = json.loads(text)
+    text = text["if-config-flags"][0]
+    assert _get_admin_logical(text, admin_physical, line_physical) == (True, False)
+
+    """
+    Testing logical admin and line with value "iff-device-down" (parent physical interface down)
+    """
+
+    text = """
+    {
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ],
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+    }
+    """
+    admin_physical = True
+    line_physical = False
+    text = json.loads(text)
+    text = text["if-config-flags"][0]
+    assert _get_admin_logical(text, admin_physical, line_physical) == (True, False)
+
+    """
     Testing logical admin and line being inherited from physical
     """
 


### PR DESCRIPTION
The Junos interface parser treated logical interfaces with iff-up as
unconditionally up, ignoring iff-hardware-down (IRB with no active
bridge domain members) and iff-device-down (parent physical interface
down). Check these flags first so runtime data correctly reports these
interfaces as line-down to Batfish.

Prompt:
```
In our recent lab-validation work, we added a Juniper lab and we
filed https://github.com/batfish/lab-validation/issues/115. A
colleague thinks this might just be that the physical interface
didn't come up and the irb unit was hard down in the lab. Can you
investigate this?
```

---

**Stack**:
- #123
- #122 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*