### PR TITLE
eos_ceos_bgp_unnumbered: enable ECMP across both unnumbered links

### DIFF
--- a/infra/examples/ceos-bgp-unnumbered/configs/leaf.cfg
+++ b/infra/examples/ceos-bgp-unnumbered/configs/leaf.cfg
@@ -24,6 +24,7 @@ ipv6 unicast-routing
 router bgp 65001
    router-id 10.0.0.2
    no bgp default ipv4-unicast
+   maximum-paths 2 ecmp 2
    neighbor SPINES peer group
    neighbor SPINES remote-as 65000
    neighbor interface Et1-2 peer-group SPINES

--- a/infra/examples/ceos-bgp-unnumbered/configs/spine.cfg
+++ b/infra/examples/ceos-bgp-unnumbered/configs/spine.cfg
@@ -24,6 +24,7 @@ ipv6 unicast-routing
 router bgp 65000
    router-id 10.0.0.1
    no bgp default ipv4-unicast
+   maximum-paths 2 ecmp 2
    neighbor LEAVES peer group
    neighbor LEAVES remote-as 65001
    neighbor interface Et1-2 peer-group LEAVES

--- a/snapshots/eos_ceos_bgp_unnumbered/configs/leaf/show_running-config.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/configs/leaf/show_running-config.txt
@@ -3,7 +3,7 @@
 !
 no aaa root
 !
-username admin privilege 15 role network-admin secret sha512 $6$RCrMhu4RXCVTcKZu$8G/QK6J6UHtVdOGXM1r7uiziXMTuXWPQMCS0CzQH4dTND7IVcMiZYU7JEVDuw1wC4ks.4hPFOdPWovTpg4e9G.
+username admin privilege 15 role network-admin secret sha512 $6$pApjqM4UH20Z73.Y$XkcGVSvW3bqTwLdoiT8M2CQyaG7GppfTKGLWmbHZXbZS6snJkDh1VXXuzT8LbsZiVCsjTwuZfj7kxbBeBhCiX.
 !
 no service interface inactive port-id allocation disabled
 !
@@ -31,8 +31,8 @@ interface Loopback0
    ip address 10.0.0.2/32
 !
 interface Management0
-   ip address 172.20.20.2/24
-   ipv6 address 3fff:172:20:20::2/64
+   ip address 172.20.20.3/24
+   ipv6 address 3fff:172:20:20::3/64
 !
 ip routing ipv6 interfaces 
 !
@@ -41,6 +41,7 @@ ipv6 unicast-routing
 router bgp 65001
    router-id 10.0.0.2
    no bgp default ipv4-unicast
+   maximum-paths 2 ecmp 2
    neighbor SPINES peer group
    neighbor SPINES remote-as 65000
    neighbor interface Ethernet1 peer-group SPINES

--- a/snapshots/eos_ceos_bgp_unnumbered/configs/spine/show_running-config.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/configs/spine/show_running-config.txt
@@ -3,7 +3,7 @@
 !
 no aaa root
 !
-username admin privilege 15 role network-admin secret sha512 $6$SuIWy285uErsAFn9$9N4rKhjHt3/ZMtDWJH5hnvmcBNVYTj8PsiyRnjpkZnYsjnAoXGu.UWIJpfiQYZjjCqjI7uEe.LxncNXEm0Bzm/
+username admin privilege 15 role network-admin secret sha512 $6$ywW2ON.fZRUW0T1E$6O8CMf1hxcP.i/17TVSwlP7wcOKw50D2Xx/x1ykHXDxey/WGOI.k9GvmWJusLwTyty0vgaRxW/2kgniz8E.If1
 !
 no service interface inactive port-id allocation disabled
 !
@@ -31,8 +31,8 @@ interface Loopback0
    ip address 10.0.0.1/32
 !
 interface Management0
-   ip address 172.20.20.3/24
-   ipv6 address 3fff:172:20:20::3/64
+   ip address 172.20.20.2/24
+   ipv6 address 3fff:172:20:20::2/64
 !
 ip routing ipv6 interfaces 
 !
@@ -41,6 +41,7 @@ ipv6 unicast-routing
 router bgp 65000
    router-id 10.0.0.1
    no bgp default ipv4-unicast
