### PR TITLE
validators: require annotated tuples in CostResult, remove bare-float options

### DIFF
--- a/src/lab_validation/validators/A10AcosValidator.py
+++ b/src/lab_validation/validators/A10AcosValidator.py
@@ -23,7 +23,7 @@ from lab_validation.validators.batfish_models.interface_properties import (
 from lab_validation.validators.batfish_models.routes import BgpRibRoute, MainRibRoute
 from lab_validation.validators.batfish_models.runtime_data import NodeRuntimeData
 
-from .utils.validation_utils import match_pairs, matched_pairs_to_failures
+from .utils.validation_utils import CostResult, match_pairs, matched_pairs_to_failures
 from .vendor_validator import ValidationError, VendorValidator
 
 
@@ -119,14 +119,12 @@ def _compare_all_main_rib_routes(
     return matched_pairs_to_failures(matched_routes)
 
 
-def _bgp_rib_cost(
-    a10_route: A10BgpRoute, bf_route: BgpRibRoute
-) -> list[tuple[str, float]]:
+def _bgp_rib_cost(a10_route: A10BgpRoute, bf_route: BgpRibRoute) -> CostResult:
     """Compares a single pair of A10 and Batfish BGP RIB routes, explaining any differences."""
     if a10_route.network != bf_route.network:
         return [("network", math.inf)]
 
-    ret: list[tuple[str, float]] = []
+    ret: CostResult = []
 
     if isinstance(bf_route.next_hop, NextHopDiscard):
         if a10_route.next_hop_ip != "0.0.0.0":
@@ -164,14 +162,12 @@ def _bgp_origin_type_compatible(bf: str, acos: str) -> bool:
     return bool(acos == "?")
 
 
-def _main_rib_cost(
-    a10_route: A10MainRibRoute, bf_route: MainRibRoute
-) -> list[tuple[str, float]]:
+def _main_rib_cost(a10_route: A10MainRibRoute, bf_route: MainRibRoute) -> CostResult:
     """Compares a single pair of A10 and Batfish main RIB routes, explaining any differences."""
     if a10_route.network != bf_route.network:
         return [("network", math.inf)]
 
-    ret: list[tuple[str, float]] = []
+    ret: CostResult = []
     ret += _main_rib_protocol_cost(a10_route, bf_route)
     if any(cost == math.inf for reason, cost in ret):
         # Stop if we found inf already
@@ -193,7 +189,7 @@ _bf_kernel_route_tags = {"N": 1, "VF": 2, "V": 3, "F": 4}
 
 def _main_rib_protocol_cost(
     a10_route: A10MainRibRoute, bf_route: MainRibRoute
-) -> list[tuple[str, float]]:
+) -> CostResult:
     """Compares the protocol fields, explaining any differences."""
     # show ip route acos routes (in Batfish as kernel route with specific tag)
     if a10_route.protocol == "N":
@@ -238,9 +234,7 @@ def _main_rib_protocol_cost(
     return [("protocol", math.inf)]
 
 
-def _main_rib_nexthop_cost(
-    a10_route: A10MainRibRoute, next_hop: NextHop
-) -> list[tuple[str, float]]:
+def _main_rib_nexthop_cost(a10_route: A10MainRibRoute, next_hop: NextHop) -> CostResult:
     """Compares the next hops, explaining any differences."""
 
     if a10_route.protocol in _bf_kernel_route_tags.keys():

--- a/src/lab_validation/validators/AristaValidator.py
+++ b/src/lab_validation/validators/AristaValidator.py
@@ -29,7 +29,7 @@ from lab_validation.parsers.arista.models.routes import (
 from .batfish_models.interface_properties import InterfaceProperties
 from .batfish_models.routes import BgpRibRoute, EvpnRibRoute, MainRibRoute
 from .batfish_models.runtime_data import InterfaceRuntimeData, NodeRuntimeData
-from .utils.validation_utils import match_pairs, matched_pairs_to_failures
+from .utils.validation_utils import CostResult, match_pairs, matched_pairs_to_failures
 from .vendor_validator import VendorValidator
 
 
@@ -109,7 +109,7 @@ class AristaValidator(VendorValidator):
     def _diff_routes_cost(
         arista_route: AristaIpRoute,
         batfish_route: MainRibRoute,
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         if arista_route.network != batfish_route.network:
             return [("network", math.inf)]
         if arista_route.vrf != batfish_route.vrf:
@@ -147,7 +147,7 @@ class AristaValidator(VendorValidator):
     @staticmethod
     def compute_protocol_cost(
         arista_protocol: str, batfish_protocol: str
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         """Computes the cost related to protocol differences in Main RIB."""
         if arista_protocol == batfish_protocol:
             return []
@@ -171,7 +171,7 @@ class AristaValidator(VendorValidator):
     @staticmethod
     def compute_next_hop_cost(
         arista_route: AristaIpRoute, next_hop: NextHop
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         """Computes the cost related to next hops."""
         if isinstance(next_hop, NextHopVtep):
             if not arista_route.vni or not arista_route.vtep_ip:
@@ -289,7 +289,7 @@ class AristaValidator(VendorValidator):
     def _diff_bgp_routes_cost(
         arista_route: AristaBgpRoute,
         batfish_route: BgpRibRoute,
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         if arista_route.network != batfish_route.network:
             return [("network", math.inf)]
         if arista_route.vrf != batfish_route.vrf:
@@ -424,7 +424,7 @@ class AristaValidator(VendorValidator):
     def _diff_evpn_routes_cost(
         arista_route: AristaEvpnRoute,
         batfish_route: EvpnRibRoute,
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         if arista_route.network != batfish_route.network:
             return [("network", math.inf)]
         if arista_route.vrf != batfish_route.vrf:

--- a/src/lab_validation/validators/CumulusFrrValidator.py
+++ b/src/lab_validation/validators/CumulusFrrValidator.py
@@ -19,7 +19,7 @@ from lab_validation.validators.batfish_models.runtime_data import (
     NodeRuntimeData,
 )
 
-from .utils.validation_utils import match_pairs, matched_pairs_to_failures
+from .utils.validation_utils import CostResult, match_pairs, matched_pairs_to_failures
 from .vendor_validator import VendorValidator
 
 
@@ -196,59 +196,55 @@ class CumulusFrrValidator(VendorValidator):
         return parse_show_ip_route_vrf_all_json(routes_text)
 
     @staticmethod
-    def _diff_routes_cost(show_route: FrrIpRoute, batfish_route: MainRibRoute) -> float:
-        cost = 0.0
-        # return infinite cost if prefix does not match
+    def _diff_routes_cost(
+        show_route: FrrIpRoute, batfish_route: MainRibRoute
+    ) -> CostResult:
         if show_route.network != batfish_route.network:
-            return math.inf
-        if show_route.protocol != batfish_route.protocol:
-            cost += compute_protocol_cost(show_route.protocol, batfish_route.protocol)
+            return [("network", math.inf)]
+
+        cost: CostResult = []
+        cost += compute_protocol_cost(show_route.protocol, batfish_route.protocol)
 
         if show_route.metric != batfish_route.metric:
-            cost += 1.0
+            cost.append(("metric", 1.0))
         if show_route.admin_distance != batfish_route.admin:
-            cost += 1.0
+            cost.append(("admin", 1.0))
         if show_route.vrf != batfish_route.vrf:
-            cost += 1.0
+            cost.append(("vrf", 1.0))
         cost += compute_next_hop_cost(show_route, batfish_route.next_hop)
 
         return cost
 
 
-def compute_next_hop_cost(frr_route: FrrIpRoute, next_hop: NextHop) -> float:
-    """Returns a cost based on the next-hops of the routes. Takes into account null route, ip, and interface."""
+def compute_next_hop_cost(frr_route: FrrIpRoute, next_hop: NextHop) -> CostResult:
     if frr_route.blackhole and isinstance(next_hop, NextHopDiscard):
-        # Both null routes, don't compare anything else
-        return 0.0
+        return []
     if frr_route.blackhole or isinstance(next_hop, NextHopDiscard):
-        # Null route and non-null route are dang incompatible
-        return 10.0
+        return [("next_hop", 10.0)]
 
     if isinstance(next_hop, NextHopIp):
         if frr_route.next_hop_ip != next_hop.ip:
-            return 1.0
-        return 0.0
+            return [("next_hop_ip", 1.0)]
+        return []
     # For static routes with only next-hop IP, FRR includes the resolved interface,
     # so do not check that it's not present.
 
     if isinstance(next_hop, NextHopInterface):
-        cost = 0.0
+        cost: CostResult = []
         if frr_route.next_hop_int != next_hop.interface:
-            # Different interfaces, not a match.
-            cost += 3.0
+            cost.append(("next_hop_int", 3.0))
         if next_hop.ip and frr_route.next_hop_ip != next_hop.ip:
-            cost += 1.0
+            cost.append(("next_hop_ip", 1.0))
         return cost
 
     raise ValueError("Unsupported next hop " + repr(next_hop))
 
 
-def compute_protocol_cost(real_protocol: str, batfish_protocol: str) -> float:
+def compute_protocol_cost(real_protocol: str, batfish_protocol: str) -> CostResult:
     if real_protocol == batfish_protocol:
-        return 0.0
+        return []
     if real_protocol == "bgp" and batfish_protocol in {"bgp", "ibgp"}:
-        # Show data doesn't distinguish different BGP types
-        return 0.0
+        return []
     if real_protocol == "ospf" and batfish_protocol in {
         "ospf",
         "ospfE1",
@@ -256,6 +252,5 @@ def compute_protocol_cost(real_protocol: str, batfish_protocol: str) -> float:
         "ospfIA",
         "ospfIS",
     }:
-        # Show data doesn't distinguish different OSPF types
-        return 0.0
-    return math.inf
+        return []
+    return [("protocol", math.inf)]

--- a/src/lab_validation/validators/IosValidator.py
+++ b/src/lab_validation/validators/IosValidator.py
@@ -23,7 +23,7 @@ from lab_validation.validators.batfish_models.interface_properties import (
 from lab_validation.validators.batfish_models.routes import BgpRibRoute, MainRibRoute
 from lab_validation.validators.batfish_models.runtime_data import NodeRuntimeData
 
-from .utils.validation_utils import match_pairs, matched_pairs_to_failures
+from .utils.validation_utils import CostResult, match_pairs, matched_pairs_to_failures
 from .vendor_validator import VendorValidator
 
 
@@ -123,34 +123,33 @@ class IosValidator(VendorValidator):
     @staticmethod
     def _diff_bgp_routes_cost(
         ios_route_and_vrf: tuple[str, IosBgpRoute], bf_route: BgpRibRoute
-    ) -> float:
-        # return infinite cost if vrf or network subnet does not match
+    ) -> CostResult:
         expected_vrf = ios_route_and_vrf[0]
         if expected_vrf != bf_route.vrf:
-            return math.inf
+            return [("vrf", math.inf)]
         ios_route = ios_route_and_vrf[1]
         if ios_route.network != bf_route.network:
-            return math.inf
+            return [("network", math.inf)]
 
-        cost = 0.0
+        cost: CostResult = []
 
         if bf_route.metric != ios_route.metric:
-            cost += 1.0
+            cost.append(("metric", 1.0))
 
         if bf_route.local_preference != ios_route.local_preference:
-            cost += 1.0
+            cost.append(("local_preference", 1.0))
 
         if bf_route.weight != ios_route.weight:
-            cost += 1.0
+            cost.append(("weight", 1.0))
 
         if bf_route.as_path != ios_route.as_path:
             # TODO Better AS path comparison
-            cost += 1.0
+            cost.append(("as_path", 1.0))
 
         if not IosValidator._bgp_origin_type_compatible(
             bf_route.origin_type, ios_route.origin_type
         ):
-            cost += 1.0
+            cost.append(("origin_type", 1.0))
 
         cost += IosValidator.compute_bgp_nexthop_cost(ios_route, bf_route.next_hop)
 
@@ -161,19 +160,23 @@ class IosValidator(VendorValidator):
         return r.weight == 32768 and r.next_hop_ip == "0.0.0.0"
 
     @staticmethod
-    def compute_bgp_nexthop_cost(ios_route: IosBgpRoute, next_hop: NextHop) -> float:
+    def compute_bgp_nexthop_cost(
+        ios_route: IosBgpRoute, next_hop: NextHop
+    ) -> CostResult:
         if isinstance(next_hop, NextHopDiscard):
             if IosValidator.is_local_route(ios_route):
-                return 0.0
-            return 10.0
+                return []
+            return [("next_hop", 10.0)]
 
         if isinstance(next_hop, NextHopIp):
-            return 0.0 if ios_route.next_hop_ip == next_hop.ip else 1.0
+            if ios_route.next_hop_ip == next_hop.ip:
+                return []
+            return [("next_hop_ip", 1.0)]
 
         if isinstance(next_hop, NextHopVrf):
             # It's indistinguishable in IOS show data, trust Batfish.
             # TODO: We simply need to not build labs where the same route is originated in different VRFs.
-            return 0.0
+            return []
 
         raise ValueError("Unsupported next hop " + repr(next_hop))
 
@@ -229,94 +232,84 @@ class IosValidator(VendorValidator):
     @staticmethod
     def _diff_routes_cost(
         expected_route: IosIpRoute, batfish_route: MainRibRoute
-    ) -> float:
-        cost = 0.0
+    ) -> CostResult:
         if expected_route.network != batfish_route.network:
-            return math.inf
+            return [("network", math.inf)]
         if expected_route.vrf != batfish_route.vrf:
-            return math.inf
+            return [("vrf", math.inf)]
 
-        if expected_route.protocol != batfish_route.protocol:
-            cost += IosValidator.compute_protocol_cost(
-                expected_route.protocol, batfish_route.protocol
-            )
+        cost: CostResult = []
+
+        cost += IosValidator.compute_protocol_cost(
+            expected_route.protocol, batfish_route.protocol
+        )
         if expected_route.metric != batfish_route.metric:
             if expected_route.protocol == "ospfIS":
                 # IOS doesn't put metric in the show output for these routes.
                 pass
             else:
-                cost += 1.0
+                cost.append(("metric", 1.0))
         if expected_route.admin != batfish_route.admin:
             if expected_route.protocol == "ospfIS":
                 # IOS doesn't put AD in the show output for these routes.
                 pass
             else:
-                cost += 1.0
+                cost.append(("admin", 1.0))
 
         cost += IosValidator._next_hop_cost(expected_route, batfish_route.next_hop)
 
         return cost
 
     @staticmethod
-    def _next_hop_cost(ios_route: IosIpRoute, next_hop: NextHop) -> float:
-        """Returns the cost of the next-hop difference."""
+    def _next_hop_cost(ios_route: IosIpRoute, next_hop: NextHop) -> CostResult:
         if isinstance(next_hop, NextHopDiscard):
             if ios_route.next_hop_int == "Null0":
-                return 0.0
-            # Next-hop mismatch - IOS is not null routed.
-            return 10.0
+                return []
+            return [("next_hop", 10.0)]
         elif ios_route.next_hop_int == "Null0":
-            # Next-hop mismatch - Batfish is not null routed.
-            return 10.0
+            return [("next_hop", 10.0)]
 
         if isinstance(next_hop, NextHopInterface):
-            cost = 0.0
+            cost: CostResult = []
             if (
                 ios_route.next_hop_int is None
                 or ios_route.next_hop_int.lower() != next_hop.interface.lower()
             ):
-                cost += 1.0
+                cost.append(("next_hop_int", 1.0))
             if next_hop.ip is not None and next_hop.ip != ios_route.next_hop_ip:
-                cost += 1.0
+                cost.append(("next_hop_ip", 1.0))
             return cost
 
         if isinstance(next_hop, NextHopIp):
             if next_hop.ip != ios_route.next_hop_ip:
-                return 1.0
-            return 0.0
+                return [("next_hop_ip", 1.0)]
+            return []
 
         if isinstance(next_hop, NextHopVrf):
             if next_hop.vrf != ios_route.vrf:
-                return 5.0
-            return 0.0
+                return [("next_hop_vrf", 5.0)]
+            return []
 
         raise ValueError("Unsupported next hop " + repr(next_hop))
 
     @staticmethod
-    def compute_protocol_cost(ios_protocol: str, batfish_protocol: str) -> float:
-        """
-        Computes the protocol cost, given that they are not equal.
-        Return 0, when ios is bgp and batfish is bgp sub-types as ios does provide bgp sub-type info.
-        Return 1, when protocols are from ospf sub-types.
-        Return math.inf, when they are totally different protocols. Examples bgp & ospf, ospf & eigrp etc...
-        :param ios_protocol:
-        :param batfish_protocol:
-        :return: cost
-        """
+    def compute_protocol_cost(ios_protocol: str, batfish_protocol: str) -> CostResult:
+        if ios_protocol == batfish_protocol:
+            return []
 
         # IOS does not provide granular(IBGP/EBGP) info. IOS will only show `bgp`, while Batfish will say IBGP.
         if ios_protocol == "bgp" and batfish_protocol in {"ibgp", "bgp"}:
-            return 0.0
+            return []
 
         # Both IOS and Batfish model OSPF subtype. So if they disagree, return 1.
         ospf_sub_types = {"ospf", "ospfE1", "ospfE2", "ospfIA"}
         if ios_protocol in ospf_sub_types and batfish_protocol in ospf_sub_types:
-            return 1.0
+            return [("protocol", 1.0)]
 
         # Both IOS and Batfish model EIGRP subtype. So if they disagree, return 1.
         eigrp_sub_types = {"eigrp", "eigrpEX"}
         if ios_protocol in eigrp_sub_types and batfish_protocol in eigrp_sub_types:
-            return 1.0
+            return [("protocol", 1.0)]
 
         # Protocols are completely different. (TODO: update when we have labs with other protocols that have subtypes)
-        return math.inf
+        return [("protocol", math.inf)]

--- a/src/lab_validation/validators/IosXrValidator.py
+++ b/src/lab_validation/validators/IosXrValidator.py
@@ -33,6 +33,7 @@ from lab_validation.validators.batfish_models.runtime_data import (
 )
 
 from .utils.validation_utils import (
+    CostResult,
     match_pairs,
     matched_pairs_to_failures,
     preprocess_batfish_bgp_route,
@@ -109,7 +110,7 @@ class IosXrValidator(VendorValidator):
     @staticmethod
     def _diff_routes_cost(
         xr_route: IosXrRoute, batfish_route: MainRibRoute
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         if xr_route.network != batfish_route.network:
             return [("network", math.inf)]
         if xr_route.vrf != batfish_route.vrf:
@@ -146,9 +147,7 @@ class IosXrValidator(VendorValidator):
         return cost
 
     @staticmethod
-    def compute_protocol_cost(
-        xr_protocol: str, batfish_protocol: str
-    ) -> list[tuple[str, float]]:
+    def compute_protocol_cost(xr_protocol: str, batfish_protocol: str) -> CostResult:
         """
         Computes the protocol cost, given that they are not equal.
         Return [], when ios xr is bgp and batfish is bgp sub-types as ios xr does not provide bgp sub-type info.
@@ -183,9 +182,7 @@ class IosXrValidator(VendorValidator):
         return [("protocol", math.inf)]
 
     @staticmethod
-    def compute_next_hop_cost(
-        xr_route: IosXrRoute, next_hop: NextHop
-    ) -> list[tuple[str, float]]:
+    def compute_next_hop_cost(xr_route: IosXrRoute, next_hop: NextHop) -> CostResult:
         """Computes cost related to next hops."""
         if isinstance(next_hop, NextHopVrf):
             if xr_route.next_hop_vrf != next_hop.vrf:
@@ -382,7 +379,7 @@ class IosXrValidator(VendorValidator):
     @staticmethod
     def _diff_bgp_routes_cost(
         expected_route_and_vrf: tuple[str, IosXrBgpRoute], batfish_route: BgpRibRoute
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         # return infinite cost if vrf or network subnet does not match
         expected_vrf = expected_route_and_vrf[0]
         if expected_vrf != batfish_route.vrf:
@@ -419,7 +416,7 @@ class IosXrValidator(VendorValidator):
     @staticmethod
     def compute_bgp_nexthop_cost(
         expected_route: IosXrBgpRoute, batfish_route: BgpRibRoute
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         if (
             batfish_route.next_hop_ip is None
             and batfish_route.next_hop_int == "null_interface"

--- a/src/lab_validation/validators/JunosValidator.py
+++ b/src/lab_validation/validators/JunosValidator.py
@@ -41,7 +41,7 @@ from lab_validation.validators.batfish_models.runtime_data import (
     NodeRuntimeData,
 )
 
-from .utils.validation_utils import match_pairs, matched_pairs_to_failures
+from .utils.validation_utils import CostResult, match_pairs, matched_pairs_to_failures
 from .vendor_validator import VendorValidator
 
 
@@ -368,13 +368,13 @@ class JunosValidator(VendorValidator):
 
 def _bgp_routes_cost(
     real_route: JunosBgpRoute, batfish_route: BgpRibRoute
-) -> list[tuple[str, float]]:
+) -> CostResult:
     if real_route.network != batfish_route.network:
         return [("network", math.inf)]
     if real_route.vrf != batfish_route.vrf:
         return [("vrf", math.inf)]
 
-    cost: list[tuple[str, float]] = []
+    cost: CostResult = []
     real_metric = 0 if real_route.metric is None else real_route.metric
 
     # When Batfish shows ibgp and device shows BGP, the route was learned
@@ -405,61 +405,41 @@ def _bgp_routes_cost(
 
 def _routes_cost(
     expected_route: JunosMainRibRoute, batfish_route: MainRibRoute
-) -> float:
-    """A cost function between Juniper show routes and Batfish routes for the main RIB"""
-
-    # Different networks, different VRFs, are wholly incompatible.
+) -> CostResult:
     if expected_route.network != batfish_route.network:
-        return math.inf
+        return [("network", math.inf)]
     if expected_route.vrf != batfish_route.vrf:
-        return math.inf
+        return [("vrf", math.inf)]
 
-    cost = 0.0
+    cost: CostResult = []
 
     cost += _compute_protocol_cost(expected_route, batfish_route)
     cost += _compute_nexthop_cost(expected_route, batfish_route.next_hop)
 
     if (expected_route.metric or 0) != batfish_route.metric:
-        cost += 1.0
+        cost.append(("metric", 1.0))
     if expected_route.admin != batfish_route.admin:
-        cost += 1.0
+        cost.append(("admin", 1.0))
 
     return cost
 
 
 def _compute_protocol_cost(
     expected_route: JunosMainRibRoute, batfish_route: MainRibRoute
-) -> float:
-    if expected_route.protocol == "Direct":
-        if batfish_route.protocol == "connected":
-            return 0.0
-        return math.inf
-    if expected_route.protocol == "Local":
-        if batfish_route.protocol == "local":
-            return 0.0
-        return math.inf
-    if expected_route.protocol == "Aggregate":
-        if batfish_route.protocol == "aggregate":
-            return 0.0
-        return math.inf
-    if expected_route.protocol == "Static":
-        if batfish_route.protocol == "static":
-            return 0.0
-        return math.inf
-    if expected_route.protocol == "BGP":
-        if batfish_route.protocol in {"bgp", "ibgp"}:
-            return 0.0
-        return math.inf
-    if expected_route.protocol == "EVPN":
-        if batfish_route.protocol in {"bgp", "ibgp"}:
-            return 0.0
-        return math.inf
-    if expected_route.protocol == "OSPF":
-        if batfish_route.protocol in {"ospf", "ospfE1", "ospfE2", "ospfIA", "ospfIS"}:
-            return 0.0
-        return math.inf
-
-    return math.inf
+) -> CostResult:
+    _PROTOCOL_MAP = {
+        "Direct": {"connected"},
+        "Local": {"local"},
+        "Aggregate": {"aggregate"},
+        "Static": {"static"},
+        "BGP": {"bgp", "ibgp"},
+        "EVPN": {"bgp", "ibgp"},
+        "OSPF": {"ospf", "ospfE1", "ospfE2", "ospfIA", "ospfIS"},
+    }
+    valid = _PROTOCOL_MAP.get(expected_route.protocol)
+    if valid is not None and batfish_route.protocol in valid:
+        return []
+    return [("protocol", math.inf)]
 
 
 def _is_mgmt_iface(junos_name: str | None) -> bool:
@@ -471,54 +451,43 @@ def _is_mgmt_iface(junos_name: str | None) -> bool:
 
 def _compute_nexthop_cost(
     expected_route: JunosMainRibRoute, next_hop: NextHop
-) -> float:
+) -> CostResult:
     if _is_mgmt_iface(expected_route.next_hop_int) and isinstance(
         next_hop, NextHopDiscard
     ):
-        # Batfish creates null discard routes for down management interfaces.
-        return 0.0
+        return []
 
     if expected_route.nh_type in {"Discard", "Reject"} and isinstance(
         next_hop, NextHopDiscard
     ):
-        return 0.0
+        return []
     if expected_route.nh_type in {"Discard", "Reject"} or isinstance(
         next_hop, NextHopDiscard
     ):
-        # Only one is null-routed.
-        return 10.0
+        return [("next_hop", 10.0)]
 
     if isinstance(next_hop, NextHopIp):
         if expected_route.protocol in ("Static", "BGP", "EVPN"):
             # Junos recursively resolves next-hops to underlay addresses while
-            # Batfish reports the protocol-level next-hop. For Static routes
-            # this was always the case. For BGP/EVPN it manifests in overlay
-            # topologies: e.g., a VRF BGP route with Batfish next-hop
-            # 172.16.0.100 (iBGP peer loopback) appears on Junos with
-            # next-hop 172.16.254.1 (the underlay physical hop toward that
-            # loopback). The IPs are in different address planes so comparing
-            # them would always produce false mismatches.
-            return 0.0
+            # Batfish reports the protocol-level next-hop.
+            return []
         elif expected_route.next_hop_ip == next_hop.ip:
-            return 0.0
+            return []
         else:
-            return 1.0
+            return [("next_hop_ip", 1.0)]
 
     if isinstance(next_hop, NextHopInterface):
-        cost = 0.0
+        cost: CostResult = []
         if expected_route.next_hop_int != next_hop.interface:
-            cost += 5.0
+            cost.append(("next_hop_int", 5.0))
         if next_hop.ip is not None and expected_route.next_hop_ip != next_hop.ip:
-            cost += 1.0
+            cost.append(("next_hop_ip", 1.0))
         return cost
 
     if isinstance(next_hop, NextHopVtep):
         # NextHopVtep carries the VTEP IP and VNI, but Junos resolves EVPN
-        # routes to underlay physical next-hops (e.g., VTEP 172.16.0.100
-        # resolves to 172.16.254.1 via ge-0/0/1.0). The device's next_hop_ip
-        # is the resolved underlay address, not the VTEP, so they can't be
-        # meaningfully compared.
-        return 0.0
+        # routes to underlay physical next-hops.
+        return []
 
     raise ValueError("Unsupported next hop " + repr(next_hop))
 

--- a/src/lab_validation/validators/NxosValidator.py
+++ b/src/lab_validation/validators/NxosValidator.py
@@ -25,7 +25,7 @@ from lab_validation.validators.batfish_models.runtime_data import (
     NodeRuntimeData,
 )
 
-from .utils.validation_utils import match_pairs, matched_pairs_to_failures
+from .utils.validation_utils import CostResult, match_pairs, matched_pairs_to_failures
 from .vendor_validator import VendorValidator
 
 
@@ -102,7 +102,7 @@ class NxosValidator(VendorValidator):
     @staticmethod
     def _diff_routes_cost(
         batfish_route: MainRibRoute, nxos_route: NxosMainRibRoute
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         if nxos_route.network != batfish_route.network:
             return [("network", math.inf)]
         if nxos_route.vrf != batfish_route.vrf:
@@ -145,7 +145,7 @@ class NxosValidator(VendorValidator):
     @staticmethod
     def _diff_bgp_routes_cost(
         batfish_route: BgpRibRoute, nxos_route: NxosBgpRoute
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         if nxos_route.network != batfish_route.network:
             return [("network", math.inf)]
         if nxos_route.vrf != batfish_route.vrf:
@@ -182,7 +182,7 @@ class NxosValidator(VendorValidator):
     @staticmethod
     def _diff_bgp_next_hop_cost(
         next_hop: NextHop, nxos_route: NxosBgpRoute
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         cost = []
         if isinstance(next_hop, NextHopDiscard):
             if nxos_route.next_hop_ip != "0.0.0.0":
@@ -307,9 +307,7 @@ class NxosValidator(VendorValidator):
         return parse_show_ip_bgp_all(file_text)
 
     @staticmethod
-    def compute_protocol_cost(
-        nxos_protocol: str, batfish_protocol: str
-    ) -> list[tuple[str, float]]:
+    def compute_protocol_cost(nxos_protocol: str, batfish_protocol: str) -> CostResult:
         """Computes the cost related to protocol differences in Main RIB."""
         batfish_protocol = batfish_protocol
         if nxos_protocol == batfish_protocol:
@@ -336,7 +334,7 @@ class NxosValidator(VendorValidator):
     @staticmethod
     def compute_bgp_protocol_cost(
         nxos_protocol: str, batfish_protocol: str
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         """Computes the cost related to protocol differences in BGP RIB."""
         batfish_protocol = batfish_protocol
         if nxos_protocol == batfish_protocol:
@@ -351,7 +349,7 @@ class NxosValidator(VendorValidator):
     @staticmethod
     def compute_next_hop_cost(
         nxos_route: NxosMainRibRoute, next_hop: NextHop
-    ) -> list[tuple[str, float]]:
+    ) -> CostResult:
         """Computes the cost related to next hops."""
         if isinstance(next_hop, NextHopVtep):
             # We judge if nxos_route is learned via EVPN using the evpn field

--- a/src/lab_validation/validators/PanosValidator.py
+++ b/src/lab_validation/validators/PanosValidator.py
@@ -13,7 +13,7 @@ from lab_validation.validators.batfish_models.interface_properties import (
 from lab_validation.validators.batfish_models.routes import BgpRibRoute, MainRibRoute
 from lab_validation.validators.batfish_models.runtime_data import NodeRuntimeData
 
-from .utils.validation_utils import match_pairs, matched_pairs_to_failures
+from .utils.validation_utils import CostResult, match_pairs, matched_pairs_to_failures
 from .vendor_validator import ValidationError, VendorValidator
 
 
@@ -63,33 +63,37 @@ class PanosValidator(VendorValidator):
     @staticmethod
     def _diff_routes_cost(
         expected_route: PanosMainRibRoute, batfish_route: MainRibRoute
-    ) -> float:
-        cost = 0.0
+    ) -> CostResult:
         expected_network_tokens = expected_route.network.split("/")
         batfish_network_tokens = batfish_route.network.split("/")
-        # return infinite cost if vrf or network subnet does not match
         if expected_network_tokens[0] != batfish_network_tokens[0]:
-            return math.inf
+            return [("network", math.inf)]
         if expected_route.virtual_router != batfish_route.vrf:
-            return math.inf
+            return [("vrf", math.inf)]
+
+        cost: CostResult = []
 
         if expected_network_tokens[1] != batfish_network_tokens[1]:
-            cost += abs(
-                float(expected_network_tokens[1]) - float(batfish_network_tokens[1])
+            cost.append(
+                (
+                    "prefix_length",
+                    abs(
+                        float(expected_network_tokens[1])
+                        - float(batfish_network_tokens[1])
+                    ),
+                )
             )
 
-        expected_protocol = expected_route.get_protocol()
-        if expected_protocol != batfish_route.protocol:
-            cost += PanosValidator.compute_protocol_cost(
-                expected_protocol, batfish_route.protocol
-            )
+        cost += PanosValidator.compute_protocol_cost(
+            expected_route.get_protocol(), batfish_route.protocol
+        )
 
         if expected_route.metric != batfish_route.metric:
             # show data metric missing(none) means 0. So, skipping that case
             if expected_route.metric is None and batfish_route.metric == 0:
                 pass
             else:
-                cost += 1.0
+                cost.append(("metric", 1.0))
 
         cost += PanosValidator.compute_nexthop_cost(
             expected_route, batfish_route.next_hop
@@ -100,47 +104,41 @@ class PanosValidator(VendorValidator):
     @staticmethod
     def compute_nexthop_cost(
         expected_route: PanosMainRibRoute, next_hop: NextHop
-    ) -> float:
-        # null route section
+    ) -> CostResult:
         if expected_route.next_hop_ip == "discard" and isinstance(
             next_hop, NextHopDiscard
         ):
-            return 0.0
+            return []
         elif expected_route.next_hop_ip == "discard" or isinstance(
             next_hop, NextHopDiscard
         ):
-            # Only one is null-routed.
-            return 10.0
+            return [("next_hop", 10.0)]
 
-        # nh_ip section
         if isinstance(next_hop, NextHopIp):
             if expected_route.next_hop_ip == next_hop.ip:
-                return 0.0
-            return 1.0
+                return []
+            return [("next_hop_ip", 1.0)]
 
         if isinstance(next_hop, NextHopInterface):
-            cost = 0.0
+            cost: CostResult = []
             if next_hop.interface != expected_route.next_hop_int:
                 if "H" not in expected_route.flags:
                     # PanOS Host routes (local routes) do not have the interface listed
-                    cost += 1.0
+                    cost.append(("next_hop_int", 1.0))
             if next_hop.ip is not None and next_hop.ip != expected_route.next_hop_ip:
-                cost += 1.0
+                cost.append(("next_hop_ip", 1.0))
             return cost
 
         raise ValueError("Unsupported next hop " + repr(next_hop))
 
     @staticmethod
-    def compute_protocol_cost(panos_protocol: str, batfish_protocol: str) -> float:
-        """
-        Computes the protocol cost, given that they are not equal.
-        Return math.inf when they are totally different protocols. Examples bgp & ospf, ospf & eigrp etc...
-        """
+    def compute_protocol_cost(panos_protocol: str, batfish_protocol: str) -> CostResult:
+        if panos_protocol == batfish_protocol:
+            return []
 
         # Return 0 when panos is bgp and batfish is bgp sub-type; panos does not provide bgp sub-type info.
         if panos_protocol == "bgp" and batfish_protocol in {"ibgp", "bgp"}:
-            return 0.0
+            return []
 
         # TODO: Add cases for more protocols (e.g. OSPF, EIGRP) as PAN showparser supports them.
-        # Protocols are completely different.
-        return math.inf
+        return [("protocol", math.inf)]

--- a/src/lab_validation/validators/utils/validation_utils.py
+++ b/src/lab_validation/validators/utils/validation_utils.py
@@ -3,7 +3,6 @@ from collections.abc import Callable, Sequence
 from typing import (
     Any,
     TypeVar,
-    Union,
 )
 
 import attr
@@ -12,24 +11,14 @@ from ..batfish_models.routes import BgpRibRoute
 
 T = TypeVar("T")
 S = TypeVar("S")
-CostResult = Union[Sequence[tuple[str, float] | float], float]
+CostItem = tuple[str, float]
+CostResult = list[CostItem]
 CostFn = Callable[[S, T], CostResult]
 
 
 def cost_total(left: S, right: T, cost: CostFn) -> float:
-    """Returns the total cost after applying the given cost function to left and right.
-
-    Handles all the union complexities of CostFn."""
-    result: CostResult = cost(left, right)
-    if isinstance(result, float):
-        return result
-    ret = 0.0
-    for c in result:
-        if isinstance(c, float):
-            ret += c
-        else:
-            ret += c[1]
-    return ret
+    """Returns the total cost after applying the given cost function to left and right."""
+    return sum(c for _, c in cost(left, right))
 
 
 def match_pairs(
@@ -70,7 +59,7 @@ def match_pairs(
             None,
         )
         if matched_left is not None:
-            result.append((matched_left, r, 0))
+            result.append((matched_left, r, []))
             used_left.append(matched_left)
             used_right.add(r)
 
@@ -92,9 +81,9 @@ def match_pairs(
             result.append((l, best_right, cost(l, best_right)))
             used_right.add(best_right)
         else:
-            result.append((l, None, math.inf))
+            result.append((l, None, [("unmatched", math.inf)]))
     for r in set(right) - used_right:
-        result.append((None, r, math.inf))
+        result.append((None, r, [("unmatched", math.inf)]))
     return result
 
 

--- a/tests/lab_validation/validators/test_CumulusFrrValidator.py
+++ b/tests/lab_validation/validators/test_CumulusFrrValidator.py
@@ -158,7 +158,9 @@ def test_diff_routes_cost_nhint_mismatch() -> None:
         metric=0,
         admin=0,
     )
-    assert CumulusFrrValidator._diff_routes_cost(show_route, batfish_route) == 3.0
+    assert CumulusFrrValidator._diff_routes_cost(show_route, batfish_route) == [
+        ("next_hop_int", 3.0)
+    ]
 
 
 def test_diff_routes_cost_blackhole_match() -> None:
@@ -182,7 +184,7 @@ def test_diff_routes_cost_blackhole_match() -> None:
         metric=0,
         admin=0,
     )
-    assert CumulusFrrValidator._diff_routes_cost(show_route, batfish_route) == 0.0
+    assert CumulusFrrValidator._diff_routes_cost(show_route, batfish_route) == []
 
 
 def test_diff_routes_cost_blackhole_mismatch() -> None:
@@ -206,7 +208,9 @@ def test_diff_routes_cost_blackhole_mismatch() -> None:
         metric=0,
         admin=0,
     )
-    assert CumulusFrrValidator._diff_routes_cost(show_route, batfish_route) == 10.0
+    assert CumulusFrrValidator._diff_routes_cost(show_route, batfish_route) == [
+        ("next_hop", 10.0)
+    ]
 
 
 def test_diff_routes_cost_nhint_ignore() -> None:
@@ -230,7 +234,7 @@ def test_diff_routes_cost_nhint_ignore() -> None:
         metric=0,
         admin=1,
     )
-    assert CumulusFrrValidator._diff_routes_cost(show_route, batfish_route) == 0.0
+    assert CumulusFrrValidator._diff_routes_cost(show_route, batfish_route) == []
 
 
 def test_show_route_processed_update_vrf() -> None:
@@ -291,7 +295,7 @@ def test_match_pairs_single_route_equal() -> None:
         match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
             0
         ][2]
-        == 0
+        == []
     )
 
 
@@ -322,12 +326,9 @@ def test_match_pairs_single_route_not_equal() -> None:
         ),
     ]
 
-    assert (
-        match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
-            0
-        ][2]
-        == math.inf
-    )
+    assert match_pairs(
+        show_route, batfish_route, CumulusFrrValidator._diff_routes_cost
+    )[0][2] == [("unmatched", math.inf)]
 
 
 def test_match_pairs_single_route_attribute_mismatch() -> None:
@@ -358,12 +359,9 @@ def test_match_pairs_single_route_attribute_mismatch() -> None:
         ),
     ]
 
-    assert (
-        match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
-            0
-        ][2]
-        == 2
-    )
+    assert match_pairs(
+        show_route, batfish_route, CumulusFrrValidator._diff_routes_cost
+    )[0][2] == [("metric", 1.0), ("admin", 1.0)]
 
 
 def test_match_pairs_ecmp_route_equal() -> None:
@@ -416,13 +414,13 @@ def test_match_pairs_ecmp_route_equal() -> None:
         match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
             0
         ][2]
-        == 0
+        == []
     )
     assert (
         match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
             1
         ][2]
-        == 0
+        == []
     )
 
 
@@ -472,18 +470,12 @@ def test_match_pairs_ecmp_route_not_equal() -> None:
             tag=None,
         ),
     ]
-    assert (
-        match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
-            0
-        ][2]
-        == 2
-    )
-    assert (
-        match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
-            1
-        ][2]
-        == 2
-    )
+    assert match_pairs(
+        show_route, batfish_route, CumulusFrrValidator._diff_routes_cost
+    )[0][2] == [("metric", 1.0), ("admin", 1.0)]
+    assert match_pairs(
+        show_route, batfish_route, CumulusFrrValidator._diff_routes_cost
+    )[1][2] == [("metric", 1.0), ("admin", 1.0)]
 
 
 def test_match_pairs_static_route_ip() -> None:
@@ -518,7 +510,7 @@ def test_match_pairs_static_route_ip() -> None:
         match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
             0
         ][2]
-        == 0
+        == []
     )
 
 
@@ -554,24 +546,24 @@ def test_match_pairs_static_route_interface() -> None:
         match_pairs(show_route, batfish_route, CumulusFrrValidator._diff_routes_cost)[
             0
         ][2]
-        == 0
+        == []
     )
 
 
 def test_compute_protocol_cost() -> None:
     """Test the custom protocol differ."""
-    assert compute_protocol_cost("connected", "connected") == 0
+    assert compute_protocol_cost("connected", "connected") == []
 
-    assert compute_protocol_cost("static", "static") == 0
+    assert compute_protocol_cost("static", "static") == []
 
-    assert compute_protocol_cost("bgp", "bgp") == 0
-    assert compute_protocol_cost("bgp", "ibgp") == 0
+    assert compute_protocol_cost("bgp", "bgp") == []
+    assert compute_protocol_cost("bgp", "ibgp") == []
 
-    assert compute_protocol_cost("ospf", "ospf") == 0
-    assert compute_protocol_cost("ospf", "ospfIA") == 0
-    assert compute_protocol_cost("ospf", "ospfE1") == 0
-    assert compute_protocol_cost("ospf", "ospfE2") == 0
-    assert compute_protocol_cost("ospf", "ospfIS") == 0
+    assert compute_protocol_cost("ospf", "ospf") == []
+    assert compute_protocol_cost("ospf", "ospfIA") == []
+    assert compute_protocol_cost("ospf", "ospfE1") == []
+    assert compute_protocol_cost("ospf", "ospfE2") == []
+    assert compute_protocol_cost("ospf", "ospfIS") == []
 
-    assert compute_protocol_cost("ospf", "bgp") == math.inf
-    assert compute_protocol_cost("connected", "static") == math.inf
+    assert compute_protocol_cost("ospf", "bgp") == [("protocol", math.inf)]
+    assert compute_protocol_cost("connected", "static") == [("protocol", math.inf)]

--- a/tests/lab_validation/validators/test_iosValidator.py
+++ b/tests/lab_validation/validators/test_iosValidator.py
@@ -38,7 +38,7 @@ def test_bgp_equal() -> None:
         as_path=(1, 2),
         origin_type="e",
     )
-    assert IosValidator._diff_bgp_routes_cost(("default", ios), bf) == 0
+    assert IosValidator._diff_bgp_routes_cost(("default", ios), bf) == []
 
 
 def test_bgp_equal_local_routes() -> None:
@@ -68,7 +68,7 @@ def test_bgp_equal_local_routes() -> None:
         as_path=(),
         origin_type="?",
     )
-    assert IosValidator._diff_bgp_routes_cost(("default", ios), bf) == 0
+    assert IosValidator._diff_bgp_routes_cost(("default", ios), bf) == []
 
 
 def test_bgp_not_equal() -> None:
@@ -99,8 +99,9 @@ def test_bgp_not_equal() -> None:
         as_path=(1, 2, 3),
         origin_type="i",
     )
-    # Accumulates a difference cost of 4 (AS path, local pref, origin type, metric, weight)
-    assert IosValidator._diff_bgp_routes_cost(("default", ios), bf) == 5
+    # 5 mismatches: metric, local_preference, weight, as_path, origin_type
+    result = IosValidator._diff_bgp_routes_cost(("default", ios), bf)
+    assert len(result) == 5
 
 
 def test_origin_types() -> None:
@@ -235,9 +236,9 @@ def test_diff_routes_cost_nhint_dynamic() -> None:
         metric=0,
         admin=1,
     )
-    assert (
-        IosValidator._diff_routes_cost(expected_route, batfish_route) == 1
-    )  # next hop IP
+    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == [
+        ("next_hop_ip", 1.0)
+    ]  # next hop IP
 
 
 def test_compat_routes_null() -> None:
@@ -259,7 +260,7 @@ def test_compat_routes_null() -> None:
         metric=0,
         admin=0,
     )
-    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == 0
+    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == []
 
 
 def test_diff_routes_cost_null() -> None:
@@ -281,9 +282,9 @@ def test_diff_routes_cost_null() -> None:
         metric=0,
         admin=0,
     )
-    assert (
-        IosValidator._diff_routes_cost(expected_route, batfish_route) == 10.0
-    )  # only one side null
+    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == [
+        ("next_hop", 10.0)
+    ]  # only one side null
 
 
 def test_diff_routes_cost_nhint_ignore() -> None:
@@ -305,7 +306,7 @@ def test_diff_routes_cost_nhint_ignore() -> None:
         metric=0,
         admin=1,
     )
-    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == 0
+    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == []
 
 
 def test_diff_routes_cost_skip_ibgp_comparision() -> None:
@@ -330,7 +331,7 @@ def test_diff_routes_cost_skip_ibgp_comparision() -> None:
         metric=0,
         admin=200,
     )
-    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == 0
+    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == []
 
 
 def test_diff_routes_cost_route_in_multiple_vrf() -> None:
@@ -355,7 +356,9 @@ def test_diff_routes_cost_route_in_multiple_vrf() -> None:
         metric=0,
         admin=20,
     )
-    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == math.inf
+    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == [
+        ("vrf", math.inf)
+    ]
 
 
 def test_ospf_summary_ignores_ad_and_metric() -> None:
@@ -378,18 +381,18 @@ def test_ospf_summary_ignores_ad_and_metric() -> None:
         admin=20,
     )
     # Ignore different admin, metric
-    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == 0
+    assert IosValidator._diff_routes_cost(expected_route, batfish_route) == []
 
 
 def test_compute_protocol_cost() -> None:
     result = IosValidator.compute_protocol_cost("bgp", "ibgp")
-    assert result == 0.0
+    assert result == []
 
     result = IosValidator.compute_protocol_cost("ospf", "ospfE1")
-    assert result == 1.0
+    assert result == [("protocol", 1.0)]
 
     result = IosValidator.compute_protocol_cost("eigrp", "eigrpEX")
-    assert result == 1.0
+    assert result == [("protocol", 1.0)]
 
     result = IosValidator.compute_protocol_cost("bgp", "ospf")
-    assert result == math.inf
+    assert result == [("protocol", math.inf)]

--- a/tests/lab_validation/validators/test_junosValidator.py
+++ b/tests/lab_validation/validators/test_junosValidator.py
@@ -53,28 +53,32 @@ def test_routes_cost() -> None:
         vrf="vrf",
     )
     # Routes are compatible
-    assert _routes_cost(junos_route, batfish_route) == 0.0
+    assert _routes_cost(junos_route, batfish_route) == []
 
     # Wrong vrf -> routes are incompatible
-    assert _routes_cost(junos_route, attr.evolve(batfish_route, vrf="vrf2")) == math.inf
+    assert _routes_cost(junos_route, attr.evolve(batfish_route, vrf="vrf2")) == [
+        ("vrf", math.inf)
+    ]
 
     # Wrong network -> routes are incompatible
-    assert (
-        _routes_cost(junos_route, attr.evolve(batfish_route, network="1.1.1.1/30"))
-        == math.inf
-    )
+    assert _routes_cost(
+        junos_route, attr.evolve(batfish_route, network="1.1.1.1/30")
+    ) == [("network", math.inf)]
 
     # Wrong protocol -> routes are incompatible
-    assert (
-        _routes_cost(junos_route, attr.evolve(batfish_route, protocol="ospf"))
-        == math.inf
-    )
+    assert _routes_cost(junos_route, attr.evolve(batfish_route, protocol="ospf")) == [
+        ("protocol", math.inf)
+    ]
 
     # Wrong metric -> routes are incompatible
-    assert _routes_cost(junos_route, attr.evolve(batfish_route, metric=5)) == 1.0
+    assert _routes_cost(junos_route, attr.evolve(batfish_route, metric=5)) == [
+        ("metric", 1.0)
+    ]
 
     # Wrong admin -> routes are incompatible
-    assert _routes_cost(junos_route, attr.evolve(batfish_route, admin=5)) == 1.0
+    assert _routes_cost(junos_route, attr.evolve(batfish_route, admin=5)) == [
+        ("admin", 1.0)
+    ]
 
 
 def test_nexthop_cost_static_routes() -> None:
@@ -91,31 +95,25 @@ def test_nexthop_cost_static_routes() -> None:
         active=True,
     )
     # Batfish NHIP routes are compatible with Junos routes that have a resolved NHINT
-    assert _compute_nexthop_cost(junos_route, NextHopIp(ip="10.12.1.1")) == 0.0
+    assert _compute_nexthop_cost(junos_route, NextHopIp(ip="10.12.1.1")) == []
     # Since Batfish shows protocol NHOP while Junos shows resolved, cannot enforce
     # that they appear equal
-    assert _compute_nexthop_cost(junos_route, NextHopIp(ip="10.12.1.2")) == 0.0
+    assert _compute_nexthop_cost(junos_route, NextHopIp(ip="10.12.1.2")) == []
 
     # Also compatible if it's a Batfish NHINT + NHIP route.
     assert (
         _compute_nexthop_cost(
             junos_route, NextHopInterface(interface="xe-0/0/1.0", ip="10.12.1.1")
         )
-        == 0.0
+        == []
     )
     # Incompatible if either NHIP or NHINT is wrong
-    assert (
-        _compute_nexthop_cost(
-            junos_route, NextHopInterface(interface="xe-0/0/1.1", ip="10.12.1.1")
-        )
-        == 5.0
-    )
-    assert (
-        _compute_nexthop_cost(
-            junos_route, NextHopInterface(interface="xe-0/0/1.0", ip="10.12.1.2")
-        )
-        == 1.0
-    )
+    assert _compute_nexthop_cost(
+        junos_route, NextHopInterface(interface="xe-0/0/1.1", ip="10.12.1.1")
+    ) == [("next_hop_int", 5.0)]
+    assert _compute_nexthop_cost(
+        junos_route, NextHopInterface(interface="xe-0/0/1.0", ip="10.12.1.2")
+    ) == [("next_hop_ip", 1.0)]
 
 
 def test_nexthop_cost_ospf_routes() -> None:
@@ -136,16 +134,13 @@ def test_nexthop_cost_ospf_routes() -> None:
         _compute_nexthop_cost(
             junos_route, NextHopInterface(interface="xe-0/0/1.0", ip="2.2.2.2")
         )
-        == 0.0
+        == []
     )
 
     # next-hop interface does not match
-    assert (
-        _compute_nexthop_cost(
-            junos_route, NextHopInterface(interface="xe-0/0/1.1", ip="2.2.2.2")
-        )
-        == 5.0
-    )
+    assert _compute_nexthop_cost(
+        junos_route, NextHopInterface(interface="xe-0/0/1.1", ip="2.2.2.2")
+    ) == [("next_hop_int", 5.0)]
 
 
 def test_nexthop_cost_discard() -> None:
@@ -162,12 +157,11 @@ def test_nexthop_cost_discard() -> None:
         active=True,
     )
     # Batfish null routes are compatible with junos null routes
-    assert _compute_nexthop_cost(junos_route, NextHopDiscard()) == 0.0
+    assert _compute_nexthop_cost(junos_route, NextHopDiscard()) == []
     # Not a null route -> incompatible
-    assert (
-        _compute_nexthop_cost(junos_route, NextHopInterface(interface="xe-0/1/0.0"))
-        == 10.0
-    )
+    assert _compute_nexthop_cost(
+        junos_route, NextHopInterface(interface="xe-0/1/0.0")
+    ) == [("next_hop", 10.0)]
 
 
 def test_nexthop_cost_reject() -> None:
@@ -185,12 +179,11 @@ def test_nexthop_cost_reject() -> None:
     )
 
     # Batfish null aggregates are compatible with junos null routes
-    assert _compute_nexthop_cost(junos_route, NextHopDiscard()) == 0.0
+    assert _compute_nexthop_cost(junos_route, NextHopDiscard()) == []
     # Not a null route -> incompatible
-    assert (
-        _compute_nexthop_cost(junos_route, NextHopInterface(interface="xe-0/1/0.0"))
-        == 10.0
-    )
+    assert _compute_nexthop_cost(
+        junos_route, NextHopInterface(interface="xe-0/1/0.0")
+    ) == [("next_hop", 10.0)]
 
 
 def test_protocol_cost() -> None:
@@ -216,12 +209,11 @@ def test_protocol_cost() -> None:
     )
 
     # Static and static work
-    assert _compute_protocol_cost(junos_static, bf_static) == 0.0
+    assert _compute_protocol_cost(junos_static, bf_static) == []
     # Static and not static doesn't
-    assert (
-        _compute_protocol_cost(junos_static, attr.evolve(bf_static, protocol="ospf"))
-        == math.inf
-    )
+    assert _compute_protocol_cost(
+        junos_static, attr.evolve(bf_static, protocol="ospf")
+    ) == [("protocol", math.inf)]
 
     # Direct and connected work
     junos_direct = attr.evolve(junos_static, protocol="Direct")
@@ -229,19 +221,19 @@ def test_protocol_cost() -> None:
         _compute_protocol_cost(
             junos_direct, attr.evolve(bf_static, protocol="connected")
         )
-        == 0.0
+        == []
     )
     # Direct and static doesn't
-    assert _compute_protocol_cost(junos_direct, bf_static) == math.inf
+    assert _compute_protocol_cost(junos_direct, bf_static) == [("protocol", math.inf)]
 
     # Local and Local work
     junos_local = attr.evolve(junos_static, protocol="Local")
     assert (
         _compute_protocol_cost(junos_local, attr.evolve(bf_static, protocol="local"))
-        == 0.0
+        == []
     )
     # Local and static doesn't
-    assert _compute_protocol_cost(junos_local, bf_static) == math.inf
+    assert _compute_protocol_cost(junos_local, bf_static) == [("protocol", math.inf)]
 
     # Aggregate and aggregate work
     junos_aggregate = attr.evolve(junos_static, protocol="Aggregate")
@@ -249,47 +241,48 @@ def test_protocol_cost() -> None:
         _compute_protocol_cost(
             junos_aggregate, attr.evolve(bf_static, protocol="aggregate")
         )
-        == 0.0
+        == []
     )
     # Aggregate and static doesn't
-    assert _compute_protocol_cost(junos_aggregate, bf_static) == math.inf
+    assert _compute_protocol_cost(junos_aggregate, bf_static) == [
+        ("protocol", math.inf)
+    ]
 
     # BGP and bgp/ibgp
     junos_bgp = attr.evolve(junos_static, protocol="BGP")
     assert (
-        _compute_protocol_cost(junos_bgp, attr.evolve(bf_static, protocol="bgp")) == 0.0
+        _compute_protocol_cost(junos_bgp, attr.evolve(bf_static, protocol="bgp")) == []
     )
     assert (
-        _compute_protocol_cost(junos_bgp, attr.evolve(bf_static, protocol="ibgp"))
-        == 0.0
+        _compute_protocol_cost(junos_bgp, attr.evolve(bf_static, protocol="ibgp")) == []
     )
     # BGP and static doesn't
-    assert _compute_protocol_cost(junos_bgp, bf_static) == math.inf
+    assert _compute_protocol_cost(junos_bgp, bf_static) == [("protocol", math.inf)]
 
     # OSPF and ospf*
     junos_ospf = attr.evolve(junos_static, protocol="OSPF")
     assert (
         _compute_protocol_cost(junos_ospf, attr.evolve(bf_static, protocol="ospf"))
-        == 0.0
+        == []
     )
     assert (
         _compute_protocol_cost(junos_ospf, attr.evolve(bf_static, protocol="ospfIA"))
-        == 0.0
+        == []
     )
     assert (
         _compute_protocol_cost(junos_ospf, attr.evolve(bf_static, protocol="ospfIS"))
-        == 0.0
+        == []
     )
     assert (
         _compute_protocol_cost(junos_ospf, attr.evolve(bf_static, protocol="ospfE1"))
-        == 0.0
+        == []
     )
     assert (
         _compute_protocol_cost(junos_ospf, attr.evolve(bf_static, protocol="ospfE2"))
-        == 0.0
+        == []
     )
     # OSPF and static doesn't
-    assert _compute_protocol_cost(junos_ospf, bf_static) == math.inf
+    assert _compute_protocol_cost(junos_ospf, bf_static) == [("protocol", math.inf)]
 
 
 def test_get_interface_runtime_date() -> None:

--- a/tests/lab_validation/validators/test_panosValidator.py
+++ b/tests/lab_validation/validators/test_panosValidator.py
@@ -28,7 +28,7 @@ def test_diff_routes_cost_nhint_ignore() -> None:
         metric=0,
         admin=1,
     )
-    assert PanosValidator._diff_routes_cost(expected_route, batfish_route) == 0
+    assert PanosValidator._diff_routes_cost(expected_route, batfish_route) == []
 
 
 def test_diff_routes_cost_skip_ibgp_comparision() -> None:
@@ -54,7 +54,7 @@ def test_diff_routes_cost_skip_ibgp_comparision() -> None:
         metric=0,
         admin=1,
     )
-    assert PanosValidator._diff_routes_cost(expected_route, batfish_route) == 0
+    assert PanosValidator._diff_routes_cost(expected_route, batfish_route) == []
 
 
 def test_diff_routes_cost_route_in_multiple_vrf() -> None:
@@ -80,15 +80,17 @@ def test_diff_routes_cost_route_in_multiple_vrf() -> None:
         metric=0,
         admin=1,
     )
-    assert PanosValidator._diff_routes_cost(expected_route, batfish_route) == math.inf
+    assert PanosValidator._diff_routes_cost(expected_route, batfish_route) == [
+        ("vrf", math.inf)
+    ]
 
 
 def test_compute_protocol_cost() -> None:
     result = PanosValidator.compute_protocol_cost("bgp", "ibgp")
-    assert result == 0.0
+    assert result == []
 
     result = PanosValidator.compute_protocol_cost("bgp", "ospf")
-    assert result == math.inf
+    assert result == [("protocol", math.inf)]
 
 
 def test_compute_nexthop_cost_local() -> None:
@@ -106,7 +108,7 @@ def test_compute_nexthop_cost_local() -> None:
     result = PanosValidator.compute_nexthop_cost(
         real_route, NextHopInterface(interface="ethernet1/1")
     )
-    assert result == 0.0
+    assert result == []
 
 
 def test_compute_nexthop_cost_connected() -> None:
@@ -124,13 +126,13 @@ def test_compute_nexthop_cost_connected() -> None:
     result = PanosValidator.compute_nexthop_cost(
         real_route, NextHopInterface(interface="ethernet1/1")
     )
-    assert result == 0.0
+    assert result == []
 
     # not compatible_nh: connected
     result = PanosValidator.compute_nexthop_cost(
         real_route, NextHopInterface(interface="ethernet1/2")
     )
-    assert result == 1.0
+    assert result == [("next_hop_int", 1.0)]
 
 
 def test_compute_nexthop_cost_static_null() -> None:
@@ -146,13 +148,13 @@ def test_compute_nexthop_cost_static_null() -> None:
         next_AS=None,
     )
     result = PanosValidator.compute_nexthop_cost(real_route, NextHopDiscard())
-    assert result == 0.0
+    assert result == []
 
     # not compatible_nh: static null
     result = PanosValidator.compute_nexthop_cost(
         real_route, NextHopInterface(interface="ethernet2/2", ip="11.22.33.44")
     )
-    assert result == 10.0
+    assert result == [("next_hop", 10.0)]
 
 
 def test_compute_nexthop_cost_static() -> None:
@@ -170,21 +172,21 @@ def test_compute_nexthop_cost_static() -> None:
     result = PanosValidator.compute_nexthop_cost(
         real_route, NextHopInterface(interface="ethernet1/1", ip="1.2.3.4")
     )
-    assert result == 0.0
+    assert result == []
 
     # compatible_nh: static route using next_hop ip
     result = PanosValidator.compute_nexthop_cost(
         real_route,
         NextHopIp(ip="1.2.3.4"),
     )
-    assert result == 0.0
+    assert result == []
 
     # not compatible_nh: static
     result = PanosValidator.compute_nexthop_cost(
         real_route,
         NextHopInterface(interface="ethernet2/2", ip="11.22.33.44"),
     )
-    assert result == 2.0
+    assert result == [("next_hop_int", 1.0), ("next_hop_ip", 1.0)]
 
 
 def test_compute_nexthop_cost_bgp() -> None:
@@ -200,13 +202,13 @@ def test_compute_nexthop_cost_bgp() -> None:
         next_AS=None,
     )
     result = PanosValidator.compute_nexthop_cost(real_route, NextHopIp(ip="1.2.3.4"))
-    assert result == 0.0
+    assert result == []
 
     # not compatible_nh: bgp
     result = PanosValidator.compute_nexthop_cost(
         real_route, NextHopIp(ip="11.22.33.44")
     )
-    assert result == 1.0
+    assert result == [("next_hop_ip", 1.0)]
 
 
 def test_diff_routes_cost_metric_none() -> None:
@@ -230,10 +232,9 @@ def test_diff_routes_cost_metric_none() -> None:
         metric=0,
         admin=20,
     )
-    assert PanosValidator._diff_routes_cost(real_route, bf_route) == 0.0
+    assert PanosValidator._diff_routes_cost(real_route, bf_route) == []
 
     # test metric real = none & batfish = 10
-    assert (
-        PanosValidator._diff_routes_cost(real_route, attr.evolve(bf_route, metric=10))
-        == 1.0
-    )
+    assert PanosValidator._diff_routes_cost(
+        real_route, attr.evolve(bf_route, metric=10)
+    ) == [("metric", 1.0)]

--- a/tests/lab_validation/validators/utils/test_validation_utils.py
+++ b/tests/lab_validation/validators/utils/test_validation_utils.py
@@ -1,4 +1,5 @@
 import math
+from typing import Any
 
 import attr
 from pybatfish.datamodel import NextHopInterface, NextHopIp
@@ -83,9 +84,9 @@ def test_match_pairs_same_count() -> None:
     ]
     matched_pairs = match_pairs(left, right, IosValidator._diff_routes_cost)
     assert matched_pairs == [
-        (left[0], None, math.inf),
-        (left[1], right[0], 2),  # metric and admin
-        (None, right[1], math.inf),
+        (left[0], None, [("unmatched", math.inf)]),
+        (left[1], right[0], [("metric", 1.0), ("admin", 1.0)]),
+        (None, right[1], [("unmatched", math.inf)]),
     ]
 
 
@@ -128,9 +129,9 @@ def test_match_pairs_more_in_left() -> None:
         (
             left[0],
             right[0],
-            2.0,
+            [("next_hop_int", 1.0), ("next_hop_ip", 1.0)],
         ),  # cost 2 (for next hop IP and interface)
-        (left[1], None, math.inf),
+        (left[1], None, [("unmatched", math.inf)]),
     ]
 
 
@@ -197,9 +198,9 @@ def test_match_pairs_duplicate_route_in_different_vrf() -> None:
 
     matched_pairs = match_pairs(left, right, IosValidator._diff_routes_cost)
     assert matched_pairs == [
-        (left[2], right[0], 0.0),
-        (left[0], right[2], 1.0),
-        (left[1], right[1], 1.0),
+        (left[2], right[0], []),
+        (left[0], right[2], [("next_hop_ip", 1.0)]),
+        (left[1], right[1], [("next_hop_ip", 1.0)]),
     ]
 
 
@@ -242,21 +243,21 @@ def test_matched_routes_to_failures() -> None:
             admin=1,
         ),
     )
-    matched_routes: list[tuple[IosIpRoute, MainRibRoute, float]] = [
-        (ios_route1, batfish_route1, 1.0),
-        (ios_route2, None, math.inf),
+    matched_routes: list[tuple[IosIpRoute | None, MainRibRoute | None, Any]] = [
+        (ios_route1, batfish_route1, [("next_hop_ip", 1.0)]),
+        (ios_route2, None, [("unmatched", math.inf)]),
         (
             None,
             batfish_route2,
             math.inf,
         ),
-        (batfish_route1, batfish_route1, 0.0),
+        (batfish_route1, batfish_route1, []),
         (batfish_route2, batfish_route2, []),
     ]
 
     failures = matched_pairs_to_failures(matched_routes)
     assert failures == {
-        f"Left_element: {ios_route1}": f"Right_element: {batfish_route1} (cost 1.0)",
+        f"Left_element: {ios_route1}": f"Right_element: {batfish_route1} (cost {[('next_hop_ip', 1.0)]})",
         f"Left_element: {ios_route2}": "No_match_found_on_the_right",
         f"Right_element: {batfish_route2}": "No_match_found_on_the_left",
     }
@@ -308,8 +309,8 @@ def test_match_pairs_perfectly_match_right() -> None:
     matched_pairs = match_pairs(left, right, IosValidator._diff_routes_cost)
     # right[0] should get its perfect match even though it is the best match for left[0]
     assert matched_pairs == [
-        (left[1], right[0], 0.0),
-        (left[0], right[1], 1.0),
+        (left[1], right[0], []),
+        (left[0], right[1], [("metric", 1.0)]),
     ]
 
 


### PR DESCRIPTION
CostResult was `Union[Sequence[tuple[str, float] | float], float]`,
which let implementations return bare floats with no labels. Tighten
to `list[CostItem]` where `CostItem = tuple[str, float]`, so every
cost component carries a descriptive label.

Convert the five cost functions that returned bare float
(IOS, PanOS, Cumulus/FRR, Junos main RIB) and their helpers to
return labeled tuples. Simplify cost_total from a 10-line
union-handling function to a one-liner.

----

Prompt:
```
Can we refactor CostResult to get rid of any options that just
let implementations use float? Always require annotated tuples
```

Also:
```
I see list[tuple[str, float]] everywhere. Can we add, and use
throughout, type aliases for tuple[str, float] and
list[THATTHING]?
```