### PR TITLE
infra: improve health-check robustness and EC2 setup

### DIFF
--- a/infra/ec2-launch.sh
+++ b/infra/ec2-launch.sh
@@ -16,7 +16,7 @@
 #   - A security group allowing SSH from your current IP
 #   - A key pair (if --key-name not provided)
 #   - An EC2 instance with ec2-setup.sh as user-data
-#   - A CloudWatch alarm to auto-terminate after --timeout-hours (default: 4)
+#   - Auto-termination via scheduled shutdown (InstanceInitiatedShutdownBehavior=terminate)
 #
 # Instance state is saved to ~/.lab-validation/instance.json for use by other scripts.
 
@@ -225,9 +225,11 @@ else
 fi
 
 # Generate user-data script with parameters baked in
+TIMEOUT_MINUTES=$((TIMEOUT_HOURS * 60))
 USER_DATA_FILE=$(mktemp)
 sed -e "s|%%BUCKET_NAME%%|${BUCKET_NAME}|g" \
     -e "s|%%IMAGE_FILTER%%|${IMAGE_FILTER}|g" \
+    -e "s|%%TIMEOUT_MINUTES%%|${TIMEOUT_MINUTES}|g" \
     "${SCRIPT_DIR}/ec2-setup.sh" > "${USER_DATA_FILE}"
 
 # Build run-instances command
