### PR TITLE
infra/README: clarify lab determinism, re-collect, and check-in rules

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -251,6 +251,51 @@ ssh -i $KEY ubuntu@$IP \
 
 Then re-download and re-validate locally.
 
+**Always re-collect after changing the lab.** The snapshot's
+`configs/<node>/show_running-config.txt` and every file under
+`show/<node>/` must come from the actual running device after your
+change. Do not hand-edit collected show data to match an updated
+startup config — the snapshot is the observed state of the real lab,
+and editing it defeats the point of empirical validation. If you
+change a startup config (e.g., add ECMP), redeploy (or push-config)
+and re-run `collect` + `build-snapshot`.
+
+### Adding or editing `checks.yaml`
+
+`checks.yaml` lives alongside the topology in `infra/examples/<lab>/`
+and defines preconditions the lab must satisfy before collection
+(interfaces up, specific routes learned, BGP peers Established). To
+add or iterate on one:
+
+1. Write `infra/examples/<lab>/checks.yaml` (see
+   `infra/examples/evpn-type5/checks.yaml` for the schema).
+2. Upload to the EC2 box alongside the topology and run:
+   ```bash
+   ssh -i $KEY ubuntu@$IP \
+       'cd ~/lab && PYTHONPATH=src python3 -m lab_builder validate mylab/topology.clab.yml --checks mylab/checks.yaml'
+   ```
+3. Adjust checks until everything passes against the deployed lab,
+   then commit the final version to `infra/examples/<lab>/`.
+
+## What to check in
+
+Only commit artifacts that were actually produced by (or fed into)
+the lab process:
+
+- `infra/examples/<lab>/` — the inputs used to build the lab:
+  `topology.clab.yml`, startup `configs/*.cfg`, and `checks.yaml`
+  (if any). These must match what was last deployed to produce the
+  snapshot.
+- `snapshots/<lab>/` — the outputs collected from the running lab:
+  `configs/<node>/`, `show/<node>/`, `show/host_nos.txt`, plus hand-
+  authored `batfish/layer1_topology.json` and `validation/sickbay.yaml`
+  as needed.
+
+Do not commit files you did not exercise end-to-end. If `checks.yaml`
+was never run against the lab, don't check it in yet — run it first.
+If startup configs drifted from what produced the snapshot, either
+redeploy+re-collect or revert the configs.
+
 ## Scripts Reference
 
 | Script            | Where it runs | Purpose                                                   |
@@ -385,7 +430,17 @@ the large Juniper VM images and reducing bootstrap time from ~5 min to
 - **Simplicity**: minimum routers to demonstrate the feature (2-3 typical)
 - **Feature isolation**: one feature per lab
 - **Corner cases**: misconfigurations, asymmetric settings, boundary values
