### PR TITLE
AristaValidator: handle RFC 5549 unnumbered BGP next-hops

### DIFF
--- a/src/lab_validation/validators/AristaValidator.py
+++ b/src/lab_validation/validators/AristaValidator.py
@@ -32,6 +32,64 @@ from .batfish_models.runtime_data import InterfaceRuntimeData, NodeRuntimeData
 from .utils.validation_utils import CostResult, match_pairs, matched_pairs_to_failures
 from .vendor_validator import VendorValidator
 
+# RFC 5549 unnumbered BGP: Arista reports the peer's IPv6 link-local as the
+# next-hop (e.g. 'fe80::.../Et1') while Batfish models it with a synthetic
+# IPv4 169.254.x.x address paired with the outgoing interface.
+_IPV6_LINK_LOCAL_PREFIX = "fe80:"
+_IPV4_LINK_LOCAL_PREFIX = "169.254."
+
+# Arista interface name abbreviations used in IPv6 zone identifiers and CLI
+# short forms. Used to normalize e.g. 'Et1' into the canonical 'Ethernet1'.
+_ARISTA_IFACE_ABBREVIATIONS = {
+    "Eth": "Ethernet",
+    "Et": "Ethernet",
+    "Lo": "Loopback",
+    "Ma": "Management",
+    "Po": "Port-Channel",
+    "Vl": "Vlan",
+}
+
+
+def _canonicalize_arista_interface(name: str) -> str:
+    """Expand an abbreviated Arista interface name to its canonical form."""
+    for prefix in sorted(_ARISTA_IFACE_ABBREVIATIONS, key=len, reverse=True):
+        if (
+            name.startswith(prefix)
+            and len(name) > len(prefix)
+            and not name[len(prefix)].isalpha()
+        ):
+            return _ARISTA_IFACE_ABBREVIATIONS[prefix] + name[len(prefix) :]
+    return name
+
+
+def _split_ipv6_zone(nhip: str | None) -> tuple[str | None, str | None]:
+    """Split an IPv6 address with an optional zone identifier.
+
+    e.g. 'fe80::1%Et1' -> ('fe80::1', 'Ethernet1'); '10.0.0.1' -> ('10.0.0.1', None).
+    """
+    if nhip is None:
+        return (None, None)
+    ip, sep, zone = nhip.partition("%")
+    if not sep:
+        return (ip, None)
+    return (ip, _canonicalize_arista_interface(zone))
+
+
+def _is_rfc5549_unnumbered_match(
+    arista_nhip: str | None,
+    batfish_nhip: str | None,
+) -> bool:
+    """Return True if the device's IPv6 link-local next-hop matches Batfish's
+    synthetic IPv4 link-local next-hop used for RFC 5549 unnumbered peering."""
+    if not arista_nhip or not batfish_nhip:
+        return False
+    arista_ip, _ = _split_ipv6_zone(arista_nhip)
+    return bool(
+        arista_ip
+        and arista_ip.lower().startswith(_IPV6_LINK_LOCAL_PREFIX)
+        and batfish_nhip.startswith(_IPV4_LINK_LOCAL_PREFIX)
+    )
+
 
 class AristaValidator(VendorValidator):
     SHOW_ROUTE_FILENAME = "show_ip_route_vrf_all_|_json.txt"
@@ -207,7 +265,13 @@ class AristaValidator(VendorValidator):
                 cost.append(("asymmetric nhint", 5.0))
             elif arista_route.next_hop_int.lower() != next_hop.interface.lower():
                 cost.append(("nhint", 5.0))
-            if next_hop.ip and next_hop.ip != arista_route.next_hop_ip:
+            if (
+                next_hop.ip
+                and next_hop.ip != arista_route.next_hop_ip
+                and not _is_rfc5549_unnumbered_match(
+                    arista_route.next_hop_ip, next_hop.ip
+                )
+            ):
                 cost.append(("nhip", 1.0))
             return cost
 
@@ -305,15 +369,34 @@ class AristaValidator(VendorValidator):
         if arista_route.origin_type != batfish_route.origin_type:
             cost.append(("origin_type", 1.0))
 
-        if arista_route.next_hop_ip != batfish_route.next_hop_ip:
+        arista_ip, arista_zone = _split_ipv6_zone(arista_route.next_hop_ip)
+        batfish_nh_ip = (
+            batfish_route.next_hop.ip
+            if isinstance(batfish_route.next_hop, (NextHopIp, NextHopInterface))
+            else batfish_route.next_hop_ip
+        )
+        if arista_ip != batfish_nh_ip:
             if (
                 arista_route.next_hop_ip is None
                 and batfish_route.next_hop_ip == "AUTO/NONE(-1l)"
                 and batfish_route.next_hop_int == "null_interface"
             ):
                 pass
+            elif _is_rfc5549_unnumbered_match(arista_route.next_hop_ip, batfish_nh_ip):
+                pass
             else:
                 cost.append(("nhip", 1.0))
