### PR TITLE
AristaValidator: extract origin_protocol and origin_type for BGP and EVPN routes

### DIFF
--- a/src/lab_validation/parsers/arista/commands/bgp_routes.py
+++ b/src/lab_validation/parsers/arista/commands/bgp_routes.py
@@ -8,6 +8,7 @@ ACTIVE = "active"
 ADDRESS = "address"
 AS_PATH = "asPath"
 AS_PATH_ENTRY = "asPathEntry"
+AS_PATH_TYPE = "asPathType"
 BGP_ROUTE_ENTRIES = "bgpRouteEntries"
 BGP_ROUTE_PATHS = "bgpRoutePaths"
 ECMP = "ecmp"
@@ -15,6 +16,7 @@ LOCAL_PREFERENCE = "localPreference"
 MED = "med"
 NEXT_HOP = "nextHop"
 NOT_INSTALLED_REASON = "notInstalledReason"
+ORIGIN = "origin"
 ROUTE_TYPE = "routeType"
 VRFS = "vrfs"
 WEIGHT = "weight"
@@ -48,6 +50,7 @@ def _get_bgp_routes(vrf: str, json_obj: dict[Any, Any]) -> Sequence[AristaBgpRou
             if next_hop_ip == "":
                 next_hop_ip = None
 
+            as_path, origin_type = _get_as_path_and_origin(path[AS_PATH_ENTRY][AS_PATH])
             routes.append(
                 AristaBgpRoute(
                     vrf=vrf,
@@ -55,13 +58,17 @@ def _get_bgp_routes(vrf: str, json_obj: dict[Any, Any]) -> Sequence[AristaBgpRou
                     next_hop_ip=next_hop_ip,
                     local_preference=path.get(LOCAL_PREFERENCE, None),
                     metric=path.get(MED, None),
-                    as_path=_get_as_path(path[AS_PATH_ENTRY][AS_PATH]),
+                    as_path=as_path,
                     weight=get_weight(path.get(WEIGHT), next_hop_ip),
                     is_active=path[ROUTE_TYPE][ACTIVE],
                     is_ecmp=path[ROUTE_TYPE][ECMP],
                     not_installed_reason=path[ROUTE_TYPE].get(
                         NOT_INSTALLED_REASON, None
                     ),
+                    origin_protocol=get_origin_protocol(
+                        path[AS_PATH_ENTRY].get(AS_PATH_TYPE)
+                    ),
+                    origin_type=origin_type,
                 )
             )
     return routes
@@ -75,5 +82,24 @@ def get_weight(weight: int | None, next_hop_ip: str | None) -> int | None:
         return weight
 
 
-def _get_as_path(as_path: str) -> Sequence[int]:
-    return tuple(map(int, as_path.split()[:-1]))
+_ORIGIN_TYPE_MAP = {"i": "igp", "e": "egp", "?": "incomplete"}
+
+_ORIGIN_PROTOCOL_MAP = {
+    "Internal": "ibgp",
+    "External": "bgp",
+    "Local": "bgp",
+}
+
+
+def _get_as_path_and_origin(as_path: str) -> tuple[Sequence[int], str]:
+    parts = as_path.split()
+    origin_char = parts[-1]
+    origin_type = _ORIGIN_TYPE_MAP[origin_char]
+    as_numbers = tuple(map(int, parts[:-1]))
+    return as_numbers, origin_type
+
+
+def get_origin_protocol(as_path_type: str | None) -> str | None:
+    if as_path_type is None:
+        return None
+    return _ORIGIN_PROTOCOL_MAP.get(as_path_type)

--- a/src/lab_validation/parsers/arista/commands/evpn_routes.py
+++ b/src/lab_validation/parsers/arista/commands/evpn_routes.py
@@ -3,6 +3,7 @@ from collections.abc import Sequence
 from typing import Any
 
 from ..models.routes import AristaEvpnRoute
+from .bgp_routes import get_origin_protocol
 
 ACTIVE = "active"
 AS_PATH = "asPath"
@@ -69,6 +70,9 @@ def _get_evpn_routes(vrf: str, json_obj: dict[Any, Any]) -> Sequence[AristaEvpnR
                     next_hop_ip=next_hop,
                     is_active=path[ROUTE_TYPE][ACTIVE],
                     origin=path[ROUTE_TYPE][ORIGIN],
+                    origin_protocol=get_origin_protocol(
+                        path[AS_PATH_ENTRY][AS_PATH_TYPE]
+                    ),
                     route_distinguisher=rd,
                 )
             )

--- a/src/lab_validation/parsers/arista/models/routes.py
+++ b/src/lab_validation/parsers/arista/models/routes.py
@@ -36,6 +36,8 @@ class AristaBgpRoute:
     local_preference: int | None = attr.ib(converter=optional_int_converter)
     as_path: Sequence[int]
     weight: int | None = attr.ib(converter=optional_int_converter)
+    origin_protocol: str | None
+    origin_type: str
 
 
 @attr.s(frozen=True, auto_attribs=True, kw_only=True)
@@ -49,6 +51,7 @@ class AristaEvpnRoute:
     as_path_type: str
     weight: int | None
     origin: str
+    origin_protocol: str | None
 
     # Evpn attributes
     route_distinguisher: str

--- a/src/lab_validation/validators/AristaValidator.py
+++ b/src/lab_validation/validators/AristaValidator.py
@@ -297,8 +297,13 @@ class AristaValidator(VendorValidator):
 
         cost = []
 
-        # AristaBgpRoute currently doesn't have information on whether the route is iBGP or eBGP or the origin_protocol
-        # https://github.com/batfish/lab-validation/issues/62
+        if arista_route.origin_protocol is not None:
+            cost += AristaValidator._compute_bgp_protocol_cost(
+                arista_route.origin_protocol, batfish_route.protocol
+            )
+
+        if arista_route.origin_type != batfish_route.origin_type:
+            cost.append(("origin_type", 1.0))
 
         if arista_route.next_hop_ip != batfish_route.next_hop_ip:
             if (
@@ -329,6 +334,14 @@ class AristaValidator(VendorValidator):
             cost.append(("as path", 1.0))
 
         return cost
+
+    @staticmethod
+    def _compute_bgp_protocol_cost(
+        arista_protocol: str, batfish_protocol: str
+    ) -> CostResult:
+        if arista_protocol == batfish_protocol:
+            return []
+        return [("bgp subtype", 1.0)]
 
     def _parse_interfaces(self) -> Sequence[AristaInterface]:
         show_interfaces_path = self._first_file(
@@ -433,6 +446,11 @@ class AristaValidator(VendorValidator):
             return [("route_distinguisher", math.inf)]
 
         cost = []
+
+        if arista_route.origin_protocol is not None:
+            cost += AristaValidator._compute_bgp_protocol_cost(
+                arista_route.origin_protocol, batfish_route.protocol
+            )
 
         if batfish_route.next_hop_ip != arista_route.next_hop_ip:
             if (

--- a/tests/lab_validation/parsers/arista/commands/test_bgp_routes.py
+++ b/tests/lab_validation/parsers/arista/commands/test_bgp_routes.py
@@ -50,6 +50,8 @@ def test_parse_show_ip_bgp_vrf_all_json() -> None:
             is_active=True,
             is_ecmp=False,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
         ),
         AristaBgpRoute(
             vrf="default",
@@ -62,6 +64,8 @@ def test_parse_show_ip_bgp_vrf_all_json() -> None:
             is_active=True,
             is_ecmp=False,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
         ),
         AristaBgpRoute(
             vrf="default",
@@ -74,6 +78,8 @@ def test_parse_show_ip_bgp_vrf_all_json() -> None:
             is_active=False,
             is_ecmp=False,
             not_installed_reason="routeBestInactive",
+            origin_protocol=None,
+            origin_type="igp",
         ),
         AristaBgpRoute(
             vrf="default",
@@ -86,6 +92,8 @@ def test_parse_show_ip_bgp_vrf_all_json() -> None:
             is_active=True,
             is_ecmp=False,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
         ),
         AristaBgpRoute(
             vrf="cust10",
@@ -98,6 +106,8 @@ def test_parse_show_ip_bgp_vrf_all_json() -> None:
             is_active=True,
             is_ecmp=False,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
         ),
     ]
 
@@ -140,6 +150,8 @@ def test_parse_show_ip_bgp_vrf_all_json_no_metric() -> None:
             is_active=True,
             is_ecmp=False,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
         )
     ]
 