@@ -239,6 +241,7 @@ RUN_ARGS=(
     --user-data "file://${USER_DATA_FILE}"
     --iam-instance-profile "Name=${PROFILE_NAME}"
     --cpu-options "NestedVirtualization=enabled"
+    --instance-initiated-shutdown-behavior terminate
     --block-device-mappings '[{"DeviceName":"/dev/sda1","Ebs":{"VolumeSize":50,"VolumeType":"gp3"}}]'
     --tag-specifications "ResourceType=instance,Tags=[{Key=Name,Value=lab-validation-containerlab},{Key=Project,Value=lab-validation}]"
     --query 'Instances[0].InstanceId'
@@ -267,25 +270,9 @@ PUBLIC_IP=$(aws ec2 describe-instances \
     --output text)
 echo "Public IP: ${PUBLIC_IP}"
 
-# Set up auto-termination alarm
-echo "Setting auto-terminate alarm (${TIMEOUT_HOURS}h)..."
-ALARM_NAME="lab-validation-auto-terminate-${INSTANCE_ID}"
-aws cloudwatch put-metric-alarm \
-    --alarm-name "${ALARM_NAME}" \
-    --namespace AWS/EC2 \
-    --metric-name CPUUtilization \
-    --statistic Average \
-    --period 300 \
-    --evaluation-periods 1 \
-    --threshold 100 \
-    --comparison-operator GreaterThanThreshold \
-    --alarm-actions "arn:aws:automate:${REGION}:ec2:terminate" \
-    --dimensions "Name=InstanceId,Value=${INSTANCE_ID}" \
-    --treat-missing-data missing 2>/dev/null || true
-
-# Schedule the alarm to fire after timeout (set state to ALARM after delay)
-# We use a simpler approach: tag with expiry time, and the alarm is a safety net.
-# The real auto-termination relies on the alarm being set to ALARM state.
+# Auto-termination is handled by `shutdown` scheduled in ec2-setup.sh.
+# The instance has InstanceInitiatedShutdownBehavior=terminate, so
+# shutdown will terminate it (and delete the EBS volume).
 EXPIRY=$(date -u -v+${TIMEOUT_HOURS}H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
          date -u -d "+${TIMEOUT_HOURS} hours" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
          echo "unknown")
@@ -303,7 +290,6 @@ state = {
     'key_name': '${KEY_NAME}',
     'key_file': '${KEY_FILE}',
     'security_group_id': '${SG_ID}',
-    'alarm_name': '${ALARM_NAME}',
     'auto_terminate_after': '${EXPIRY}',
     'spot': True if '${USE_SPOT}' == 'true' else False,
 }

--- a/infra/ec2-setup.sh
+++ b/infra/ec2-setup.sh
@@ -19,6 +19,7 @@ set -euo pipefail
 
 BUCKET_NAME="%%BUCKET_NAME%%"
 IMAGE_FILTER="%%IMAGE_FILTER%%"
+TIMEOUT_MINUTES="%%TIMEOUT_MINUTES%%"
 
 LOG_FILE="/var/log/ec2-setup.log"
 exec > >(tee -a "${LOG_FILE}") 2>&1
@@ -26,6 +27,11 @@ exec > >(tee -a "${LOG_FILE}") 2>&1
 echo "=== ec2-setup.sh starting at $(date -u) ==="
 echo "Image bucket: ${BUCKET_NAME}"
 echo "Image filter: ${IMAGE_FILTER}"
+
+# Schedule auto-shutdown. The instance is configured with
+# InstanceInitiatedShutdownBehavior=terminate, so this terminates it.
+echo "Scheduling shutdown in ${TIMEOUT_MINUTES} minutes"
+shutdown -h +${TIMEOUT_MINUTES}
 
 # Check if an image tag matches the filter.
 # Usage: image_wanted <tag>  (e.g., image_wanted "vjunos-router")
@@ -84,6 +90,10 @@ echo "--- Installing Python tools ---"
 apt-get install -y python3-pip python3-venv
 pip3 install --break-system-packages --ignore-installed netmiko paramiko PyYAML
 pip3 install --break-system-packages awscli
+
+# Debugging tools
+echo "--- Installing debugging tools ---"
+apt-get install -y sshpass jq
 
 # --- Load network OS images ---
 echo "--- Loading network OS images ---"

--- a/infra/ec2-teardown.sh
+++ b/infra/ec2-teardown.sh
@@ -26,15 +26,6 @@ echo "Terminating instance: ${INSTANCE_ID}"
 aws ec2 terminate-instances --instance-ids "${INSTANCE_ID}" \
     --query 'TerminatingInstances[0].CurrentState.Name' --output text
 
-# Clean up CloudWatch alarm
-if [[ -f "${STATE_FILE}" ]]; then
-    ALARM_NAME=$(python3 -c "import json; print(json.load(open('${STATE_FILE}')).get('alarm_name', ''))" 2>/dev/null || true)
-    if [[ -n "${ALARM_NAME}" ]]; then
-        echo "Deleting alarm: ${ALARM_NAME}"
-        aws cloudwatch delete-alarms --alarm-names "${ALARM_NAME}" 2>/dev/null || true
-    fi
-fi
-
 # Remove state file
 rm -f "${STATE_FILE}"
 echo "Instance terminated. State file removed."

--- a/src/lab_builder/device.py
+++ b/src/lab_builder/device.py
@@ -77,11 +77,18 @@ def check_ssh_reachable(node: NodeInfo, timeout: int = 10) -> bool:
         return False
 
 
-def wait_for_ssh(node: NodeInfo, timeout: int = 900, interval: int = 15) -> bool:
+def wait_for_ssh(
+    node: NodeInfo,
+    timeout: int = 900,
+    interval: int = 15,
+    max_auth_failures: int = 5,
+) -> bool:
     """Wait until SSH is reachable on a node.
 
     Returns True if reachable within timeout, False otherwise.
-    Raises SshPermanentError immediately on non-transient failures.
+    Raises SshPermanentError if authentication fails repeatedly (more than
+    *max_auth_failures* consecutive times), indicating bad credentials
+    rather than a device still booting.
     """
     # Suppress paramiko's transport thread tracebacks during retries.
     # Without this, every failed SSH attempt prints a multi-line exception
@@ -92,12 +99,28 @@ def wait_for_ssh(node: NodeInfo, timeout: int = 900, interval: int = 15) -> bool
 
     deadline = time.time() + timeout
     attempt = 0
+    consecutive_auth_failures = 0
     try:
         while time.time() < deadline:
             attempt += 1
-            if check_ssh_reachable(node, timeout=10):
-                print(f"  {node.name}: SSH reachable (attempt {attempt})")
-                return True
+            try:
+                if check_ssh_reachable(node, timeout=10):
+                    print(f"  {node.name}: SSH reachable (attempt {attempt})")
+                    return True
+                consecutive_auth_failures = 0
+            except SshPermanentError:
+                consecutive_auth_failures += 1
+                remaining = int(deadline - time.time())
+                print(
+                    f"  {node.name}: SSH auth failed "
+                    f"(attempt {attempt}, "
+                    f"{consecutive_auth_failures}/{max_auth_failures}, "
+                    f"{remaining}s remaining)"
+                )
+                if consecutive_auth_failures >= max_auth_failures:
+                    raise
+                time.sleep(interval)
+                continue
             remaining = int(deadline - time.time())
             print(
                 f"  {node.name}: SSH not ready "

--- a/src/lab_builder/health.py
+++ b/src/lab_builder/health.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import time
 
-from lab_builder.device import run_command, wait_for_ssh
+from lab_builder.device import SshPermanentError, run_command, wait_for_ssh
 from lab_builder.models import HealthStatus, NodeInfo
 
 # ---------------------------------------------------------------------------
@@ -16,7 +16,7 @@ from lab_builder.models import HealthStatus, NodeInfo
 def _junos_check_bgp(node: NodeInfo) -> bool | None:
     """Check if all BGP neighbors are Established. Returns None if no BGP configured."""
     try:
-        output = run_command(node, "show bgp neighbor | display json")
+        output = run_command(node, "show bgp neighbor | display json", timeout=10)
         data = json.loads(output)
     except Exception:
         return False
@@ -41,7 +41,7 @@ def _junos_check_bgp(node: NodeInfo) -> bool | None:
 def _junos_check_ospf(node: NodeInfo) -> bool | None:
     """Check if all OSPF neighbors are Full. Returns None if no OSPF configured."""
     try:
-        output = run_command(node, "show ospf neighbor | display json")
+        output = run_command(node, "show ospf neighbor | display json", timeout=10)
         data = json.loads(output)
     except Exception:
         return False
@@ -66,7 +66,7 @@ def _junos_check_ospf(node: NodeInfo) -> bool | None:
 def _junos_check_isis(node: NodeInfo) -> bool | None:
     """Check if all ISIS adjacencies are Up. Returns None if no ISIS configured."""
     try:
-        output = run_command(node, "show isis adjacency | display json")
+        output = run_command(node, "show isis adjacency | display json", timeout=10)
         data = json.loads(output)
     except Exception:
         return False
@@ -97,7 +97,7 @@ def _junos_check_platform_warnings(node: NodeInfo) -> list[str]:
     comments in 'show configuration'.
     """
     try:
-        output = run_command(node, "show configuration")
+        output = run_command(node, "show configuration", timeout=10)
     except Exception:
         return []
     warnings = []
@@ -115,7 +115,7 @@ def _junos_check_platform_warnings(node: NodeInfo) -> list[str]:
 def _arista_check_bgp(node: NodeInfo) -> bool | None:
     """Check if all BGP peers are Established via 'show ip bgp summary | json'."""
     try:
-        output = run_command(node, "show ip bgp summary | json")
+        output = run_command(node, "show ip bgp summary | json", timeout=10)
         data = json.loads(output)
     except Exception:
         return False
@@ -139,7 +139,7 @@ def _arista_check_bgp(node: NodeInfo) -> bool | None:
 def _arista_check_ospf(node: NodeInfo) -> bool | None:
     """Check if all OSPF neighbors are full via 'show ip ospf neighbor | json'."""
     try:
-        output = run_command(node, "show ip ospf neighbor | json")
+        output = run_command(node, "show ip ospf neighbor | json", timeout=10)
         data = json.loads(output)
     except Exception:
         return False
@@ -164,7 +164,7 @@ def _arista_check_ospf(node: NodeInfo) -> bool | None:
 def _arista_check_isis(node: NodeInfo) -> bool | None:
     """Check if all ISIS adjacencies are up via 'show isis neighbors | json'."""
     try:
-        output = run_command(node, "show isis neighbors | json")
+        output = run_command(node, "show isis neighbors | json", timeout=10)
         data = json.loads(output)
     except Exception:
         return False
@@ -225,7 +225,12 @@ def check_node_health(node: NodeInfo) -> HealthStatus:
     """Run all health checks on a single node."""
     status = HealthStatus(node=node.name)
 
-    status.ssh_reachable = wait_for_ssh(node, timeout=10, interval=5)
+    try:
+        status.ssh_reachable = wait_for_ssh(node, timeout=10, interval=5)
+    except SshPermanentError:
+        status.ssh_reachable = False
+        status.details = "SSH authentication failed"
+        return status
     if not status.ssh_reachable:
         status.details = "SSH not reachable"
         return status
@@ -260,18 +265,24 @@ def wait_for_convergence(
     print("Waiting for SSH on all nodes...")
     boot_timeout = max(n.profile.boot_timeout_seconds for n in nodes)
     for node in nodes:
-        if not wait_for_ssh(node, timeout=boot_timeout, interval=15):
-            print(f"  {node.name}: TIMEOUT waiting for SSH")
-            return [HealthStatus(node=n.name, details="SSH timeout") for n in nodes]
+        try:
+            if not wait_for_ssh(node, timeout=boot_timeout, interval=15):
+                print(f"  {node.name}: TIMEOUT waiting for SSH")
+                return [HealthStatus(node=n.name, details="SSH timeout") for n in nodes]
+        except SshPermanentError:
+            print(f"  {node.name}: SSH authentication failed persistently")
+            return [HealthStatus(node=n.name, details="SSH auth failed") for n in nodes]
 
     print("All nodes reachable. Waiting for routing protocol convergence...")
     deadline = time.time() + timeout
     while time.time() < deadline:
-        statuses = [check_node_health(node) for node in nodes]
+        statuses = []
+        for node in nodes:
+            print(f"  Checking {node.name}...", end="", flush=True)
+            s = check_node_health(node)
+            print(f" {'OK' if s.healthy else 'WAITING'} - {s.details}")
+            statuses.append(s)
         all_healthy = all(s.healthy for s in statuses)
-
-        for s in statuses:
-            print(f"  {s.node}: {'OK' if s.healthy else 'WAITING'} - {s.details}")
 
         if all_healthy:
             print("All nodes converged. Checking for platform warnings...")


### PR DESCRIPTION
Three fixes for issues encountered during lab builds:

1. ec2-setup: install sshpass and jq for ad-hoc debugging on EC2
2. device.py: retry SSH auth failures during boot window instead of
crashing immediately. vrnetlab containers expose SSH before the
device OS loads credentials, causing transient auth failures.
wait_for_ssh now retries up to 5 consecutive auth failures before
treating them as permanent.
3. health.py: add per-node progress output during convergence polling
("Checking <node>...") so hangs are immediately visible, and reduce
run_command timeouts from 60s to 10s for protocol status checks.

Also includes the CloudWatch alarm → shutdown timer migration for EC2
auto-termination (ec2-launch.sh, ec2-setup.sh, ec2-teardown.sh).

----

Prompt:
```
Ok now let's plan out your 1/2/3
[referring to three issues from the community-delete lab build:
1. install sshpass on EC2 by default
2. health-check crashes on SSH auth failure during boot
3. health-check hangs with no progress output]
```