### PR TITLE
Improve lab_builder robustness and platform detection

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -157,6 +157,10 @@ format in `infra/examples/evpn-type5/checks.yaml` for an example.
 If no `checks.yaml` exists, manually verify the lab state by connecting to
 each node and checking:
 
+- `show configuration` — look for `## Warning: configuration block ignored:
+unsupported platform` comments, which indicate the device is silently
+  dropping config (e.g., using vJunos-router for features that need
+  vJunos-switch)
 - `show interfaces` — look for `hardware-down` flags on key interfaces
 - `show route table <vrf>.inet.0` — confirm expected routes exist
 - `show ethernet-switching vxlan-tunnel-endpoint remote` — confirm VXLAN

--- a/mypy.ini
+++ b/mypy.ini
@@ -4,12 +4,14 @@ warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = True
 
-# Ignore missing stubs for external libraries
 [mypy-cerberus.*]
 ignore_missing_imports = True
 
-[mypy-ttp.*]
+[mypy-netmiko.*]
 ignore_missing_imports = True
 
-[mypy-pybatfish.*]
+[mypy-paramiko.*]
+ignore_missing_imports = True
+
+[mypy-ttp.*]
 ignore_missing_imports = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,9 +100,8 @@ strict_equality = true
 
 [[tool.mypy.overrides]]
 module = [
-    "pandas.*",
-    "pybatfish.*",
-    "pytest.*",
+    "netmiko.*",
+    "paramiko.*",
 ]
 ignore_missing_imports = true
 

--- a/src/lab_builder/device.py
+++ b/src/lab_builder/device.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import logging
 import time
 
-from netmiko import ConnectHandler  # type: ignore[import-untyped,import-not-found]
+from netmiko import ConnectHandler
+from netmiko.exceptions import NetmikoAuthenticationException
 
 from lab_builder.models import NodeInfo
 
@@ -19,6 +21,10 @@ def connect(node: NodeInfo, timeout: int = 30) -> ConnectHandler:
         password=node.password,
         timeout=timeout,
         session_timeout=120,
+        # Containerlab containers get new host keys on each deploy.
+        ssh_strict=False,
+        system_host_keys=False,
+        alt_host_keys=False,
     )
 
 
@@ -52,12 +58,21 @@ def push_config(node: NodeInfo, config_lines: list[str]) -> str:
         conn.disconnect()
 
 
+class SshPermanentError(Exception):
+    """SSH error that will not resolve by retrying (e.g., auth failure)."""
+
+
 def check_ssh_reachable(node: NodeInfo, timeout: int = 10) -> bool:
-    """Check if SSH is reachable on a node."""
+    """Check if SSH is reachable on a node.
+
+    Raises SshPermanentError for errors that won't resolve by retrying.
+    """
     try:
         conn = connect(node, timeout=timeout)
         conn.disconnect()
         return True
+    except NetmikoAuthenticationException as e:
+        raise SshPermanentError(f"authentication failed: {e}") from e
     except Exception:
         return False
 
@@ -66,17 +81,29 @@ def wait_for_ssh(node: NodeInfo, timeout: int = 900, interval: int = 15) -> bool
     """Wait until SSH is reachable on a node.
 
     Returns True if reachable within timeout, False otherwise.
+    Raises SshPermanentError immediately on non-transient failures.
     """
+    # Suppress paramiko's transport thread tracebacks during retries.
+    # Without this, every failed SSH attempt prints a multi-line exception
+    # to stderr (from paramiko's background thread), flooding the output.
+    paramiko_logger = logging.getLogger("paramiko.transport")
+    original_level = paramiko_logger.level
+    paramiko_logger.setLevel(logging.CRITICAL)
+
     deadline = time.time() + timeout
     attempt = 0