-- **Reproducibility**: deterministic results, avoid time-dependent behavior
+- **Determinism**: eliminate ties that can be broken differently by the
+  device vs. Batfish, or non-deterministically across reboots (e.g.,
+  some vendors' default BGP tiebreaker is "oldest path"). Common
+  techniques, using whatever the vendor's equivalent CLI is:
+  - **Deterministic tiebreakers**: force tiebreaks to use router-id
+    rather than path age.
+  - **ECMP**: enable multipath so equal-cost paths are all active,
+    sidestepping tiebreakers entirely.
+  - **Differentiated candidates**: give routes distinct local-prefs,
+    MEDs, or AS-path lengths so best-path selection is unambiguous
+    before the tiebreak stage.
 - **Documentation**: README explaining what the lab tests and why
 
 ## Supported Vendor Profiles

--- a/infra/examples/ceos-bgp-unnumbered/configs/leaf.cfg
+++ b/infra/examples/ceos-bgp-unnumbered/configs/leaf.cfg
@@ -24,6 +24,7 @@ ipv6 unicast-routing
 router bgp 65001
    router-id 10.0.0.2
    no bgp default ipv4-unicast
+   bgp bestpath tie-break router-id
    maximum-paths 2 ecmp 2
    neighbor SPINES peer group
    neighbor SPINES remote-as 65000

--- a/infra/examples/ceos-bgp-unnumbered/configs/spine.cfg
+++ b/infra/examples/ceos-bgp-unnumbered/configs/spine.cfg
@@ -24,6 +24,7 @@ ipv6 unicast-routing
 router bgp 65000
    router-id 10.0.0.1
    no bgp default ipv4-unicast
+   bgp bestpath tie-break router-id
    maximum-paths 2 ecmp 2
    neighbor LEAVES peer group
    neighbor LEAVES remote-as 65001

--- a/snapshots/eos_ceos_bgp_unnumbered/configs/leaf/show_running-config.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/configs/leaf/show_running-config.txt
@@ -3,7 +3,7 @@
 !
 no aaa root
 !
-username admin privilege 15 role network-admin secret sha512 $6$pApjqM4UH20Z73.Y$XkcGVSvW3bqTwLdoiT8M2CQyaG7GppfTKGLWmbHZXbZS6snJkDh1VXXuzT8LbsZiVCsjTwuZfj7kxbBeBhCiX.
+username admin privilege 15 role network-admin secret sha512 $6$bhetwM7siK2ZyQgX$qJ/Gvv7.7gH9SjQ7K.NwWXzBDTmxsY5fjmW8T1dqESjleNIKftFnDM5TlEhqlPWV/w9ybMByqCwwFLmWp4S6o.
 !
 no service interface inactive port-id allocation disabled
 !
@@ -42,6 +42,7 @@ router bgp 65001
    router-id 10.0.0.2
    no bgp default ipv4-unicast
    maximum-paths 2 ecmp 2
+   bgp bestpath tie-break router-id
    neighbor SPINES peer group
    neighbor SPINES remote-as 65000
    neighbor interface Ethernet1 peer-group SPINES

--- a/snapshots/eos_ceos_bgp_unnumbered/configs/spine/show_running-config.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/configs/spine/show_running-config.txt
@@ -3,7 +3,7 @@
 !
 no aaa root
 !
-username admin privilege 15 role network-admin secret sha512 $6$ywW2ON.fZRUW0T1E$6O8CMf1hxcP.i/17TVSwlP7wcOKw50D2Xx/x1ykHXDxey/WGOI.k9GvmWJusLwTyty0vgaRxW/2kgniz8E.If1
+username admin privilege 15 role network-admin secret sha512 $6$rMqGKuDn3RwKHZhv$iU7R1MVF1vcGePbMGusGde0aHwH65sUItsGFj.5kkCn.j5EzXFkGYnfSA9nP1wKm7ZBvHG2YaNKGvgoBlcxJx.
 !
 no service interface inactive port-id allocation disabled
 !
@@ -42,6 +42,7 @@ router bgp 65000
    router-id 10.0.0.1
    no bgp default ipv4-unicast
    maximum-paths 2 ecmp 2
+   bgp bestpath tie-break router-id
    neighbor LEAVES peer group
    neighbor LEAVES remote-as 65001
    neighbor interface Ethernet1 peer-group LEAVES

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_interfaces_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_interfaces_|_json.txt
@@ -26,7 +26,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::a8c1:abff:feaf:260d",
+                    "address": "fe80::a8c1:abff:feaa:a25e",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -36,28 +36,28 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "aa:c1:ab:af:26:0d",
-            "burnedInAddress": "aa:c1:ab:af:26:0d",
+            "physicalAddress": "aa:c1:ab:aa:a2:5e",
+            "burnedInAddress": "aa:c1:ab:aa:a2:5e",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777290452.262966,
+            "lastStatusChangeTimestamp": 1777295032.4233508,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 99.2516525967884,
-                "inPktsRate": 0.10931429299499652,
+                "inBitsRate": 113.61447781926036,
+                "inPktsRate": 0.12804490536259608,
                 "outBitsRate": 0.0,
                 "outPktsRate": 0.0
             },
             "interfaceCounters": {
-                "inOctets": 4422,
-                "inUcastPkts": 12,
-                "inMulticastPkts": 27,
+                "inOctets": 4783,
+                "inUcastPkts": 18,
+                "inMulticastPkts": 25,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 39,
+                "inTotalPkts": 43,
                 "outOctets": 0,
                 "outUcastPkts": 0,
                 "outMulticastPkts": 0,
@@ -81,7 +81,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777290528.965824
+                "counterRefreshTime": 1777295085.4842389
             },
             "duplex": "duplexFull",
             "autoNegotiate": "unknown",