+   maximum-paths 2 ecmp 2
    neighbor LEAVES peer group
    neighbor LEAVES remote-as 65001
    neighbor interface Ethernet1 peer-group LEAVES

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_interfaces_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_interfaces_|_json.txt
@@ -26,7 +26,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::a8c1:abff:fea9:d37f",
+                    "address": "fe80::a8c1:abff:feaf:260d",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -36,28 +36,28 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "aa:c1:ab:a9:d3:7f",
-            "burnedInAddress": "aa:c1:ab:a9:d3:7f",
+            "physicalAddress": "aa:c1:ab:af:26:0d",
+            "burnedInAddress": "aa:c1:ab:af:26:0d",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777285264.5162916,
+            "lastStatusChangeTimestamp": 1777290452.262966,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 393.32401527323276,
-                "inPktsRate": 0.4534428402559515,
+                "inBitsRate": 99.2516525967884,
+                "inPktsRate": 0.10931429299499652,
                 "outBitsRate": 0.0,
                 "outPktsRate": 0.0
             },
             "interfaceCounters": {
-                "inOctets": 27862,
-                "inUcastPkts": 128,
-                "inMulticastPkts": 131,
+                "inOctets": 4422,
+                "inUcastPkts": 12,
+                "inMulticastPkts": 27,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 259,
+                "inTotalPkts": 39,
                 "outOctets": 0,
                 "outUcastPkts": 0,
                 "outMulticastPkts": 0,
@@ -81,7 +81,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777285637.978681
+                "counterRefreshTime": 1777290528.965824
             },
             "duplex": "duplexFull",
             "autoNegotiate": "unknown",
@@ -114,7 +114,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::a8c1:abff:fe1d:89a4",
+                    "address": "fe80::a8c1:abff:fe39:fae4",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -124,28 +124,28 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "aa:c1:ab:1d:89:a4",
-            "burnedInAddress": "aa:c1:ab:1d:89:a4",
+            "physicalAddress": "aa:c1:ab:39:fa:e4",
+            "burnedInAddress": "aa:c1:ab:39:fa:e4",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777285264.5164769,
+            "lastStatusChangeTimestamp": 1777290452.263168,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 374.8969493646272,
-                "inPktsRate": 0.4306744682338162,
+                "inBitsRate": 105.19455928178905,
+                "inPktsRate": 0.11490448138724384,
                 "outBitsRate": 0.0,
                 "outPktsRate": 0.0
             },
             "interfaceCounters": {
-                "inOctets": 26516,
-                "inUcastPkts": 116,
-                "inMulticastPkts": 129,
+                "inOctets": 4688,
+                "inUcastPkts": 14,
+                "inMulticastPkts": 27,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 245,
+                "inTotalPkts": 41,
                 "outOctets": 0,
                 "outUcastPkts": 0,
                 "outMulticastPkts": 0,
@@ -169,7 +169,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777285638.0038693
+                "counterRefreshTime": 1777290528.9666147
             },
             "duplex": "duplexFull",
             "autoNegotiate": "unknown",
