### PR TITLE
eos_ceos_bgp_unnumbered: remove main_rib_routes sickbay entries

### DIFF
--- a/snapshots/eos_ceos_bgp_unnumbered/validation/sickbay.yaml
+++ b/snapshots/eos_ceos_bgp_unnumbered/validation/sickbay.yaml
@@ -1,17 +1,9 @@
 entries:
   - hostname: leaf
-    test_name: test_main_rib_routes
-    skip:
-      reason: Batfish does not yet model BGP route exchange for unnumbered interface peers, https://github.com/batfish/batfish/pull/9894
-  - hostname: spine
-    test_name: test_main_rib_routes
-    skip:
-      reason: Batfish does not yet model BGP route exchange for unnumbered interface peers, https://github.com/batfish/batfish/pull/9894
-  - hostname: leaf
     test_name: test_bgp_rib_routes
     skip:
-      reason: weight difference on locally-originated route (https://github.com/batfish/lab-validation/issues/6) and missing received routes from unnumbered peers (https://github.com/batfish/batfish/pull/9894)
+      reason: weight difference on locally-originated route, https://github.com/batfish/lab-validation/issues/6
   - hostname: spine
     test_name: test_bgp_rib_routes
     skip:
-      reason: weight difference on locally-originated route (https://github.com/batfish/lab-validation/issues/6) and missing received routes from unnumbered peers (https://github.com/batfish/batfish/pull/9894)
+      reason: weight difference on locally-originated route, https://github.com/batfish/lab-validation/issues/6


### PR DESCRIPTION
Now that batfish/batfish#9894 is merged, Batfish simulates BGP
route exchange for `neighbor interface` (RFC 5549) unnumbered peers
and produces matching main RIB routes. Remove the main_rib_routes
sickbay entries that referenced the PR as an open issue.

The remaining bgp_rib_routes sickbay entries are now just the
locally-originated weight diff (#6), same as eos_ceos_ebgp.

Prompt:
```
I merged https://github.com/batfish/batfish/pull/9894 and now the
behavior should match what you saw with that dev version of batfish.
Update the sickbay
```