### PR TITLE
eos_bgp_aggregate: remove origin_type sickbay entry (fixed in batfish)

### DIFF
--- a/snapshots/eos_bgp_aggregate/validation/sickbay.yaml
+++ b/snapshots/eos_bgp_aggregate/validation/sickbay.yaml
@@ -3,7 +3,3 @@ entries:
     test_name: test_bgp_rib_routes
     skip:
       reason: weight difference, https://github.com/batfish/lab-validation/issues/6
-  - hostname: EOS-2
-    test_name: test_bgp_rib_routes
-    skip:
-      reason: origin_type mismatch on aggregate routes, https://github.com/batfish/lab-validation/issues/141


### PR DESCRIPTION
Batfish now correctly models Arista aggregate routes with origin type
incomplete instead of IGP (batfish/batfish#9908).

Closes #141

----

Prompt:
```
Can we try to fix https://github.com/batfish/lab-validation/issues/141
in batfish/, then re-run lab-validation to confirm it worked?
```