@@ -185,7 +185,7 @@
             "interfaceAddress": [
                 {
                     "primaryIp": {
-                        "address": "172.20.20.2",
+                        "address": "172.20.20.3",
                         "maskLen": 24
                     },
                     "secondaryIps": {},
@@ -202,7 +202,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::bce4:4aff:fe23:5af",
+                    "address": "fe80::58a0:dfff:feef:be8e",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -210,7 +210,7 @@
                 },
                 "globalUnicastIp6s": [
                     {
-                        "address": "3fff:172:20:20::2",
+                        "address": "3fff:172:20:20::3",
                         "subnet": "3fff:172:20:20::/64",
                         "active": true,
                         "leastpref": false,
@@ -220,34 +220,34 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "be:e4:4a:23:05:af",
-            "burnedInAddress": "be:e4:4a:23:05:af",
+            "physicalAddress": "5a:a0:df:ef:be:8e",
+            "burnedInAddress": "5a:a0:df:ef:be:8e",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777285263.1894054,
+            "lastStatusChangeTimestamp": 1777290450.8672192,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 503.75854320698414,
-                "inPktsRate": 0.44143837532539837,
-                "outBitsRate": 692.6205431998569,
-                "outPktsRate": 0.48855286667005393
+                "inBitsRate": 1274.6165147344097,
+                "inPktsRate": 1.2034889514601688,
+                "outBitsRate": 2297.789237622162,
+                "outPktsRate": 1.6592393109068455
             },
             "interfaceCounters": {
-                "inOctets": 40571,
-                "inUcastPkts": 295,
+                "inOctets": 55429,
+                "inUcastPkts": 421,
                 "inMulticastPkts": 0,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 295,
-                "outOctets": 53405,
-                "outUcastPkts": 315,
+                "inTotalPkts": 421,
+                "outOctets": 97916,
+                "outUcastPkts": 569,
                 "outMulticastPkts": 0,
                 "outBroadcastPkts": 0,
                 "outDiscards": 0,
-                "outTotalPkts": 315,
+                "outTotalPkts": 569,
                 "linkStatusChanges": 3,
                 "totalInErrors": 0,
                 "inputErrorsDetail": {
@@ -265,7 +265,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777285638.0046556
+                "counterRefreshTime": 1777290528.9673686
             },
             "duplex": "duplexFull",
             "autoNegotiate": "success",
@@ -301,7 +301,7 @@
             "mtu": 65535,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777285263.478566
+            "lastStatusChangeTimestamp": 1777290451.14668
         }
     }
 }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_ip_bgp_vrf_all_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_ip_bgp_vrf_all_|_json.txt
@@ -10,7 +10,7 @@
                     "maskLength": 32,
                     "bgpRoutePaths": [
                         {
-                            "nextHop": "fe80::a8c1:abff:fe02:b602%Et1",
+                            "nextHop": "fe80::a8c1:abff:fe5d:5121%Et2",
                             "reasonNotBestpath": "noReason",
                             "localPreference": 100,
                             "weight": 0,
@@ -22,9 +22,9 @@
                                 "suppressed": false,
                                 "active": true,
                                 "backup": false,
-                                "ecmpHead": false,
-                                "ecmp": false,
-                                "ecmpContributor": false,
+                                "ecmpHead": true,
+                                "ecmp": true,
+                                "ecmpContributor": true,
                                 "atomicAggregator": false,
                                 "queued": false,
                                 "luRoute": false,
@@ -33,7 +33,7 @@
                                 "origin": "Igp"
                             },
                             "peerEntry": {
-                                "peerAddr": "fe80::a8c1:abff:fe02:b602%Et1",
+                                "peerAddr": "fe80::a8c1:abff:fe5d:5121%Et2",
                                 "peerRouterId": "10.0.0.1"
                             },
                             "asPathEntry": {
@@ -42,7 +42,7 @@
                             }
                         },
                         {
-                            "nextHop": "fe80::a8c1:abff:fe26:c161%Et2",
+                            "nextHop": "fe80::a8c1:abff:fe01:2083%Et1",
                             "reasonNotBestpath": "noReason",
                             "localPreference": 100,
                             "weight": 0,
@@ -55,8 +55,8 @@
                                 "active": false,
                                 "backup": false,
                                 "ecmpHead": false,
-                                "ecmp": false,
-                                "ecmpContributor": false,
+                                "ecmp": true,
+                                "ecmpContributor": true,
                                 "atomicAggregator": false,
                                 "queued": false,
                                 "luRoute": false,
@@ -65,7 +65,7 @@
                                 "origin": "Igp"
                             },
                             "peerEntry": {
-                                "peerAddr": "fe80::a8c1:abff:fe26:c161%Et2",
+                                "peerAddr": "fe80::a8c1:abff:fe01:2083%Et1",
                                 "peerRouterId": "10.0.0.1"
                             },
                             "asPathEntry": {

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_ip_route_vrf_all_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_ip_route_vrf_all_|_json.txt
@@ -15,8 +15,12 @@
                     "metric": 0,
                     "vias": [
                         {
-                            "nexthopAddr": "fe80::a8c1:abff:fe02:b602",
+                            "nexthopAddr": "fe80::a8c1:abff:fe01:2083",
                             "interface": "Ethernet1"
+                        },
+                        {
+                            "nexthopAddr": "fe80::a8c1:abff:fe5d:5121",
+                            "interface": "Ethernet2"
                         }
                     ],
                     "routeAction": "forward",

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_version_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_version_|_json.txt
@@ -2,8 +2,8 @@
     "mfgName": "Arista",
     "modelName": "cEOSLab",
     "hardwareRevision": "",
-    "serialNumber": "EA6C9E67BF5095668E539361531EF018",
-    "systemMacAddress": "00:1c:73:7a:79:ca",
+    "serialNumber": "93DA295CD602FD6F24AB95B5FA97AF62",
+    "systemMacAddress": "00:1c:73:d2:eb:2e",
     "hwMacAddress": "00:00:00:00:00:00",
     "configMacAddress": "00:00:00:00:00:00",
     "version": "4.36.0.1F-47401373.43601F (engineering build)",
@@ -13,9 +13,9 @@
     "imageFormatVersion": "1.0",
     "imageOptimization": "None",
     "kernelVersion": "6.17.0-1012-aws",
-    "bootupTimestamp": 1777285246.0252306,
-    "uptime": 401.36695671081543,
+    "bootupTimestamp": 1777290433.6270192,
+    "uptime": 104.69992685317993,
     "memTotal": 32311432,
-    "memFree": 28130628,
+    "memFree": 28130776,
     "isIntlVersion": false
 }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_vrf_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_vrf_|_json.txt