@@ -182,6 +194,8 @@ def test_parse_show_ip_bgp_vrf_all_json_no_local_pref() -> None:
             is_active=True,
             is_ecmp=False,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
         )
     ]
 
@@ -224,6 +238,8 @@ def test_parse_show_ip_bgp_vrf_all_json_origin_incomplete() -> None:
             is_active=True,
             is_ecmp=False,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="incomplete",
         )
     ]
 
@@ -266,6 +282,8 @@ def test_parse_bgp_local_route() -> None:
             is_active=True,
             is_ecmp=False,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
         )
     ]
 
@@ -356,6 +374,8 @@ def test_parse_bgp_ecmp_routes() -> None:
             is_active=True,
             is_ecmp=True,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
         ),
         AristaBgpRoute(
             vrf="default",
@@ -368,6 +388,83 @@ def test_parse_bgp_ecmp_routes() -> None:
             is_active=False,
             is_ecmp=True,
             not_installed_reason=None,
+            origin_protocol=None,
+            origin_type="igp",
+        ),
+    ]
+
+
+def test_parse_show_ip_bgp_vrf_all_json_with_as_path_type() -> None:
+    text = """
+    {
+    "vrfs":
+    {"default": {
+        "routerId": "1.1.1.1",
+        "vrf": "default",
+        "bgpRouteEntries":
+        {"1.1.1.1/32": {
+            "bgpAdvertisedPeerGroups": {},
+            "maskLength": 32,
+            "bgpRoutePaths": [{
+                "asPathEntry": {"asPathType": "Local", "asPath": "i"},
+                "nextHop": "",
+                "peerEntry": {},
+                "reasonNotBestpath": null,
+                "routeType": {"atomicAggregator": false, "suppressed": false, "queued": false, "valid": true, "ecmpContributor": false, "luRoute": false, "active": true, "stale": false, "ecmp": false, "backup": false, "ecmpHead": false, "ucmp": false, "sixPeRoute": false, "origin": "Igp"},
+                "tag": 0,
+                "weight": 32768
+            }],
+            "address": "1.1.1.1"},
+            "2.2.2.2/32": {"bgpAdvertisedPeerGroups": {}, "maskLength": 32, "bgpRoutePaths": [{"asPathEntry": {"asPathType": "External", "asPath": "65002 i"}, "localPreference": 100, "med": 0, "nextHop": "10.0.0.2", "peerEntry": {}, "reasonNotBestpath": null, "routeType": {"atomicAggregator": false, "suppressed": false, "queued": false, "valid": true, "ecmpContributor": false, "luRoute": false, "active": true, "stale": false, "ecmp": false, "backup": false, "ecmpHead": false, "ucmp": false, "sixPeRoute": false, "origin": "Igp"}, "tag": 0, "weight": 0}], "address": "2.2.2.2"},
+            "3.3.3.3/32": {"bgpAdvertisedPeerGroups": {}, "maskLength": 32, "bgpRoutePaths": [{"asPathEntry": {"asPathType": "Internal", "asPath": "i"}, "localPreference": 100, "med": 0, "nextHop": "10.0.0.3", "peerEntry": {}, "reasonNotBestpath": null, "routeType": {"atomicAggregator": false, "suppressed": false, "queued": false, "valid": true, "ecmpContributor": false, "luRoute": false, "active": true, "stale": false, "ecmp": false, "backup": false, "ecmpHead": false, "ucmp": false, "sixPeRoute": false, "origin": "Igp"}, "tag": 0, "weight": 0}], "address": "3.3.3.3"}
+         },
+     "asn": "65001"
+    }
+    }}
+    """
+    routes = parse_show_ip_bgp_vrf_all_json(text)
+    assert routes == [
+        AristaBgpRoute(
+            vrf="default",
+            network="1.1.1.1/32",
+            next_hop_ip=None,
+            local_preference=None,
+            metric=None,
+            as_path=(),
+            weight=32768,
+            is_active=True,
+            is_ecmp=False,
+            not_installed_reason=None,
+            origin_protocol="bgp",
+            origin_type="igp",
+        ),
+        AristaBgpRoute(
+            vrf="default",
+            network="2.2.2.2/32",
+            next_hop_ip="10.0.0.2",
+            local_preference=100,
+            metric=0,
+            as_path=(65002,),
+            weight=0,
+            is_active=True,
+            is_ecmp=False,
+            not_installed_reason=None,
+            origin_protocol="bgp",
+            origin_type="igp",
+        ),
+        AristaBgpRoute(
+            vrf="default",
+            network="3.3.3.3/32",
+            next_hop_ip="10.0.0.3",
+            local_preference=100,
+            metric=0,
+            as_path=(),
+            weight=0,
+            is_active=True,
+            is_ecmp=False,
+            not_installed_reason=None,
+            origin_protocol="ibgp",
+            origin_type="igp",
         ),
     ]
 