@@ -114,7 +114,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::a8c1:abff:fe39:fae4",
+                    "address": "fe80::a8c1:abff:feeb:3dc",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -124,28 +124,28 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "aa:c1:ab:39:fa:e4",
-            "burnedInAddress": "aa:c1:ab:39:fa:e4",
+            "physicalAddress": "aa:c1:ab:eb:03:dc",
+            "burnedInAddress": "aa:c1:ab:eb:03:dc",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777290452.263168,
+            "lastStatusChangeTimestamp": 1777295032.4236758,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 105.19455928178905,
-                "inPktsRate": 0.11490448138724384,
+                "inBitsRate": 119.9822280853676,
+                "inPktsRate": 0.13398598465011055,
                 "outBitsRate": 0.0,
                 "outPktsRate": 0.0
             },
             "interfaceCounters": {
-                "inOctets": 4688,
-                "inUcastPkts": 14,
-                "inMulticastPkts": 27,
+                "inOctets": 5049,
+                "inUcastPkts": 19,
+                "inMulticastPkts": 26,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 41,
+                "inTotalPkts": 45,
                 "outOctets": 0,
                 "outUcastPkts": 0,
                 "outMulticastPkts": 0,
@@ -169,7 +169,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777290528.9666147
+                "counterRefreshTime": 1777295085.4850626
             },
             "duplex": "duplexFull",
             "autoNegotiate": "unknown",
@@ -202,7 +202,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::58a0:dfff:feef:be8e",
+                    "address": "fe80::d02b:56ff:feef:2213",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -220,34 +220,34 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "5a:a0:df:ef:be:8e",
-            "burnedInAddress": "5a:a0:df:ef:be:8e",
+            "physicalAddress": "d2:2b:56:ef:22:13",
+            "burnedInAddress": "d2:2b:56:ef:22:13",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777290450.8672192,
+            "lastStatusChangeTimestamp": 1777295031.2134829,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 1274.6165147344097,
-                "inPktsRate": 1.2034889514601688,
-                "outBitsRate": 2297.789237622162,
-                "outPktsRate": 1.6592393109068455
+                "inBitsRate": 1338.5600644067797,
+                "inPktsRate": 1.2562554097309184,
+                "outBitsRate": 2338.04720289226,
+                "outPktsRate": 1.6533449598138457
             },
             "interfaceCounters": {
-                "inOctets": 55429,
-                "inUcastPkts": 421,
+                "inOctets": 54347,
+                "inUcastPkts": 410,
                 "inMulticastPkts": 0,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 421,
-                "outOctets": 97916,
-                "outUcastPkts": 569,
+                "inTotalPkts": 410,
+                "outOctets": 92666,
+                "outUcastPkts": 528,
                 "outMulticastPkts": 0,
                 "outBroadcastPkts": 0,
                 "outDiscards": 0,
-                "outTotalPkts": 569,
+                "outTotalPkts": 528,
                 "linkStatusChanges": 3,
                 "totalInErrors": 0,
                 "inputErrorsDetail": {
@@ -265,7 +265,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777290528.9673686
+                "counterRefreshTime": 1777295085.4858065
             },
             "duplex": "duplexFull",
             "autoNegotiate": "success",
@@ -301,7 +301,7 @@
             "mtu": 65535,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777290451.14668
+            "lastStatusChangeTimestamp": 1777295031.439684
         }
     }
 }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_ip_bgp_vrf_all_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_ip_bgp_vrf_all_|_json.txt
