### PR TITLE
NxosValidator: implement EVPN RIB route validation (#23)

### DIFF
--- a/snapshots/nxos_evpn_l2vni/validation/sickbay.yaml
+++ b/snapshots/nxos_evpn_l2vni/validation/sickbay.yaml
@@ -2,4 +2,4 @@ entries:
   - hostname: NX-1|NX-2
     test_name: test_evpn_rib_routes
     skip:
-      reason: https://github.com/batfish/lab-validation/issues/23
+      reason: https://github.com/batfish/lab-validation/issues/156

--- a/snapshots/nxos_evpn_l3vni/validation/sickbay.yaml
+++ b/snapshots/nxos_evpn_l3vni/validation/sickbay.yaml
@@ -1,5 +1,1 @@
-entries:
-  - hostname: NX-1|NX-2
-    test_name: test_evpn_rib_routes
-    skip:
-      reason: https://github.com/batfish/lab-validation/issues/23
+entries: []

--- a/src/lab_validation/parsers/nxos/commands/evpn_routes.py
+++ b/src/lab_validation/parsers/nxos/commands/evpn_routes.py
@@ -1,0 +1,120 @@
+import re
+from collections.abc import Sequence
+
+from pyparsing import (
+    Combine,
+    Group,
+    Literal,
+    MatchFirst,
+    OneOrMore,
+    Optional,
+    ParserElement,
+    Regex,
+    SkipTo,
+    White,
+    ZeroOrMore,
+    one_of,
+)
+
+from lab_validation.parsers.common.tokens import dec, ip, newline
+from lab_validation.parsers.nxos.models.routes import NxosEvpnRoute
+
+_EVPN_NETWORK = Regex(r"\[[0-9]\]:\[[^\]]*\](?::\[[^\]]*\])*\/\d+")
+
+_TYPE3_RE = re.compile(r"^\[3\]:\[0\]:\[(\d+)\]:\[([^\]]+)\]/\d+$")
+_TYPE5_RE = re.compile(r"^\[5\]:\[0\]:\[0\]:\[(\d+)\]:\[([^\]]+)\]/\d+$")
+
+
+def _extract_ip_network(evpn_nlri: str) -> str | None:
+    """Extract the IP network from an EVPN NLRI string.
+
+    Returns an IP prefix string (e.g., "192.168.10.0/24") for supported
+    route types, or None for types Batfish does not model (Type 2).
+    """
+    m = _TYPE5_RE.match(evpn_nlri)
+    if m:
+        return f"{m.group(2)}/{m.group(1)}"
+    m = _TYPE3_RE.match(evpn_nlri)
+    if m:
+        return f"{m.group(2)}/{m.group(1)}"
+    return None
+
+
+def parse_show_bgp_l2vpn_evpn(text: str) -> Sequence[NxosEvpnRoute]:
+    all_parse_results = OneOrMore(_rd_block()).leave_whitespace().parse_string(text)
+    routes: list[NxosEvpnRoute] = []
+    for block in all_parse_results:
+        rd = block["rd"]
+        for record in block.get("routes", []):
+            network = _extract_ip_network(record["network"])
+            if network is None:
+                continue
+            as_path_str = _filter_empty(record.get("as_path", ""))
+            as_path = tuple(map(int, as_path_str))
+            routes.append(
+                NxosEvpnRoute(
+                    route_distinguisher=rd,
+                    network=network,
+                    next_hop_ip=record["next_hop"],
+                    metric=record.get("metric", None),
+                    local_preference=record.get("local_preference", 100),
+                    weight=record["weight"],
+                    as_path=as_path,
+                    best_path=record["status"][1] in (">", "|"),
+                    origin_type=record["origin_type"],
+                )
+            )
+    return routes
+
+
+def _rd_header() -> ParserElement:
+    return (
+        Literal("Route Distinguisher:").suppress()
+        + White(" ").suppress()
+        + Combine(ip + Literal(":") + dec).set_results_name("rd")
+        + Optional(White(" ").suppress() + Regex(r"\(.*?\)").suppress())
+        + newline
+    )
+
+
+def _rd_block() -> ParserElement:
+    return Group(
+        SkipTo(_rd_header()).suppress()
+        + _rd_header()
+        + OneOrMore(_get_record()).set_results_name("routes")
+    )
+
+
+def _get_record() -> ParserElement:
+    route_status = Combine(
+        one_of(["*", "s", " "]) + one_of([">", "|", " "])
+    ).set_results_name("status")
+    path_type = MatchFirst(
+        [Literal("e"), Literal("l"), Literal("i"), Literal("a"), Literal("r")]
+    )
+    origin_type = Regex(r"(e|i|\?)")
+    as_path = ZeroOrMore(dec + White(" ")).set_results_name("as_path")
+    record = Group(
+        route_status
+        + Optional(White(" ", max=1))
+        + path_type.set_results_name("path_type")
+        + _EVPN_NETWORK.set_results_name("network")
+        + newline
+        + White(" ", min=1)
+        + ip.set_results_name("next_hop")
+        + White(" ", min=1, max=18)
+        + Optional(dec).set_results_name("metric")
+        + White(" ", min=1, max=9)
+        + Optional(dec).set_results_name("local_preference")
+        + White(" ", min=1)
+        + dec.set_results_name("weight")
+        + White(" ", min=1)
+        + as_path
+        + origin_type.set_results_name("origin_type")
+        + Optional(newline)
+    ).leave_whitespace()
+    return record
+
+
+def _filter_empty(as_path_list: Sequence[str]) -> list[str]:
+    return list(filter(lambda x: (False if x == " " else True), as_path_list))

--- a/src/lab_validation/parsers/nxos/models/routes.py
+++ b/src/lab_validation/parsers/nxos/models/routes.py
@@ -33,3 +33,16 @@ class NxosBgpRoute:
     as_path: Sequence[int]
     best_path: bool
     origin_type: str
+
+
+@attr.s(frozen=True, auto_attribs=True, kw_only=True)
+class NxosEvpnRoute:
+    route_distinguisher: str
+    network: str = attr.ib(converter=normalized_network)
+    next_hop_ip: str
+    metric: int | None
+    local_preference: int
+    weight: int
+    as_path: Sequence[int]
+    best_path: bool
+    origin_type: str

--- a/src/lab_validation/validators/NxosValidator.py
+++ b/src/lab_validation/validators/NxosValidator.py
@@ -12,14 +12,23 @@ from pybatfish.datamodel.route import (
 )
 
 from lab_validation.parsers.nxos.commands.bgp_route import parse_show_ip_bgp_all
+from lab_validation.parsers.nxos.commands.evpn_routes import parse_show_bgp_l2vpn_evpn
 from lab_validation.parsers.nxos.commands.interfaces import parse_show_interface
 from lab_validation.parsers.nxos.commands.routes import parse_show_ip_route_vrf_all
 from lab_validation.parsers.nxos.models.interfaces import NxosInterface
-from lab_validation.parsers.nxos.models.routes import NxosBgpRoute, NxosMainRibRoute
+from lab_validation.parsers.nxos.models.routes import (
+    NxosBgpRoute,
+    NxosEvpnRoute,
+    NxosMainRibRoute,
+)
 from lab_validation.validators.batfish_models.interface_properties import (
     InterfaceProperties,
 )
-from lab_validation.validators.batfish_models.routes import BgpRibRoute, MainRibRoute
+from lab_validation.validators.batfish_models.routes import (
+    BgpRibRoute,
+    EvpnRibRoute,
+    MainRibRoute,
+)
 from lab_validation.validators.batfish_models.runtime_data import (
     InterfaceRuntimeData,
     NodeRuntimeData,
@@ -128,6 +137,16 @@ class NxosValidator(VendorValidator):
             self._get_bgp_rib_all_vrfs(), routes
         )
 
+    def validate_evpn_rib_routes(
+        self, batfish_routes: Sequence[EvpnRibRoute]
+    ) -> dict[Any, Any]:
+        if not batfish_routes:
+            return {}
+        nxos_routes = self._get_evpn_routes()
+        if not nxos_routes:
+            return {}
+        return NxosValidator._validate_evpn_rib_routes(nxos_routes, batfish_routes)
+
     @staticmethod
     def _validate_bgp_rib_routes(
         nxos_routes: Sequence[NxosBgpRoute], batfish_routes: Sequence[BgpRibRoute]
@@ -211,6 +230,51 @@ class NxosValidator(VendorValidator):
                 cost.append(("nhip", 1.0))
         else:
             raise ValueError("Unsupported next hop " + repr(next_hop))
+        return cost
+
+    @staticmethod
+    def _validate_evpn_rib_routes(
+        nxos_routes: Sequence[NxosEvpnRoute],
+        batfish_routes: Sequence[EvpnRibRoute],
+    ) -> dict[Any, Any]:
+        validate_routes = [r for r in nxos_routes if r.best_path]
+        matched_routes = match_pairs(
+            validate_routes,
+            batfish_routes,
+            NxosValidator._diff_evpn_routes_cost,
+        )
+        return matched_pairs_to_failures(matched_routes)
+
+    @staticmethod
+    def _diff_evpn_routes_cost(
+        nxos_route: NxosEvpnRoute,
+        batfish_route: EvpnRibRoute,
+    ) -> CostResult:
+        if nxos_route.network != batfish_route.network:
+            return [("network", math.inf)]
+        if nxos_route.route_distinguisher != batfish_route.route_distinguisher:
+            return [("route_distinguisher", math.inf)]
+
+        cost: CostResult = []
+
+        if (
+            batfish_route.next_hop_ip is not None
+            and batfish_route.next_hop_ip != nxos_route.next_hop_ip
+        ):
+            cost.append(("next_hop_ip", 10.0))
+
+        nxos_metric = 0 if nxos_route.metric is None else nxos_route.metric
+        if batfish_route.metric != nxos_metric:
+            cost.append(("metric", 1.0))
+        if batfish_route.local_preference != nxos_route.local_preference:
+            cost.append(("local_preference", 1.0))
+        if batfish_route.as_path != nxos_route.as_path:
+            cost.append(("as_path", 1.0))
+        if not NxosValidator._bgp_origin_type_compatible(
+            batfish_route.origin_type, nxos_route.origin_type
+        ):
+            cost.append(("origin_type", 1.0))
+
         return cost
 
     @staticmethod
@@ -305,6 +369,19 @@ class NxosValidator(VendorValidator):
             return []
 
         return parse_show_ip_bgp_all(file_text)
+
+    def _get_evpn_routes(self) -> Sequence[NxosEvpnRoute]:
+        """Parses and returns EVPN routes from show bgp l2vpn evpn."""
+
+        evpn_path = self.device_path / "show_bgp_l2vpn_evpn.txt"
+        if not evpn_path.is_file():
+            return []
+
+        file_text = evpn_path.read_text()
+        if not file_text.strip():
+            return []
+
+        return parse_show_bgp_l2vpn_evpn(file_text)
 
     @staticmethod
     def compute_protocol_cost(nxos_protocol: str, batfish_protocol: str) -> CostResult:

--- a/tests/lab_validation/parsers/nxos/commands/test_evpn_routes.py
+++ b/tests/lab_validation/parsers/nxos/commands/test_evpn_routes.py
@@ -1,0 +1,226 @@
+from lab_validation.parsers.nxos.commands.evpn_routes import (
+    _extract_ip_network,
+    parse_show_bgp_l2vpn_evpn,
+)
+from lab_validation.parsers.nxos.models.routes import NxosEvpnRoute
+
+_L2VNI_HEADER = """\
+BGP routing table information for VRF default, address family L2VPN EVPN
+BGP table version is 23, Local Router ID is 1.1.1.1
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup, 2 - best2
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+"""
+
+
+class TestExtractIpNetwork:
+    def test_type5(self) -> None:
+        assert (
+            _extract_ip_network("[5]:[0]:[0]:[24]:[192.168.10.0]/224")
+            == "192.168.10.0/24"
+        )
+
+    def test_type5_host(self) -> None:
+        assert _extract_ip_network("[5]:[0]:[0]:[32]:[10.0.0.1]/224") == "10.0.0.1/32"
+
+    def test_type3(self) -> None:
+        assert _extract_ip_network("[3]:[0]:[32]:[1.1.1.1]/88") == "1.1.1.1/32"
+
+    def test_type2_with_ip_skipped(self) -> None:
+        assert (
+            _extract_ip_network(
+                "[2]:[0]:[0]:[48]:[0c8e.9b19.2d01]:[32]:[192.168.10.2]/248"
+            )
+            is None
+        )
+
+    def test_type2_mac_only_skipped(self) -> None:
+        assert (
+            _extract_ip_network("[2]:[0]:[0]:[48]:[0c8e.9b19.2d01]:[0]:[0.0.0.0]/216")
+            is None
+        )
+
+
+class TestParseShowBgpL2vpnEvpn:
+    def test_type5_routes(self) -> None:
+        text = (
+            _L2VNI_HEADER
+            + """\
+Route Distinguisher: 2.2.2.2:3
+*>i[5]:[0]:[0]:[24]:[192.168.20.0]/224
+                      2.2.2.2                  0        100          0 ?
+
+Route Distinguisher: 1.1.1.1:3    (L3VNI 100777)
+*>l[5]:[0]:[0]:[24]:[192.168.10.0]/224
+                      1.1.1.1                  0        100      32768 ?
+"""
+        )
+        routes = parse_show_bgp_l2vpn_evpn(text)
+        assert routes == [
+            NxosEvpnRoute(
+                route_distinguisher="2.2.2.2:3",
+                network="192.168.20.0/24",
+                next_hop_ip="2.2.2.2",
+                metric=0,
+                local_preference=100,
+                weight=0,
+                as_path=(),
+                best_path=True,
+                origin_type="?",
+            ),
+            NxosEvpnRoute(
+                route_distinguisher="1.1.1.1:3",
+                network="192.168.10.0/24",
+                next_hop_ip="1.1.1.1",
+                metric=0,
+                local_preference=100,
+                weight=32768,
+                as_path=(),
+                best_path=True,
+                origin_type="?",
+            ),
+        ]
+
+    def test_type3_imet_routes(self) -> None:
+        text = (
+            _L2VNI_HEADER
+            + """\
+Route Distinguisher: 1.1.1.1:32777    (L2VNI 5010)
+*>l[3]:[0]:[32]:[1.1.1.1]/88
+                      1.1.1.1                           100      32768 i
+*>i[3]:[0]:[32]:[2.2.2.2]/88
+                      2.2.2.2                           100          0 i
+"""
+        )
+        routes = parse_show_bgp_l2vpn_evpn(text)
+        assert routes == [
+            NxosEvpnRoute(
+                route_distinguisher="1.1.1.1:32777",
+                network="1.1.1.1/32",
+                next_hop_ip="1.1.1.1",
+                metric=None,
+                local_preference=100,
+                weight=32768,
+                as_path=(),
+                best_path=True,
+                origin_type="i",
+            ),
+            NxosEvpnRoute(
+                route_distinguisher="1.1.1.1:32777",
+                network="2.2.2.2/32",
+                next_hop_ip="2.2.2.2",
+                metric=None,
+                local_preference=100,
+                weight=0,
+                as_path=(),
+                best_path=True,
+                origin_type="i",
+            ),
+        ]
+
+    def test_type2_routes_skipped(self) -> None:
+        """Type 2 (MAC/IP) routes are not modeled by Batfish and should be skipped."""
+        text = (
+            _L2VNI_HEADER
+            + """\
+Route Distinguisher: 1.1.1.1:32777    (L2VNI 5010)
+*>i[2]:[0]:[0]:[48]:[0c8e.9b19.2d01]:[0]:[0.0.0.0]/216
+                      2.2.2.2                           100          0 i
+*>l[2]:[0]:[0]:[48]:[0c8e.9ba4.5401]:[32]:[192.168.10.1]/248
+                      1.1.1.1                           100      32768 i
+*>l[3]:[0]:[32]:[1.1.1.1]/88
+                      1.1.1.1                           100      32768 i
+"""
+        )
+        routes = parse_show_bgp_l2vpn_evpn(text)
+        assert len(routes) == 1
+        assert routes[0].network == "1.1.1.1/32"
+
+    def test_multiple_rd_blocks(self) -> None:
+        text = (
+            _L2VNI_HEADER
+            + """\
+Route Distinguisher: 1.1.1.1:3    (L3VNI 100777)
+*>l[5]:[0]:[0]:[24]:[192.168.10.0]/224
+                      1.1.1.1                  0        100      32768 ?
+
+Route Distinguisher: 2.2.2.2:3
+*>i[5]:[0]:[0]:[24]:[192.168.20.0]/224
+                      2.2.2.2                  0        100          0 ?
+"""
+        )
+        routes = parse_show_bgp_l2vpn_evpn(text)
+        assert len(routes) == 2
+        assert routes[0].route_distinguisher == "1.1.1.1:3"
+        assert routes[1].route_distinguisher == "2.2.2.2:3"
+
+    def test_route_with_as_path(self) -> None:
+        text = (
+            _L2VNI_HEADER
+            + """\
+Route Distinguisher: 10.0.0.1:3
+*>e[5]:[0]:[0]:[24]:[172.16.0.0]/224
+                      10.0.0.2                 0        100          0 65001 65002 i
+"""
+        )
+        routes = parse_show_bgp_l2vpn_evpn(text)
+        assert len(routes) == 1
+        assert routes[0].as_path == (65001, 65002)
+        assert routes[0].origin_type == "i"
+
+    def test_non_best_path(self) -> None:
+        text = (
+            _L2VNI_HEADER
+            + """\
+Route Distinguisher: 1.1.1.1:3
+* i[5]:[0]:[0]:[24]:[192.168.10.0]/224
+                      1.1.1.1                  0        100          0 ?
+"""
+        )
+        routes = parse_show_bgp_l2vpn_evpn(text)
+        assert len(routes) == 1
+        assert routes[0].best_path is False
+
+    def test_real_l3vni_data(self) -> None:
+        """Parse actual NX-OS L3VNI lab data."""
+        text = """\
+BGP routing table information for VRF default, address family L2VPN EVPN
+BGP table version is 24, Local Router ID is 1.1.1.1
+Status: s-suppressed, x-deleted, S-stale, d-dampened, h-history, *-valid, >-best
+Path type: i-internal, e-external, c-confed, l-local, a-aggregate, r-redist, I-injected
+Origin codes: i - IGP, e - EGP, ? - incomplete, | - multipath, & - backup, 2 - best2
+
+   Network            Next Hop            Metric     LocPrf     Weight Path
+Route Distinguisher: 2.2.2.2:3
+*>i[5]:[0]:[0]:[24]:[192.168.20.0]/224
+                      2.2.2.2                  0        100          0 ?
+
+Route Distinguisher: 1.1.1.1:3    (L3VNI 100777)
+*>l[5]:[0]:[0]:[24]:[192.168.10.0]/224
+                      1.1.1.1                  0        100      32768 ?"""
+        routes = parse_show_bgp_l2vpn_evpn(text)
+        assert len(routes) == 2
+        assert routes[0] == NxosEvpnRoute(
+            route_distinguisher="2.2.2.2:3",
+            network="192.168.20.0/24",
+            next_hop_ip="2.2.2.2",
+            metric=0,
+            local_preference=100,
+            weight=0,
+            as_path=(),
+            best_path=True,
+            origin_type="?",
+        )
+        assert routes[1] == NxosEvpnRoute(
+            route_distinguisher="1.1.1.1:3",
+            network="192.168.10.0/24",
+            next_hop_ip="1.1.1.1",
+            metric=0,
+            local_preference=100,
+            weight=32768,
+            as_path=(),
+            best_path=True,
+            origin_type="?",
+        )

--- a/tests/lab_validation/validators/test_nxosValidator.py
+++ b/tests/lab_validation/validators/test_nxosValidator.py
@@ -5,11 +5,19 @@ from pybatfish.datamodel import NextHopDiscard, NextHopInterface
 from pybatfish.datamodel.route import NextHopIp, NextHopVtep
 
 from lab_validation.parsers.nxos.models.interfaces import NxosInterface
-from lab_validation.parsers.nxos.models.routes import NxosBgpRoute, NxosMainRibRoute
+from lab_validation.parsers.nxos.models.routes import (
+    NxosBgpRoute,
+    NxosEvpnRoute,
+    NxosMainRibRoute,
+)
 from lab_validation.validators.batfish_models.interface_properties import (
     InterfaceProperties,
 )
-from lab_validation.validators.batfish_models.routes import BgpRibRoute, MainRibRoute
+from lab_validation.validators.batfish_models.routes import (
+    BgpRibRoute,
+    EvpnRibRoute,
+    MainRibRoute,
+)
 from lab_validation.validators.NxosValidator import NxosValidator
 
 
@@ -742,3 +750,122 @@ def test_mgmt_route_skipped() -> None:
         )
     ]
     assert NxosValidator._validate_main_rib_routes(batfish_routes, real_routes) == {}