--- a/tests/lab_validation/parsers/arista/commands/test_evpn_routes.py
+++ b/tests/lab_validation/parsers/arista/commands/test_evpn_routes.py
@@ -120,6 +120,7 @@ def test_parse_show_bgp_evpn_json() -> None:
             is_active=True,
             route_distinguisher="2.2.2.2:4001",
             origin="Igp",
+            origin_protocol="bgp",
         ),
         AristaEvpnRoute(
             vrf="default",
@@ -132,6 +133,7 @@ def test_parse_show_bgp_evpn_json() -> None:
             is_active=False,
             route_distinguisher="2.2.2.2:4001",
             origin="Igp",
+            origin_protocol="ibgp",
         ),
         AristaEvpnRoute(
             vrf="default",
@@ -144,5 +146,6 @@ def test_parse_show_bgp_evpn_json() -> None:
             is_active=True,
             route_distinguisher="3.2.2.2:4001",
             origin="Igp",
+            origin_protocol="bgp",
         ),
     ]

--- a/tests/lab_validation/validators/test_aristaValidator.py
+++ b/tests/lab_validation/validators/test_aristaValidator.py
@@ -234,6 +234,8 @@ def test_diff_bgp_routes_cost() -> None:
         local_preference=100,
         as_path=(1,),
         weight=1,