@@ -10,7 +10,7 @@
                     "maskLength": 32,
                     "bgpRoutePaths": [
                         {
-                            "nextHop": "fe80::a8c1:abff:fe5d:5121%Et2",
+                            "nextHop": "fe80::a8c1:abff:fe88:3132%Et1",
                             "reasonNotBestpath": "noReason",
                             "localPreference": 100,
                             "weight": 0,
@@ -33,7 +33,7 @@
                                 "origin": "Igp"
                             },
                             "peerEntry": {
-                                "peerAddr": "fe80::a8c1:abff:fe5d:5121%Et2",
+                                "peerAddr": "fe80::a8c1:abff:fe88:3132%Et1",
                                 "peerRouterId": "10.0.0.1"
                             },
                             "asPathEntry": {
@@ -42,7 +42,7 @@
                             }
                         },
                         {
-                            "nextHop": "fe80::a8c1:abff:fe01:2083%Et1",
+                            "nextHop": "fe80::a8c1:abff:feac:f43c%Et2",
                             "reasonNotBestpath": "noReason",
                             "localPreference": 100,
                             "weight": 0,
@@ -65,7 +65,7 @@
                                 "origin": "Igp"
                             },
                             "peerEntry": {
-                                "peerAddr": "fe80::a8c1:abff:fe01:2083%Et1",
+                                "peerAddr": "fe80::a8c1:abff:feac:f43c%Et2",
                                 "peerRouterId": "10.0.0.1"
                             },
                             "asPathEntry": {

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_ip_route_vrf_all_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_ip_route_vrf_all_|_json.txt
@@ -15,11 +15,11 @@
                     "metric": 0,
                     "vias": [
                         {
-                            "nexthopAddr": "fe80::a8c1:abff:fe01:2083",
+                            "nexthopAddr": "fe80::a8c1:abff:fe88:3132",
                             "interface": "Ethernet1"
                         },
                         {
-                            "nexthopAddr": "fe80::a8c1:abff:fe5d:5121",
+                            "nexthopAddr": "fe80::a8c1:abff:feac:f43c",
                             "interface": "Ethernet2"
                         }
                     ],

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_version_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_version_|_json.txt
@@ -2,8 +2,8 @@
     "mfgName": "Arista",
     "modelName": "cEOSLab",
     "hardwareRevision": "",
-    "serialNumber": "93DA295CD602FD6F24AB95B5FA97AF62",
-    "systemMacAddress": "00:1c:73:d2:eb:2e",
+    "serialNumber": "79D77313478F01F01A31459CC153CA04",
+    "systemMacAddress": "00:1c:73:5e:da:eb",
     "hwMacAddress": "00:00:00:00:00:00",
     "configMacAddress": "00:00:00:00:00:00",
     "version": "4.36.0.1F-47401373.43601F (engineering build)",
@@ -13,9 +13,9 @@
     "imageFormatVersion": "1.0",
     "imageOptimization": "None",
     "kernelVersion": "6.17.0-1012-aws",
-    "bootupTimestamp": 1777290433.6270192,
-    "uptime": 104.69992685317993,
+    "bootupTimestamp": 1777295013.9576972,
+    "uptime": 80.88348817825317,
     "memTotal": 32311432,
-    "memFree": 28130776,
+    "memFree": 28052368,
     "isIntlVersion": false
 }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_vrf_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/leaf/show_vrf_|_json.txt
