### PR TITLE
ec2-launch: add --images flag to filter which images are loaded

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -358,7 +358,13 @@ For spot pricing (~70% cheaper), add `--spot`.
 --key-name NAME        Use existing EC2 key pair (auto-created if omitted)
 --timeout-hours N      Auto-terminate after N hours (default: 4)
 --spot                 Request spot instance
+--images FILTER        Comma-separated list of images to load (default: all)
+                       Available: ceos, vjunos-router, vjunos-switch, vjunos-evolved
 ```
+
+For example, `--images ceos` loads only the Arista cEOS image, skipping
+the large Juniper VM images and reducing bootstrap time from ~5 min to
+~2 min.
 
 ### Cost Safety
 

--- a/infra/ec2-launch.sh
+++ b/infra/ec2-launch.sh
@@ -31,6 +31,7 @@ INSTANCE_TYPE="m8i.2xlarge"
 KEY_NAME=""
 TIMEOUT_HOURS=4
 USE_SPOT=false
+IMAGE_FILTER="all"
 SECURITY_GROUP_NAME="lab-validation-containerlab"
 
 usage() {
@@ -44,6 +45,8 @@ Options:
   --key-name NAME        Existing EC2 key pair name (auto-created if omitted)
   --timeout-hours N      Auto-terminate after N hours (default: 4)
   --spot                 Request a spot instance (~70% cheaper, may be interrupted)
+  --images FILTER        Comma-separated list of images to load (default: all)
+                         Available: ceos, vjunos-router, vjunos-switch, vjunos-evolved, all
   --help                 Show this help
 
 Environment:
@@ -59,6 +62,7 @@ while [[ $# -gt 0 ]]; do
         --key-name) KEY_NAME="$2"; shift 2 ;;
         --timeout-hours) TIMEOUT_HOURS="$2"; shift 2 ;;
         --spot) USE_SPOT=true; shift ;;
+        --images) IMAGE_FILTER="$2"; shift 2 ;;
         --help) usage ;;
         *) echo "Unknown option: $1" >&2; usage ;;
     esac
@@ -220,9 +224,11 @@ else
     fi
 fi
 
-# Generate user-data script with bucket name baked in
+# Generate user-data script with parameters baked in
 USER_DATA_FILE=$(mktemp)
-sed "s|%%BUCKET_NAME%%|${BUCKET_NAME}|g" "${SCRIPT_DIR}/ec2-setup.sh" > "${USER_DATA_FILE}"
+sed -e "s|%%BUCKET_NAME%%|${BUCKET_NAME}|g" \
+    -e "s|%%IMAGE_FILTER%%|${IMAGE_FILTER}|g" \
+    "${SCRIPT_DIR}/ec2-setup.sh" > "${USER_DATA_FILE}"
 
 # Build run-instances command
 RUN_ARGS=(
@@ -314,6 +320,7 @@ echo "============================================"
 echo "Instance ID:  ${INSTANCE_ID}"
 echo "Public IP:    ${PUBLIC_IP}"
 echo "Instance type: ${INSTANCE_TYPE}"
+echo "Images:       ${IMAGE_FILTER}"
 echo "Auto-terminate: ${EXPIRY}"
 echo ""
 echo "SSH command:"

--- a/infra/ec2-setup.sh
+++ b/infra/ec2-setup.sh
@@ -18,12 +18,23 @@
 set -euo pipefail
 
 BUCKET_NAME="%%BUCKET_NAME%%"
+IMAGE_FILTER="%%IMAGE_FILTER%%"
 
 LOG_FILE="/var/log/ec2-setup.log"
 exec > >(tee -a "${LOG_FILE}") 2>&1
 
 echo "=== ec2-setup.sh starting at $(date -u) ==="
 echo "Image bucket: ${BUCKET_NAME}"
+echo "Image filter: ${IMAGE_FILTER}"
+
+# Check if an image tag matches the filter.
+# Usage: image_wanted <tag>  (e.g., image_wanted "vjunos-router")
+# Returns 0 (true) if the filter is "all" or contains the tag.
+image_wanted() {
+    local tag="$1"
+    [[ "${IMAGE_FILTER}" == "all" ]] && return 0
+    echo ",${IMAGE_FILTER}," | grep -q ",${tag},"
+}
 
 export DEBIAN_FRONTEND=noninteractive
 
@@ -83,6 +94,18 @@ DOCKER_TARBALLS=$(aws s3 ls "s3://${BUCKET_NAME}/docker-images/" 2>/dev/null \
 if [[ -n "${DOCKER_TARBALLS}" ]]; then
     # Strategy 1: Load pre-built Docker images
     for tarball in ${DOCKER_TARBALLS}; do
+        # Derive image tag from tarball name for filtering
+        case "${tarball}" in
+            vjunos-router*) image_tag="vjunos-router" ;;
+            vjunos-switch*) image_tag="vjunos-switch" ;;
+            vjunos*evolved*) image_tag="vjunos-evolved" ;;
+            *veos*|*arista*) image_tag="veos" ;;
+            *) image_tag="unknown" ;;
+        esac
+        if ! image_wanted "${image_tag}"; then
+            echo "Skipping ${tarball} (not in filter: ${IMAGE_FILTER})"
+            continue
+        fi
         echo "Loading Docker image: ${tarball}"
         aws s3 cp "s3://${BUCKET_NAME}/docker-images/${tarball}" - | gunzip | docker load
     done
@@ -102,15 +125,22 @@ else
 
             case "${qcow2}" in
                 vJunos-router-*|vjunos-router-*)
+                    image_tag="vjunos-router"
                     dest="/home/ubuntu/vrnetlab/juniper/vjunosrouter" ;;
                 vJunosEvolved-*|vjunosevolved-*)
+                    image_tag="vjunos-evolved"
                     dest="/home/ubuntu/vrnetlab/juniper/vjunosevolved" ;;
                 vJunos-switch-*|vjunosswitch-*)
+                    image_tag="vjunos-switch"
                     dest="/home/ubuntu/vrnetlab/juniper/vjunosswitch" ;;
                 *)
                     echo "  Unknown image type: ${qcow2}, skipping"
                     continue ;;
             esac
+            if ! image_wanted "${image_tag}"; then
+                echo "  Skipping ${qcow2} (not in filter: ${IMAGE_FILTER})"
+                continue
+            fi
 
             echo "  Downloading from S3..."
             aws s3 cp "s3://${BUCKET_NAME}/images/${qcow2}" "${dest}/"
@@ -158,6 +188,10 @@ if [[ -n "${CONTAINER_TARBALLS}" ]]; then
                 continue
                 ;;
         esac
+        if ! image_wanted "ceos"; then
+            echo "  Skipping ${tarball} (not in filter: ${IMAGE_FILTER})"
+            continue
+        fi
 
         if docker image inspect "${tag}" &>/dev/null; then
             echo "  Already loaded: ${tag}"


### PR DESCRIPTION
By default, ec2-setup.sh loads all images from S3 (Juniper VMs + Arista
cEOS), which takes ~5 minutes and wastes time when only one platform is
needed. The new --images flag accepts a comma-separated list of image
tags (ceos, vjunos-router, vjunos-switch, vjunos-evolved) to load only
the specified images. Default remains "all" for backwards compatibility.

Example: --images ceos loads only cEOS, reducing bootstrap to ~2 min.

Prompt:
```
can we make the instance only initialize the router images necessary
for the lab? That will save a lot of time and router resources
```