+        origin_protocol="bgp",
+        origin_type="igp",
     )
     batfish_route = BgpRibRoute(
         weight=1,
@@ -248,7 +250,7 @@ def test_diff_bgp_routes_cost() -> None:
         local_preference=100,
         as_path="1",
         origin_protocol="bgp",
-        origin_type="type",
+        origin_type="igp",
         tag=0,
     )
 
@@ -263,6 +265,25 @@ def test_diff_bgp_routes_cost() -> None:
     assert AristaValidator._diff_bgp_routes_cost(
         arista_route, attr.evolve(batfish_route, vrf="other")
     ) == [("vrf", math.inf)]
+
+    # bgp subtype mismatch
+    assert AristaValidator._diff_bgp_routes_cost(
+        arista_route, attr.evolve(batfish_route, protocol="ibgp")
+    ) == [("bgp subtype", 1.0)]
+
+    # origin_type mismatch
+    assert AristaValidator._diff_bgp_routes_cost(
+        arista_route, attr.evolve(batfish_route, origin_type="incomplete")
+    ) == [("origin_type", 1.0)]
+
+    # origin_protocol is None: skip protocol comparison
+    assert (
+        AristaValidator._diff_bgp_routes_cost(
+            attr.evolve(arista_route, origin_protocol=None),
+            attr.evolve(batfish_route, protocol="ibgp"),
+        )
+        == []
+    )
 
     # metric mismatch
     assert AristaValidator._diff_bgp_routes_cost(
@@ -302,6 +323,8 @@ def test_validate_bgp_rib_routes_ignore_non_best() -> None:
             local_preference=100,
             as_path=(1, 2),
             weight=1,
+            origin_protocol="bgp",
+            origin_type="igp",
         )
     ]
     failures = AristaValidator._validate_bgp_rib_routes(arista_routes, [])
@@ -320,6 +343,8 @@ def test_is_best_bgp_route() -> None:
         local_preference=100,
         as_path=(1, 2),
         weight=1,
+        origin_protocol="bgp",
+        origin_type="igp",
     )
     active = attr.evolve(inactive, is_active=True)
     rib_failure = attr.evolve(inactive, not_installed_reason="routeBestInactive")
@@ -345,6 +370,8 @@ def test_validate_bgp_rib_routes_local() -> None:
             local_preference=100,
             as_path=(),
             weight=32768,