@@ -17,20 +17,20 @@
             "vrfState": "up",
             "interfacesV4": [
                 "Loopback0",
-                "Management0",
+                "Ethernet2",
                 "Ethernet1",
-                "Ethernet2"
+                "Management0"
             ],
             "interfacesV6": [
-                "Management0",
+                "Ethernet2",
                 "Ethernet1",
-                "Ethernet2"
+                "Management0"
             ],
             "interfaces": [
                 "Loopback0",
-                "Management0",
+                "Ethernet2",
                 "Ethernet1",
-                "Ethernet2"
+                "Management0"
             ],
             "vrfId": 0
         }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_interfaces_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_interfaces_|_json.txt
@@ -26,7 +26,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::a8c1:abff:fe26:c161",
+                    "address": "fe80::a8c1:abff:fe5d:5121",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -36,28 +36,28 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "aa:c1:ab:26:c1:61",
-            "burnedInAddress": "aa:c1:ab:26:c1:61",
+            "physicalAddress": "aa:c1:ab:5d:51:21",
+            "burnedInAddress": "aa:c1:ab:5d:51:21",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777285264.5712917,
+            "lastStatusChangeTimestamp": 1777290452.4201558,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 366.5757149709425,
-                "inPktsRate": 0.42456494520546645,
+                "inBitsRate": 113.87202310757097,
+                "inPktsRate": 0.12670173222015746,
                 "outBitsRate": 0.0,
                 "outPktsRate": 0.0
             },
             "interfaceCounters": {
-                "inOctets": 27096,
-                "inUcastPkts": 118,
-                "inMulticastPkts": 134,
+                "inOctets": 5399,
+                "inUcastPkts": 18,
+                "inMulticastPkts": 30,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 252,
+                "inTotalPkts": 48,
                 "outOctets": 0,
                 "outUcastPkts": 0,
                 "outMulticastPkts": 0,
@@ -81,7 +81,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777285656.947246
+                "counterRefreshTime": 1777290547.8297613
             },
             "duplex": "duplexFull",
             "autoNegotiate": "unknown",
@@ -114,7 +114,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::a8c1:abff:fe02:b602",
+                    "address": "fe80::a8c1:abff:fe01:2083",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -124,28 +124,28 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "aa:c1:ab:02:b6:02",
-            "burnedInAddress": "aa:c1:ab:02:b6:02",
+            "physicalAddress": "aa:c1:ab:01:20:83",
+            "burnedInAddress": "aa:c1:ab:01:20:83",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777285264.57154,
+            "lastStatusChangeTimestamp": 1777290452.419912,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 359.5249724972242,
-                "inPktsRate": 0.4168610442040528,
+                "inBitsRate": 121.62713201629565,
+                "inPktsRate": 0.13496881442723874,
                 "outBitsRate": 0.0,
                 "outPktsRate": 0.0
             },
             "interfaceCounters": {
-                "inOctets": 26759,
-                "inUcastPkts": 114,
-                "inMulticastPkts": 135,
+                "inOctets": 5755,
+                "inUcastPkts": 21,
+                "inMulticastPkts": 30,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 249,
+                "inTotalPkts": 51,
                 "outOctets": 0,
                 "outUcastPkts": 0,
                 "outMulticastPkts": 0,
@@ -169,7 +169,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777285656.9723918
+                "counterRefreshTime": 1777290547.830557
             },
             "duplex": "duplexFull",
             "autoNegotiate": "unknown",