+
+
+_NXOS_EVPN = NxosEvpnRoute(
+    route_distinguisher="1.1.1.1:3",
+    network="192.168.10.0/24",
+    next_hop_ip="1.1.1.1",
+    metric=0,
+    local_preference=100,
+    weight=32768,
+    as_path=(),
+    best_path=True,
+    origin_type="?",
+)
+
+_BF_EVPN = EvpnRibRoute(
+    vrf="default",
+    network="192.168.10.0/24",
+    route_distinguisher="1.1.1.1:3",
+    next_hop=NextHopVtep(vni=100777, vtep="1.1.1.1"),
+    next_hop_ip=None,
+    next_hop_int="null_interface",
+    protocol="bgp",
+    as_path="",
+    metric=0,
+    local_preference=100,
+    communities=(),
+    origin_protocol=None,
+    origin_type="incomplete",
+    tag=None,
+)
+
+
+def test_evpn_cost_equal() -> None:
+    assert NxosValidator._diff_evpn_routes_cost(_NXOS_EVPN, _BF_EVPN) == []
+
+
+def test_evpn_cost_network_mismatch() -> None:
+    assert NxosValidator._diff_evpn_routes_cost(
+        attr.evolve(_NXOS_EVPN, network="10.0.0.0/8"), _BF_EVPN
+    ) == [("network", math.inf)]
+
+
+def test_evpn_cost_rd_mismatch() -> None:
+    assert NxosValidator._diff_evpn_routes_cost(
+        attr.evolve(_NXOS_EVPN, route_distinguisher="9.9.9.9:3"), _BF_EVPN
+    ) == [("route_distinguisher", math.inf)]
+
+
+def test_evpn_cost_next_hop_ip_mismatch() -> None:
+    bf = attr.evolve(_BF_EVPN, next_hop_ip="2.2.2.2")
+    assert NxosValidator._diff_evpn_routes_cost(_NXOS_EVPN, bf) == [
+        ("next_hop_ip", 10.0)
+    ]
+
+
+def test_evpn_cost_next_hop_ip_none_skipped() -> None:
+    assert NxosValidator._diff_evpn_routes_cost(_NXOS_EVPN, _BF_EVPN) == []
+
+
+def test_evpn_cost_metric_mismatch() -> None:
+    assert NxosValidator._diff_evpn_routes_cost(
+        attr.evolve(_NXOS_EVPN, metric=5), _BF_EVPN
+    ) == [("metric", 1.0)]
+
+
+def test_evpn_cost_metric_none_treated_as_zero() -> None:
+    assert (
+        NxosValidator._diff_evpn_routes_cost(
+            attr.evolve(_NXOS_EVPN, metric=None), _BF_EVPN
+        )
+        == []
+    )
+
+
+def test_evpn_cost_local_preference_mismatch() -> None:
+    assert NxosValidator._diff_evpn_routes_cost(
+        attr.evolve(_NXOS_EVPN, local_preference=200), _BF_EVPN
+    ) == [("local_preference", 1.0)]
+
+
+def test_evpn_cost_as_path_mismatch() -> None:
+    assert NxosValidator._diff_evpn_routes_cost(
+        attr.evolve(_NXOS_EVPN, as_path=(65001,)), _BF_EVPN
+    ) == [("as_path", 1.0)]
+
+
+def test_evpn_cost_origin_type_mismatch() -> None:
+    assert NxosValidator._diff_evpn_routes_cost(
+        attr.evolve(_NXOS_EVPN, origin_type="i"), _BF_EVPN
+    ) == [("origin_type", 1.0)]
+
+
+def test_evpn_cost_multiple_mismatches() -> None:
+    nxos = attr.evolve(_NXOS_EVPN, metric=5, local_preference=200, origin_type="i")
+    cost = NxosValidator._diff_evpn_routes_cost(nxos, _BF_EVPN)
+    assert set(cost) == {
+        ("metric", 1.0),
+        ("local_preference", 1.0),
+        ("origin_type", 1.0),
+    }
+
+
+def test_evpn_validate_non_best_path_skipped() -> None:
+    nxos = attr.evolve(_NXOS_EVPN, best_path=False)
+    assert NxosValidator._validate_evpn_rib_routes([nxos], []) == {}
+
+
+def test_evpn_validate_matching() -> None:
+    assert NxosValidator._validate_evpn_rib_routes([_NXOS_EVPN], [_BF_EVPN]) == {}
+
+
+def test_evpn_validate_missing_from_batfish() -> None:
+    result = NxosValidator._validate_evpn_rib_routes([_NXOS_EVPN], [])
+    assert len(result) == 1
+
+
+def test_evpn_validate_extra_in_batfish() -> None:
+    result = NxosValidator._validate_evpn_rib_routes([], [_BF_EVPN])
+    assert len(result) == 1


### PR DESCRIPTION
Add EVPN route parsing and validation for NX-OS devices. The
pyparsing-based parser extracts Type 3 (IMET) and Type 5 (IP Prefix)
routes from `show bgp l2vpn evpn` output, converting EVPN NLRIs to
IP prefixes to match Batfish's representation. Type 2 (MAC/IP) routes
are skipped as Batfish does not model them.

The validator uses cost-based matching (match_pairs) comparing
network, RD, next-hop IP, metric, local preference, AS path, and
origin type — consistent with the existing BGP RIB validation pattern.

L3VNI lab passes clean; L2VNI lab has known xfails where NX-OS
duplicates remote IMET routes under the local VNI's RD but Batfish
does not.

Fixes #23

----

Prompt:
```
Implement https://github.com/batfish/lab-validation/issues/23
(but do not push anything to github) - I'll do that.
```