@@ -16,10 +16,10 @@
             },
             "vrfState": "up",
             "interfacesV4": [
-                "Loopback0",
                 "Ethernet2",
                 "Ethernet1",
-                "Management0"
+                "Management0",
+                "Loopback0"
             ],
             "interfacesV6": [
                 "Ethernet2",
@@ -27,10 +27,10 @@
                 "Management0"
             ],
             "interfaces": [
-                "Loopback0",
                 "Ethernet2",
                 "Ethernet1",
-                "Management0"
+                "Management0",
+                "Loopback0"
             ],
             "vrfId": 0
         }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_interfaces_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_interfaces_|_json.txt
@@ -26,7 +26,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::a8c1:abff:fe5d:5121",
+                    "address": "fe80::a8c1:abff:feac:f43c",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -36,28 +36,28 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "aa:c1:ab:5d:51:21",
-            "burnedInAddress": "aa:c1:ab:5d:51:21",
+            "physicalAddress": "aa:c1:ab:ac:f4:3c",
+            "burnedInAddress": "aa:c1:ab:ac:f4:3c",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777290452.4201558,
+            "lastStatusChangeTimestamp": 1777295031.804141,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 113.87202310757097,
-                "inPktsRate": 0.12670173222015746,
+                "inBitsRate": 104.65428194974109,
+                "inPktsRate": 0.11378891552504465,
                 "outBitsRate": 0.0,
                 "outPktsRate": 0.0
             },
             "interfaceCounters": {
-                "inOctets": 5399,
-                "inUcastPkts": 18,
-                "inMulticastPkts": 30,
+                "inOctets": 4595,
+                "inUcastPkts": 13,
+                "inMulticastPkts": 27,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 48,
+                "inTotalPkts": 40,
                 "outOctets": 0,
                 "outUcastPkts": 0,
                 "outMulticastPkts": 0,
@@ -81,7 +81,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777290547.8297613
+                "counterRefreshTime": 1777295104.265852
             },
             "duplex": "duplexFull",
             "autoNegotiate": "unknown",
@@ -114,7 +114,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::a8c1:abff:fe01:2083",
+                    "address": "fe80::a8c1:abff:fe88:3132",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -124,28 +124,28 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "aa:c1:ab:01:20:83",
-            "burnedInAddress": "aa:c1:ab:01:20:83",
+            "physicalAddress": "aa:c1:ab:88:31:32",
+            "burnedInAddress": "aa:c1:ab:88:31:32",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777290452.419912,
+            "lastStatusChangeTimestamp": 1777295031.8040028,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 121.62713201629565,
-                "inPktsRate": 0.13496881442723874,
+                "inBitsRate": 102.49531076210609,
+                "inPktsRate": 0.11057906063892306,
                 "outBitsRate": 0.0,
                 "outPktsRate": 0.0
             },
             "interfaceCounters": {
-                "inOctets": 5755,
-                "inUcastPkts": 21,
-                "inMulticastPkts": 30,
+                "inOctets": 4514,
+                "inUcastPkts": 12,
+                "inMulticastPkts": 27,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 51,
+                "inTotalPkts": 39,
                 "outOctets": 0,
                 "outUcastPkts": 0,
                 "outMulticastPkts": 0,
@@ -169,7 +169,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777290547.830557
+                "counterRefreshTime": 1777295104.2666523
             },
             "duplex": "duplexFull",
             "autoNegotiate": "unknown",