+
+        # For routes whose next-hop is an IPv6 link-local (e.g. unnumbered BGP),
+        # the outgoing interface is encoded in the zone identifier. Use it to
+        # disambiguate parallel paths during cost-based matching.
+        if (
+            arista_zone is not None
+            and batfish_route.next_hop_int
+            and batfish_route.next_hop_int != "dynamic"
+            and arista_zone.lower() != batfish_route.next_hop_int.lower()
+        ):
+            cost.append(("nhint", 5.0))
 
         arista_metric = 0 if arista_route.metric is None else arista_route.metric
         if batfish_route.metric != arista_metric:

--- a/tests/lab_validation/validators/test_aristaValidator.py
+++ b/tests/lab_validation/validators/test_aristaValidator.py
@@ -704,3 +704,90 @@ def test_diff_evpn_routes_cost_special_localpref_cases() -> None:
     assert AristaValidator._diff_evpn_routes_cost(
         arista_route, attr.evolve(batfish_route, local_preference=10)
     ) == [("local_preference", 1.0)]
+
+
+def test_compute_next_hop_cost_rfc5549_unnumbered() -> None:
+    """Arista IPv6 link-local next-hop matches Batfish's synthetic 169.254.x.x."""
+    arista_route = AristaIpRoute(
+        network="10.0.0.1/32",
+        protocol="eBGP",
+        next_hop_ip="fe80::a8c1:abff:fe02:b602",
+        next_hop_int="Ethernet1",
+        preference=200,
+        metric=0,
+        vrf="default",
+        vni=None,
+        vtep_ip=None,
+    )
+
+    # IPv6 link-local on the device matches Batfish's 169.254.x.x on the
+    # same interface with zero cost.
+    assert (
+        AristaValidator.compute_next_hop_cost(
+            arista_route,
+            NextHopInterface(interface="Ethernet1", ip="169.254.0.1"),
+        )
+        == []
+    )
+
+    # A different Batfish interface is still an nhint mismatch.
+    assert AristaValidator.compute_next_hop_cost(
+        arista_route,
+        NextHopInterface(interface="Ethernet2", ip="169.254.0.1"),
+    ) == [("nhint", 5.0)]
+
+    # A non-link-local IPv4 Batfish next-hop is not the unnumbered case.
+    assert AristaValidator.compute_next_hop_cost(
+        arista_route,
+        NextHopInterface(interface="Ethernet1", ip="10.0.0.1"),
+    ) == [("nhip", 1.0)]
+
+
+def test_diff_bgp_routes_cost_rfc5549_unnumbered() -> None:
+    """RFC 5549 unnumbered: Arista uses 'fe80::...%EtN' zone IDs, Batfish uses
+    169.254.x.x paired with the outgoing interface. Pairing must match by
+    interface (zone id vs next_hop_int), and the nhip difference is expected."""
+    arista_route = AristaBgpRoute(
+        vrf="default",
+        network="10.0.0.1/32",
+        is_active=True,
+        is_ecmp=True,
+        not_installed_reason=None,
+        next_hop_ip="fe80::a8c1:abff:fe02:b602%Et1",
+        metric=0,
+        local_preference=100,
+        as_path=(65000,),
+        weight=0,
+        origin_protocol="bgp",
+        origin_type="igp",
+    )
+    batfish_route_et1 = BgpRibRoute(
+        weight=0,
+        vrf="default",
+        network="10.0.0.1/32",
+        next_hop=NextHopInterface(interface="Ethernet1", ip="169.254.0.1"),
+        next_hop_ip=None,
+        next_hop_int="Ethernet1",
+        protocol="bgp",
+        metric=0,
+        communities=(),
+        local_preference=100,
+        as_path="65000",
+        origin_protocol="bgp",
+        origin_type="igp",
+        tag=0,
+    )
+
+    # Same interface: zero cost.
+    assert AristaValidator._diff_bgp_routes_cost(arista_route, batfish_route_et1) == []
+
+    # Different interface: nhint cost, ensuring the matcher can pair by
+    # interface across parallel ECMP paths.
+    batfish_route_et2 = attr.evolve(
+        batfish_route_et1,
+        next_hop=NextHopInterface(interface="Ethernet2", ip="169.254.0.1"),
+        next_hop_int="Ethernet2",
+    )
+    assert AristaValidator._diff_bgp_routes_cost(arista_route, batfish_route_et2) == [
+        ("nhint", 5.0)
+    ]


### PR DESCRIPTION
Arista reports the peer's IPv6 link-local as the next-hop for RFC
5549 unnumbered BGP routes (e.g. `fe80::.../Et1`), while Batfish
models these with a synthetic IPv4 link-local (`169.254.x.x`)
paired with the outgoing interface. Treat this pair as equivalent
in both the main RIB and BGP RIB cost functions so unnumbered
peering validates cleanly.

For BGP RIB routes, also extract the interface from the IPv6 zone
identifier and compare it against Batfish's next_hop_int so
cost-based matching pairs parallel ECMP paths by interface rather
than pairing arbitrarily across them.

Prompt:
```
make those two fixes
```

Earlier in the conversation we diagnosed which two fixes were
needed against the eos_ceos_bgp_unnumbered lab: (1) the nhip
equivalence between Arista's IPv6 link-local and Batfish's
169.254.x.x, and (2) adding the next-hop interface to the BGP
RIB cost so parallel ECMP paths pair by interface.