### PR TITLE
junos_evpn_type5: update sickbay after batfish/batfish#9898

### DIFF
--- a/snapshots/junos_evpn_type5/validation/sickbay.yaml
+++ b/snapshots/junos_evpn_type5/validation/sickbay.yaml
@@ -2,11 +2,7 @@ entries:
   - hostname: "edge1|node1-1|router1"
     test_name: test_main_rib_routes
     skip:
-      reason: https://github.com/batfish/lab-validation/issues/115; https://github.com/batfish/lab-validation/issues/116; https://github.com/batfish/lab-validation/issues/117
-  - hostname: edge1
-    test_name: test_bgp_rib_routes
-    skip:
-      reason: https://github.com/batfish/lab-validation/issues/116
+      reason: https://github.com/batfish/lab-validation/issues/116; https://github.com/batfish/lab-validation/issues/117
   - hostname: "node1-1|node2-1|router1"
     test_name: test_evpn_rib_routes
     skip:


### PR DESCRIPTION
Remove issue #115 (connected route mismatches from hardware-down IRBs)
and the now-passing edge1 BGP RIB entry. The root cause was VLAN trunk
links down in containerlab, fixed by autostate applying to VNI VLANs.

Prompt:
```
In our recent lab-validation work, we added a Juniper lab and we
filed https://github.com/batfish/lab-validation/issues/115. A
colleague thinks this might just be that the physical interface
didn't come up and the irb unit was hard down in the lab. Can you
investigate this?
```