@@ -202,7 +202,7 @@
             ],
             "interfaceAddressIp6": {
                 "linkLocalIp6": {
-                    "address": "fe80::303c:acff:fee7:c208",
+                    "address": "fe80::c478:d4ff:fe3e:ef48",
                     "subnet": "fe80::/64",
                     "active": true,
                     "leastpref": false,
@@ -220,34 +220,34 @@
                 "globalAddressesAreVirtual": false,
                 "addrSource": "manual"
             },
-            "physicalAddress": "32:3c:ac:e7:c2:08",
-            "burnedInAddress": "32:3c:ac:e7:c2:08",
+            "physicalAddress": "c6:78:d4:3e:ef:48",
+            "burnedInAddress": "c6:78:d4:3e:ef:48",
             "description": "",
             "bandwidth": 1000000000,
             "mtu": 1500,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777290451.0398536,
+            "lastStatusChangeTimestamp": 1777295030.4382937,
             "interfaceStatistics": {
                 "updateInterval": 300.0,
-                "inBitsRate": 1167.2828878794778,
-                "inPktsRate": 1.0846528055669034,
-                "outBitsRate": 1942.666367346041,
-                "outPktsRate": 1.3298921194561975
+                "inBitsRate": 1272.3729317610203,
+                "inPktsRate": 1.1994449094992794,
+                "outBitsRate": 2266.9982539210173,
+                "outPktsRate": 1.6153807147410584
             },
             "interfaceCounters": {
-                "inOctets": 53348,
-                "inUcastPkts": 400,
+                "inOctets": 54020,
+                "inUcastPkts": 410,
                 "inMulticastPkts": 0,
                 "inBroadcastPkts": 0,
                 "inDiscards": 0,
-                "inTotalPkts": 400,
-                "outOctets": 87329,
-                "outUcastPkts": 482,
+                "inTotalPkts": 410,
+                "outOctets": 94178,
+                "outUcastPkts": 540,
                 "outMulticastPkts": 0,
                 "outBroadcastPkts": 0,
                 "outDiscards": 0,
-                "outTotalPkts": 482,
+                "outTotalPkts": 540,
                 "linkStatusChanges": 3,
                 "totalInErrors": 0,
                 "inputErrorsDetail": {
@@ -265,7 +265,7 @@
                     "deferredTransmissions": 0,
                     "txPause": 0
                 },
-                "counterRefreshTime": 1777290547.831328
+                "counterRefreshTime": 1777295104.2674108
             },
             "duplex": "duplexFull",
             "autoNegotiate": "success",
@@ -301,7 +301,7 @@
             "mtu": 65535,
             "l3MtuConfigured": false,
             "l2Mru": 0,
-            "lastStatusChangeTimestamp": 1777290451.1793728
+            "lastStatusChangeTimestamp": 1777295030.9365149
         }
     }
 }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_ip_bgp_vrf_all_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_ip_bgp_vrf_all_|_json.txt