+            origin_protocol="bgp",
+            origin_type="igp",
         )
     ]
     bf_routes = [
@@ -361,7 +388,7 @@ def test_validate_bgp_rib_routes_local() -> None:
             local_preference=100,
             as_path="",
             origin_protocol="bgp",
-            origin_type="type",
+            origin_type="igp",
             tag=0,
         )
     ]
@@ -513,8 +540,9 @@ def test_validate_evpn_rib_routes_equal() -> None:
         local_preference=100,
         as_path=(1,),
         weight=1,
-        as_path_type="internal",
+        as_path_type="Internal",
         origin="Igp",
+        origin_protocol="ibgp",
         route_distinguisher="rd",
     )
 
@@ -524,7 +552,7 @@ def test_validate_evpn_rib_routes_equal() -> None:
         next_hop=NextHopInterface(interface="iface", ip="2.2.2.2"),
         next_hop_ip="2.2.2.2",
         next_hop_int="iface",
-        protocol="bgp",
+        protocol="ibgp",
         metric=0,
         communities=(),
         local_preference=100,
@@ -551,6 +579,20 @@ def test_validate_evpn_rib_routes_equal() -> None:
     assert AristaValidator._diff_evpn_routes_cost(
         arista_route, attr.evolve(batfish_route, route_distinguisher="rdd")
     ) == [("route_distinguisher", math.inf)]
+
+    # bgp subtype mismatch
+    assert AristaValidator._diff_evpn_routes_cost(
+        arista_route, attr.evolve(batfish_route, protocol="bgp")
+    ) == [("bgp subtype", 1.0)]
+
+    # origin_protocol is None: skip protocol comparison
+    assert (
+        AristaValidator._diff_evpn_routes_cost(
+            attr.evolve(arista_route, origin_protocol=None),
+            attr.evolve(batfish_route, protocol="bgp"),
+        )
+        == []
+    )
 
     # next hop ip mismatch
     assert AristaValidator._diff_evpn_routes_cost(
@@ -582,8 +624,9 @@ def test_diff_evpn_routes_cost_special_nhip_cases() -> None:
         local_preference=100,
         as_path=(1,),
         weight=1,
-        as_path_type="internal",
+        as_path_type="Internal",
         origin="Igp",
+        origin_protocol="ibgp",
         route_distinguisher="rd",
     )
 
@@ -593,7 +636,7 @@ def test_diff_evpn_routes_cost_special_nhip_cases() -> None:
         next_hop_ip="AUTO/NONE(-1l)",
         next_hop=NextHopDiscard(),
         next_hop_int="null_interface",
-        protocol="bgp",
+        protocol="ibgp",
         metric=0,
         communities=(),
         local_preference=100,
@@ -628,8 +671,9 @@ def test_diff_evpn_routes_cost_special_localpref_cases() -> None:
         local_preference=None,
         as_path=(1,),
         weight=1,
-        as_path_type="internal",
+        as_path_type="Internal",
         origin="Igp",
+        origin_protocol="ibgp",
         route_distinguisher="rd",
     )
 
@@ -639,7 +683,7 @@ def test_diff_evpn_routes_cost_special_localpref_cases() -> None:
         next_hop=NextHopInterface(interface="iface", ip="2.2.2.2"),
         next_hop_ip="2.2.2.2",
         next_hop_int="iface",
-        protocol="bgp",
+        protocol="ibgp",
         metric=0,
         communities=(),
         local_preference=0,


### PR DESCRIPTION
Add origin_protocol (iBGP/eBGP) and origin_type (IGP/EGP/incomplete)
extraction to the Arista BGP and EVPN parsers. The asPathType field
from the Arista JSON (External/Internal/Local) maps to the BGP
protocol subtype, and the last character of the asPath string (i/e/?)
maps to the BGP origin attribute.

When asPathType is null (older EOS or ribd single-agent mode),
origin_protocol is set to None and the protocol comparison is
skipped, preserving backward compatibility.

Fixes batfish/lab-validation#62

Prompt:
```
Can we fix https://github.com/batfish/lab-validation/issues/62 ?
```

Follow-up: also add origin_protocol to EVPN routes, normalizing
in the parser via shared get_origin_protocol().