@@ -185,7 +185,7 @@
             "interfaceAddress": [
                 {
                     "primaryIp": {
-                        "address": "172.20.20.3",
+                        "address": "172.20.20.2",
                         "maskLen": 24
                     },
                     "secondaryIps": {},
@@ -202,7 +202,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::9c10:2aff:fe41:16a5",
+                    "address": "fe80::303c:acff:fee7:c208",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -210,7 +210,7 @@
                 },
                 "globalUnicastIp6s": [
                     {
-                        "address": "3fff:172:20:20::3",
+                        "address": "3fff:172:20:20::2",
                         "subnet": "3fff:172:20:20::/64",
                         "active": true,
                         "leastpref": false,
@@ -220,34 +220,34 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "9e:10:2a:41:16:a5",
-            "burnedInAddress": "9e:10:2a:41:16:a5",
+            "physicalAddress": "32:3c:ac:e7:c2:08",
+            "burnedInAddress": "32:3c:ac:e7:c2:08",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777285263.0608268,
+            "lastStatusChangeTimestamp": 1777290451.0398536,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 476.9338798362483,
-                "inPktsRate": 0.41465104723034013,
-                "outBitsRate": 713.9774756263226,
-                "outPktsRate": 0.5031180999816864
+                "inBitsRate": 1167.2828878794778,
+                "inPktsRate": 1.0846528055669034,
+                "outBitsRate": 1942.666367346041,
+                "outPktsRate": 1.3298921194561975
             },
             "interfaceCounters": {
-                "inOctets": 39852,
-                "inUcastPkts": 288,
+                "inOctets": 53348,
+                "inUcastPkts": 400,
                 "inMulticastPkts": 0,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 288,
-                "outOctets": 56388,
-                "outUcastPkts": 330,
+                "inTotalPkts": 400,
+                "outOctets": 87329,
+                "outUcastPkts": 482,
                 "outMulticastPkts": 0,
                 "outBroadcastPkts": 0,
                 "outDiscards": 0,
-                "outTotalPkts": 330,
+                "outTotalPkts": 482,
                 "linkStatusChanges": 3,
                 "totalInErrors": 0,
                 "inputErrorsDetail": {
@@ -265,7 +265,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777285656.9731884
+                "counterRefreshTime": 1777290547.831328
             },
             "duplex": "duplexFull",
             "autoNegotiate": "success",
@@ -301,7 +301,7 @@
             "mtu": 65535,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777285263.280339
+            "lastStatusChangeTimestamp": 1777290451.1793728
         }
     }
 }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_ip_bgp_vrf_all_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_ip_bgp_vrf_all_|_json.txt
