### PR TITLE
sickbay: retire issues/45 and issues/48 from juniper_resolution

### DIFF
--- a/snapshots/juniper_resolution/validation/sickbay.yaml
+++ b/snapshots/juniper_resolution/validation/sickbay.yaml
@@ -2,8 +2,8 @@ entries:
   - hostname: r1
     test_name: test_main_rib_routes
     skip:
-      reason: https://github.com/batfish/lab-validation/issues/45, https://github.com/batfish/lab-validation/issues/46
+      reason: https://github.com/batfish/lab-validation/issues/46
   - hostname: r1
     test_name: test_bgp_rib_routes
     skip:
-      reason: https://github.com/batfish/lab-validation/issues/48, https://github.com/batfish/lab-validation/issues/46
+      reason: https://github.com/batfish/lab-validation/issues/46


### PR DESCRIPTION
Issue #45 (Junos static route resolve/no-resolve) is fixed: all 9 static
routes are correctly modeled. Issue #48 (BGP suppression by connected
routes) was not the cause of failures here; the remaining failures are
solely due to issue #46 (resolution RIB import policy).

Fixes #45

----

Prompt:
```
What's up with https://github.com/batfish/lab-validation/issues/45 ? I
thought we implemented this in Batfish a long time ago. Can you validate
that lab and dig into what's missing?
```