### PR TITLE
sickbay: retire issues/44 from junos_ebgp_loop_prevention

### DIFF
--- a/snapshots/junos_ebgp_loop_prevention/validation/sickbay.yaml
+++ b/snapshots/junos_ebgp_loop_prevention/validation/sickbay.yaml
@@ -1,5 +1,0 @@
-entries:
-  - hostname: d6
-    test_name: test_bgp_rib_routes
-    skip:
-      reason: https://github.com/batfish/lab-validation/issues/44


### PR DESCRIPTION
Fixed in Batfish by modeling Junos advertise-peer-as with
EXCEPT_RECEIVED_FROM mode, which blocks re-advertisement
to the originating peer.

Closes #44.

----

Prompt:
```
Read up on https://github.com/batfish/lab-validation/issues/44 and
dig into both Batfish and the affected labs. Also note that there
are junos manuals in ./batfish/working/
```