@@ -47,7 +47,7 @@
                     "maskLength": 32,
                     "bgpRoutePaths": [
                         {
-                            "nextHop": "fe80::a8c1:abff:fe1d:89a4%Et1",
+                            "nextHop": "fe80::a8c1:abff:feaf:260d%Et2",
                             "reasonNotBestpath": "noReason",
                             "localPreference": 100,
                             "weight": 0,
@@ -59,9 +59,9 @@
                                 "suppressed": false,
                                 "active": true,
                                 "backup": false,
-                                "ecmpHead": false,
-                                "ecmp": false,
-                                "ecmpContributor": false,
+                                "ecmpHead": true,
+                                "ecmp": true,
+                                "ecmpContributor": true,
                                 "atomicAggregator": false,
                                 "queued": false,
                                 "luRoute": false,
@@ -70,7 +70,7 @@
                                 "origin": "Igp"
                             },
                             "peerEntry": {
-                                "peerAddr": "fe80::a8c1:abff:fe1d:89a4%Et1",
+                                "peerAddr": "fe80::a8c1:abff:feaf:260d%Et2",
                                 "peerRouterId": "10.0.0.2"
                             },
                             "asPathEntry": {
@@ -79,7 +79,7 @@
                             }
                         },
                         {
-                            "nextHop": "fe80::a8c1:abff:fea9:d37f%Et2",
+                            "nextHop": "fe80::a8c1:abff:fe39:fae4%Et1",
                             "reasonNotBestpath": "noReason",
                             "localPreference": 100,
                             "weight": 0,
@@ -92,8 +92,8 @@
                                 "active": false,
                                 "backup": false,
                                 "ecmpHead": false,
-                                "ecmp": false,
-                                "ecmpContributor": false,
+                                "ecmp": true,
+                                "ecmpContributor": true,
                                 "atomicAggregator": false,
                                 "queued": false,
                                 "luRoute": false,
@@ -102,7 +102,7 @@
                                 "origin": "Igp"
                             },
                             "peerEntry": {
-                                "peerAddr": "fe80::a8c1:abff:fea9:d37f%Et2",
+                                "peerAddr": "fe80::a8c1:abff:fe39:fae4%Et1",
                                 "peerRouterId": "10.0.0.2"
                             },
                             "asPathEntry": {

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_ip_route_vrf_all_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_ip_route_vrf_all_|_json.txt
@@ -30,8 +30,12 @@
                     "metric": 0,
                     "vias": [
                         {
-                            "nexthopAddr": "fe80::a8c1:abff:fe1d:89a4",
+                            "nexthopAddr": "fe80::a8c1:abff:fe39:fae4",
                             "interface": "Ethernet1"
+                        },
+                        {
+                            "nexthopAddr": "fe80::a8c1:abff:feaf:260d",
+                            "interface": "Ethernet2"
                         }
                     ],
                     "routeAction": "forward",

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_version_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_version_|_json.txt
@@ -2,8 +2,8 @@
     "mfgName": "Arista",
     "modelName": "cEOSLab",
     "hardwareRevision": "",
-    "serialNumber": "0F61B65BF097DD6AE03150AF296EA0FC",
-    "systemMacAddress": "00:1c:73:de:95:dd",
+    "serialNumber": "EC0D509E1347C73379C8C6042B4408F7",
+    "systemMacAddress": "00:1c:73:a2:80:97",
     "hwMacAddress": "00:00:00:00:00:00",
     "configMacAddress": "00:00:00:00:00:00",
     "version": "4.36.0.1F-47401373.43601F (engineering build)",
@@ -13,9 +13,9 @@
     "imageFormatVersion": "1.0",
     "imageOptimization": "None",
     "kernelVersion": "6.17.0-1012-aws",
-    "bootupTimestamp": 1777285246.0299149,
-    "uptime": 420.2815361022949,
+    "bootupTimestamp": 1777290433.6220193,
+    "uptime": 123.55792689323425,
     "memTotal": 32311432,
-    "memFree": 28101252,
+    "memFree": 28107312,
     "isIntlVersion": false
 }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_vrf_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_vrf_|_json.txt
@@ -16,20 +16,20 @@
             },
             "vrfState": "up",
             "interfacesV4": [
+                "Management0",
                 "Loopback0",
                 "Ethernet1",
-                "Management0",
                 "Ethernet2"
             ],
             "interfacesV6": [
-                "Ethernet1",
                 "Management0",
+                "Ethernet1",
                 "Ethernet2"
             ],
             "interfaces": [
+                "Management0",
                 "Loopback0",
                 "Ethernet1",
-                "Management0",
                 "Ethernet2"
             ],
             "vrfId": 0


### PR DESCRIPTION
Add `maximum-paths 2 ecmp 2` to both routers so the two parallel
unnumbered links are both active simultaneously, rather than one
being active and the other a tie-broken alternate. This matches the
intent of the `Et1-2` range expansion in `neighbor interface` —
multiple links to the same peer should share traffic.

With ECMP enabled, both paths to the remote loopback show as
`ecmp: true` in the BGP RIB and both next-hops appear in the FIB.

Prompt:
```
can we fix the lab? either make it deterministic (prefer router-id?)
or make it ecmp enabled?
```