### PR TITLE
CI: cancel in-progress workflow runs when a PR branch is updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,10 @@ on:
         default: "prod"
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
----

Prompt:
```
There's some github mechanism to cancel earlier builds of the same
job if a new commit is pushed. Can we use that here? Specifically,
when I update a PR I want all prior builds for that branch to be
canceled.
```

---

**Stack**:
- #135
- #134 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*