@@ -47,7 +47,7 @@
                     "maskLength": 32,
                     "bgpRoutePaths": [
                         {
-                            "nextHop": "fe80::a8c1:abff:feaf:260d%Et2",
+                            "nextHop": "fe80::a8c1:abff:feaa:a25e%Et2",
                             "reasonNotBestpath": "noReason",
                             "localPreference": 100,
                             "weight": 0,
@@ -70,7 +70,7 @@
                                 "origin": "Igp"
                             },
                             "peerEntry": {
-                                "peerAddr": "fe80::a8c1:abff:feaf:260d%Et2",
+                                "peerAddr": "fe80::a8c1:abff:feaa:a25e%Et2",
                                 "peerRouterId": "10.0.0.2"
                             },
                             "asPathEntry": {
@@ -79,7 +79,7 @@
                             }
                         },
                         {
-                            "nextHop": "fe80::a8c1:abff:fe39:fae4%Et1",
+                            "nextHop": "fe80::a8c1:abff:feeb:3dc%Et1",
                             "reasonNotBestpath": "noReason",
                             "localPreference": 100,
                             "weight": 0,
@@ -102,7 +102,7 @@
                                 "origin": "Igp"
                             },
                             "peerEntry": {
-                                "peerAddr": "fe80::a8c1:abff:fe39:fae4%Et1",
+                                "peerAddr": "fe80::a8c1:abff:feeb:3dc%Et1",
                                 "peerRouterId": "10.0.0.2"
                             },
                             "asPathEntry": {

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_ip_route_vrf_all_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_ip_route_vrf_all_|_json.txt
@@ -30,11 +30,11 @@
                     "metric": 0,
                     "vias": [
                         {
-                            "nexthopAddr": "fe80::a8c1:abff:fe39:fae4",
+                            "nexthopAddr": "fe80::a8c1:abff:feeb:3dc",
                             "interface": "Ethernet1"
                         },
                         {
-                            "nexthopAddr": "fe80::a8c1:abff:feaf:260d",
+                            "nexthopAddr": "fe80::a8c1:abff:feaa:a25e",
                             "interface": "Ethernet2"
                         }
                     ],

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_version_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_version_|_json.txt
@@ -2,8 +2,8 @@
     "mfgName": "Arista",
     "modelName": "cEOSLab",
     "hardwareRevision": "",
-    "serialNumber": "EC0D509E1347C73379C8C6042B4408F7",
-    "systemMacAddress": "00:1c:73:a2:80:97",
+    "serialNumber": "482C3CD427BB71A60949836AF9137F2D",
+    "systemMacAddress": "00:1c:73:d8:06:03",
     "hwMacAddress": "00:00:00:00:00:00",
     "configMacAddress": "00:00:00:00:00:00",
     "version": "4.36.0.1F-47401373.43601F (engineering build)",
@@ -13,9 +13,9 @@
     "imageFormatVersion": "1.0",
     "imageOptimization": "None",
     "kernelVersion": "6.17.0-1012-aws",
-    "bootupTimestamp": 1777290433.6220193,
-    "uptime": 123.55792689323425,
+    "bootupTimestamp": 1777295013.953697,
+    "uptime": 99.6514024734497,
     "memTotal": 32311432,
-    "memFree": 28107312,
+    "memFree": 28124084,
     "isIntlVersion": false
 }

--- a/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_vrf_|_json.txt
+++ b/snapshots/eos_ceos_bgp_unnumbered/show/spine/show_vrf_|_json.txt
@@ -16,21 +16,21 @@
             },
             "vrfState": "up",
             "interfacesV4": [
-                "Management0",
+                "Ethernet2",
                 "Loopback0",
                 "Ethernet1",
-                "Ethernet2"
+                "Management0"
             ],
             "interfacesV6": [
-                "Management0",
+                "Ethernet2",
                 "Ethernet1",
-                "Ethernet2"
+                "Management0"
             ],
             "interfaces": [
-                "Management0",
+                "Ethernet2",
                 "Loopback0",
                 "Ethernet1",
-                "Ethernet2"
+                "Management0"
             ],
             "vrfId": 0
         }


### PR DESCRIPTION
Expand the lab-creation docs based on lessons from the BGP unnumbered
lab:

- **Determinism**: replace the one-line "reproducibility" bullet with
three concrete techniques — deterministic tiebreakers (prefer
router-id over path age), ECMP, and differentiated best-path
candidates (local-pref, MED, AS-path length).

- **Re-collect discipline**: the snapshot must reflect the actual
device state after any lab change. Do not hand-edit collected
show data to match a new startup config — redeploy or push-config,
then re-run `collect` + `build-snapshot`.

- **`checks.yaml` iteration**: document the workflow for adding or
iterating on a per-lab `checks.yaml` in `infra/examples/<lab>/`,
and point at the evpn-type5 example for the schema.

- **What to commit**: enumerate what belongs in `infra/examples/<lab>/`
(inputs) vs. `snapshots/<lab>/` (outputs), and warn against
checking in artifacts that were never exercised end-to-end against
the running lab.

Prompt:
```
Any doc updates to make? Specifically, some things I had to correct:
1/ deterministic labs if possible, 2/ always recollecting after
changing lab not just changing show data, 3/ only check in artifacts
that were used in and are outputs from the lab process (e.g.,
checks.yaml), 4/ how to add checks.yaml in the lab context for
iteration (if desired)
```

---

**Stack**:
- #150 ⬅
- #149


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*