### PR TITLE
sickbay: retire issues/58 and enable Junos tests

### DIFF
--- a/snapshots/junos_default_address_selection/validation/sickbay.yaml
+++ b/snapshots/junos_default_address_selection/validation/sickbay.yaml
@@ -2,17 +2,14 @@ entries:
   - hostname: SW1|SW2|SW3|SW4|SW5|SW6|SW7|SW8
     test_name: "test_interface_properties"
     skip:
-      skip_type: dont_run
       reason: https://github.com/batfish/lab-validation/issues/57
 
-  - hostname: SW1|SW2|SW3|SW4|SW5|SW6|SW7|SW8
+  - hostname: SW6|SW7|SW8
     test_name: "test_main_rib_routes"
     skip:
-      skip_type: dont_run
       reason: https://github.com/batfish/lab-validation/issues/57
 
-  - hostname: SW1|SW2|SW3|SW4|SW5|SW6|SW7|SW8
+  - hostname: SW5|SW6|SW7|SW8
     test_name: "test_bgp_rib_routes"
     skip:
-      skip_type: dont_run
-      reason: https://github.com/batfish/lab-validation/issues/58, https://github.com/batfish/lab-validation/issues/57
+      reason: https://github.com/batfish/lab-validation/issues/57

--- a/snapshots/sonic_bgp_lab/validation/sickbay.yaml
+++ b/snapshots/sonic_bgp_lab/validation/sickbay.yaml
@@ -22,5 +22,4 @@ entries:
   - hostname: r01
     test_name: "test_bgp_rib_routes"
     skip:
-      skip_type: dont_run
-      reason: https://github.com/batfish/lab-validation/issues/58, https://github.com/batfish/lab-validation/issues/57
+      reason: https://github.com/batfish/lab-validation/issues/57


### PR DESCRIPTION
JunosValidator BGP ECMP support was implemented in PRs #109 and #130.
Remove the stale issues/58 references from sickbay files and convert
all Junos dont_run entries to xfail so they actually execute.

Narrow sickbay scope to only the devices that still fail:
- test_interface_properties: all SW1-SW8 xfail (real #57 failures)
- test_main_rib_routes: SW1-SW5 now pass, SW6-SW8 remain xfail
- test_bgp_rib_routes: SW1-SW4 now pass, SW5-SW8 remain xfail
- sonic_bgp_lab r01: runs without crash, xfails on #57

Fixes #58

----

Prompt:
```
Analyze and fix
https://github.com/batfish/lab-validation/issues/58
```