-    while time.time() < deadline:
-        attempt += 1
-        if check_ssh_reachable(node, timeout=10):
-            print(f"  {node.name}: SSH reachable (attempt {attempt})")
-            return True
-        remaining = int(deadline - time.time())
-        print(
-            f"  {node.name}: SSH not ready (attempt {attempt}, {remaining}s remaining)"
-        )
-        time.sleep(interval)
-    return False
+    try:
+        while time.time() < deadline:
+            attempt += 1
+            if check_ssh_reachable(node, timeout=10):
+                print(f"  {node.name}: SSH reachable (attempt {attempt})")
+                return True
+            remaining = int(deadline - time.time())
+            print(
+                f"  {node.name}: SSH not ready "
+                f"(attempt {attempt}, {remaining}s remaining)"
+            )
+            time.sleep(interval)
+        return False
+    finally:
+        paramiko_logger.setLevel(original_level)

--- a/src/lab_builder/health.py
+++ b/src/lab_builder/health.py
@@ -84,6 +84,25 @@ def check_isis_up(node: NodeInfo) -> bool | None:
     return True
 
 
+def check_platform_warnings(node: NodeInfo) -> list[str]:
+    """Check for 'unsupported platform' warnings in the running config.
+
+    Junos silently ignores config blocks that aren't supported on the
+    platform (e.g., family ethernet-switching on VMX). These show up as
+    '## Warning: configuration block ignored: unsupported platform'
+    comments in 'show configuration'.
+    """
+    try:
+        output = run_command(node, "show configuration")
+    except Exception:
+        return []
+    warnings = []
+    for line in output.splitlines():
+        if "unsupported platform" in line.lower():
+            warnings.append(line.strip())
+    return warnings
+
+
 def check_node_health(node: NodeInfo) -> HealthStatus:
     """Run all health checks on a single node."""
     status = HealthStatus(node=node.name)
@@ -137,7 +156,11 @@ def wait_for_convergence(
             print(f"  {s.node}: {'OK' if s.healthy else 'WAITING'} - {s.details}")
 
         if all_healthy:
-            print("All nodes converged.")
+            print("All nodes converged. Checking for platform warnings...")
+            for node, s in zip(nodes, statuses):
+                s.platform_warnings = check_platform_warnings(node)
+                for w in s.platform_warnings:
+                    print(f"  WARNING {s.node}: {w}")
             return statuses
 
         remaining = int(deadline - time.time())

--- a/src/lab_builder/models.py
+++ b/src/lab_builder/models.py
@@ -36,11 +36,14 @@ class HealthStatus:
     bgp_established: bool | None = None  # None if BGP not configured
     ospf_full: bool | None = None
     isis_up: bool | None = None
+    platform_warnings: list[str] = field(default_factory=list)
     details: str = ""
 
     @property
     def healthy(self) -> bool:
         if not self.ssh_reachable:
+            return False
+        if self.platform_warnings:
             return False
         for status in [self.bgp_established, self.ospf_full, self.isis_up]:
             if status is False:

--- a/src/lab_builder/validate.py
+++ b/src/lab_builder/validate.py
@@ -11,7 +11,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import yaml  # type: ignore[import-untyped]
+import yaml
 
 from lab_builder.device import run_command
 from lab_builder.models import NodeInfo


### PR DESCRIPTION
SSH reliability:
- Suppress paramiko transport thread tracebacks during wait_for_ssh
retries — every failed attempt was printing a multi-line exception
to stderr, flooding the output
- Fail immediately on permanent SSH errors (e.g., authentication
failure) via SshPermanentError instead of silently retrying until
timeout
- Explicitly set ssh_strict=False, system_host_keys=False,
alt_host_keys=False to handle changed host keys after container
redeployment

Platform warnings:
- After routing protocol convergence, check `show configuration` for
"unsupported platform" warnings — Junos silently ignores config
blocks not supported on the platform (e.g., family
ethernet-switching on VMX), causing labs to appear healthy while
producing wrong data
- Platform warnings make health-check exit non-zero
- Document the platform pitfall in README and CLAUDE.md

mypy config:
- Move netmiko/paramiko ignore to pyproject.toml and mypy.ini
overrides instead of inline type:ignore comments
- Remove unnecessary overrides for pandas, pybatfish, pytest, and
yaml (all have stubs or py.typed)

Prompt:
```
We also saw that the validation script seemingly hung on errors
until I interrupted it and asked you what to do. Once it was lack
of sshpass, once it was ssh key change.
```