### PR TITLE
junos_community_delete: add lab testing community delete with .*:.*

### DIFF
--- a/infra/examples/junos-community-delete/README.md
+++ b/infra/examples/junos-community-delete/README.md
@@ -1,0 +1,85 @@
+# Junos Community Delete Lab
+
+Does `community delete ALL-COMMUNITIES` with `members .*:.*` actually remove
+**all** community types from a BGP route?
+
+## Hypothesis
+
+The regex `.*:.*` requires a colon character. Well-known communities like
+`no-export`, `no-advertise`, and `no-export-subconfed` are represented as
+keywords, not `ASN:value` pairs. They may not match, and therefore survive
+the delete.
+
+## Topology
+
+```
+sender (AS 65001) --- dut (AS 65002) --- collector (AS 65003)
+       ge-0/0/0  <->  ge-0/0/0  ge-0/0/1  <->  ge-0/0/0
+       10.0.12.0      10.0.12.1 10.0.23.0      10.0.23.1
+```
+
+## Test Routes
+
+sender originates these static routes and tags each with a specific community
+via export policy:
+
+| Prefix       | Community Applied         | Type                      |
+| ------------ | ------------------------- | ------------------------- |
+| 10.10.0.0/24 | (none)                    | control                   |
+| 10.10.1.0/24 | 65001:100                 | standard                  |
+| 10.10.2.0/24 | no-export                 | well-known standard       |
+| 10.10.3.0/24 | no-advertise              | well-known standard       |
+| 10.10.4.0/24 | no-export-subconfed       | well-known standard       |
+| 10.10.5.0/24 | target:65001:200          | extended (route-target)   |
+| 10.10.6.0/24 | origin:65001:300          | extended (site-of-origin) |
+| 10.10.7.0/24 | large:65001:1:1           | large                     |
+| 10.10.8.0/24 | all of the above combined | kitchen sink              |
+
+## DUT Policy
+
+```junos
+community ALL-COMMUNITIES members .*:.*;
+policy-statement STRIP-COMMUNITIES {
+    term STRIP {
+        then {
+            community delete ALL-COMMUNITIES;
+            accept;
+        }
+    }
+}
+```
+
+Applied as import policy on the session with sender.
+
+## What to Observe
+
+### On dut
+
+All 9 routes should be present in `inet.0`. Check communities on each route:
+
+- If the delete worked fully, routes should have no communities
+- If well-known communities survived, `10.10.2.0/24`, `10.10.3.0/24`,
+  `10.10.4.0/24` will still carry them
+
+### On collector
+
+If `no-export` survived the delete on dut, `10.10.2.0/24` will NOT be
+advertised to collector (no-export prevents eBGP advertisement).
+
+If `no-advertise` survived, `10.10.3.0/24` will NOT be advertised at all.
+
+If `no-export-subconfed` survived, `10.10.4.0/24` may or may not appear
+depending on AS relationship.
+
+The control route (`10.10.0.0/24`) and standard community route
+(`10.10.1.0/24`) should always reach collector regardless.
+
+### Key Commands for Manual Inspection
+
+```
+# Check communities on routes at dut
+show route protocol bgp community detail | display json
+
+# Check which routes reach collector
+show route protocol bgp | display json   (on collector)
+```

--- a/infra/examples/junos-community-delete/checks.yaml
+++ b/infra/examples/junos-community-delete/checks.yaml
@@ -1,0 +1,84 @@
+# Validation checks for the Junos community delete lab.
+# Run after health-check, before collection:
+#   lab_builder validate topology.clab.yml --checks checks.yaml
+
+checks:
+  # BGP sessions must be established
+  - type: bgp_peer_established
+    node: sender
+    neighbor: 10.0.12.1
+    description: "sender -> dut eBGP"
+  - type: bgp_peer_established
+    node: dut
+    neighbor: 10.0.12.0
+    description: "dut -> sender eBGP"
+  - type: bgp_peer_established
+    node: dut
+    neighbor: 10.0.23.1
+    description: "dut -> collector eBGP"
+  - type: bgp_peer_established
+    node: collector
+    neighbor: 10.0.23.0
+    description: "collector -> dut eBGP"
+
+  # Control route (no community) must reach collector
+  - type: route_exists
+    node: collector
+    table: inet.0
+    prefix: 10.10.0.0/24
+    description: "control route (no community) reaches collector"
+
+  # Standard community route should reach collector
+  # (community stripped, so no behavioral suppression)
+  - type: route_exists
+    node: collector
+    table: inet.0
+    prefix: 10.10.1.0/24
+    description: "standard community route reaches collector"
+
+  # All routes must be present on dut (imported from sender)
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.0.0/24
+    description: "control route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.1.0/24
+    description: "standard community route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.2.0/24
+    description: "no-export route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.3.0/24
+    description: "no-advertise route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.4.0/24
+    description: "no-export-subconfed route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.5.0/24
+    description: "extended target route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.6.0/24
+    description: "extended origin route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.7.0/24
+    description: "large community route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.10.8.0/24
+    description: "kitchen sink route present on dut"

--- a/infra/examples/junos-community-delete/configs/collector.cfg
+++ b/infra/examples/junos-community-delete/configs/collector.cfg
@@ -1,0 +1,33 @@
+system {
+    host-name collector;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 3.3.3.3/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to dut";
+        unit 0 {
+            family inet {
+                address 10.0.23.1/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65003;
+    router-id 3.3.3.3;
+}
+protocols {
+    bgp {
+        group FROM-DUT {
+            type external;
+            peer-as 65002;
+            neighbor 10.0.23.0;
+        }
+    }
+}

--- a/infra/examples/junos-community-delete/configs/dut.cfg
+++ b/infra/examples/junos-community-delete/configs/dut.cfg
@@ -1,0 +1,69 @@
+system {
+    host-name dut;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 2.2.2.2/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to sender";
+        unit 0 {
+            family inet {
+                address 10.0.12.1/31;
+            }
+        }
+    }
+    ge-0/0/1 {
+        description "link to collector";
+        unit 0 {
+            family inet {
+                address 10.0.23.0/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65002;
+    router-id 2.2.2.2;
+}
+policy-options {
+    /* The community under test: does .*:.* match ALL community types? */
+    community ALL-COMMUNITIES {
+        members .*:.*;
+    }
+    policy-statement STRIP-COMMUNITIES {
+        term STRIP {
+            then {
+                community delete ALL-COMMUNITIES;
+                accept;
+            }
+        }
+    }
+    policy-statement PASS-ALL {
+        term ACCEPT {
+            then accept;
+        }
+    }
+}
+protocols {
+    bgp {
+        group FROM-SENDER {
+            type external;
+            peer-as 65001;
+            neighbor 10.0.12.0 {
+                import STRIP-COMMUNITIES;
+            }
+        }
+        group TO-COLLECTOR {
+            type external;
+            peer-as 65003;
+            neighbor 10.0.23.1 {
+                export PASS-ALL;
+            }
+        }
+    }
+}

--- a/infra/examples/junos-community-delete/configs/sender.cfg
+++ b/infra/examples/junos-community-delete/configs/sender.cfg
@@ -1,0 +1,172 @@
+system {
+    host-name sender;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 1.1.1.1/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to dut";
+        unit 0 {
+            family inet {
+                address 10.0.12.0/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65001;
+    router-id 1.1.1.1;
+    static {
+        /* control: no community */
+        route 10.10.0.0/24 discard;
+        /* standard community */
+        route 10.10.1.0/24 discard;
+        /* well-known no-export */
+        route 10.10.2.0/24 discard;
+        /* well-known no-advertise */
+        route 10.10.3.0/24 discard;
+        /* well-known no-export-subconfed */
+        route 10.10.4.0/24 discard;
+        /* extended community: route-target */
+        route 10.10.5.0/24 discard;
+        /* extended community: site-of-origin */
+        route 10.10.6.0/24 discard;
+        /* large community */
+        route 10.10.7.0/24 discard;
+        /* kitchen sink: all community types at once */
+        route 10.10.8.0/24 discard;
+    }
+}
+policy-options {
+    community STANDARD {
+        members 65001:100;
+    }
+    community NO-EXPORT {
+        members no-export;
+    }
+    community NO-ADVERTISE {
+        members no-advertise;
+    }
+    community NO-EXPORT-SUBCONFED {
+        members no-export-subconfed;
+    }
+    community EXT-TARGET {
+        members target:65001:200;
+    }
+    community EXT-ORIGIN {
+        members origin:65001:300;
+    }
+    community LARGE {
+        members large:65001:1:1;
+    }
+    community KITCHEN-SINK-STD {
+        members [ 65001:999 no-export no-advertise no-export-subconfed ];
+    }
+    community KITCHEN-SINK-EXT {
+        members [ target:65001:999 origin:65001:888 ];
+    }
+    community KITCHEN-SINK-LARGE {
+        members large:65001:9:9;
+    }
+    policy-statement EXPORT-TAGGED {
+        term CONTROL {
+            from {
+                route-filter 10.10.0.0/24 exact;
+            }
+            then accept;
+        }
+        term TAG-STANDARD {
+            from {
+                route-filter 10.10.1.0/24 exact;
+            }
+            then {
+                community add STANDARD;
+                accept;
+            }
+        }
+        term TAG-NO-EXPORT {
+            from {
+                route-filter 10.10.2.0/24 exact;
+            }
+            then {
+                community add NO-EXPORT;
+                accept;
+            }
+        }
+        term TAG-NO-ADVERTISE {
+            from {
+                route-filter 10.10.3.0/24 exact;
+            }
+            then {
+                community add NO-ADVERTISE;
+                accept;
+            }
+        }
+        term TAG-NO-EXPORT-SUBCONFED {
+            from {
+                route-filter 10.10.4.0/24 exact;
+            }
+            then {
+                community add NO-EXPORT-SUBCONFED;
+                accept;
+            }
+        }
+        term TAG-EXT-TARGET {
+            from {
+                route-filter 10.10.5.0/24 exact;
+            }
+            then {
+                community add EXT-TARGET;
+                accept;
+            }
+        }
+        term TAG-EXT-ORIGIN {
+            from {
+                route-filter 10.10.6.0/24 exact;
+            }
+            then {
+                community add EXT-ORIGIN;
+                accept;
+            }
+        }
+        term TAG-LARGE {
+            from {
+                route-filter 10.10.7.0/24 exact;
+            }
+            then {
+                community add LARGE;
+                accept;
+            }
+        }
+        term TAG-KITCHEN-SINK {
+            from {
+                route-filter 10.10.8.0/24 exact;
+            }
+            then {
+                community add KITCHEN-SINK-STD;
+                community add KITCHEN-SINK-EXT;
+                community add KITCHEN-SINK-LARGE;
+                accept;
+            }
+        }
+        term REJECT {
+            then reject;
+        }
+    }
+}
+protocols {
+    bgp {
+        group TO-DUT {
+            type external;
+            peer-as 65002;
+            neighbor 10.0.12.1 {
+                export EXPORT-TAGGED;
+            }
+        }
+    }
+}

--- a/infra/examples/junos-community-delete/topology.clab.yml
+++ b/infra/examples/junos-community-delete/topology.clab.yml
@@ -1,0 +1,45 @@
+# Junos community delete lab: does "community delete" with members ".*:.*"
+# actually remove ALL community types?
+#
+# Topology:
+#   sender (AS 65001) --[ge-0/0/0]--[ge-0/0/0]-- dut (AS 65002) --[ge-0/0/1]--[ge-0/0/0]-- collector (AS 65003)
+#     lo0: 1.1.1.1/32                               lo0: 2.2.2.2/32                             lo0: 3.3.3.3/32
+#     link1: 10.0.12.0/31                           link1: 10.0.12.1/31
+#                                                    link2: 10.0.23.0/31                         link2: 10.0.23.1/31
+#
+# sender: originates 10.10.0-7.0/24 via static, tags each with a different
+#         community type (standard, no-export, no-advertise, no-export-subconfed,
+#         extended target, large, and a kitchen-sink combination).
+#
+# dut: imports from sender with:
+#         community delete ALL-COMMUNITIES (members ".*:.*")
+#       then exports to collector.
+#
+# collector: receives routes from dut; we inspect which routes arrive and
+#            which communities survived the delete.
+#
+# Key test: if well-known communities (no-export, no-advertise) survive the
+# delete, those routes won't reach the collector at all.
+
+name: junos-community-delete
+
+topology:
+  nodes:
+    sender:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/sender.cfg
+    dut:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/dut.cfg
+    collector:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/collector.cfg
+
+  links:
+    # sender ge-0/0/0 (eth1) <-> dut ge-0/0/0 (eth1)
+    - endpoints: ["sender:eth1", "dut:eth1"]
+    # dut ge-0/0/1 (eth2) <-> collector ge-0/0/0 (eth1)
+    - endpoints: ["dut:eth2", "collector:eth1"]

--- a/snapshots/junos_community_delete/configs/collector/show_configuration_|_display_set.txt
+++ b/snapshots/junos_community_delete/configs/collector/show_configuration_|_display_set.txt
@@ -1,0 +1,22 @@
+set version 25.4R1.12
+set system host-name collector
+set system root-authentication encrypted-password "$6$.oQWnIIt$AvLg/od3rTdv5z3ZDTdr/MlWafgjjIjjHPAj1dj1AiuXTk9L1ZSZQw70CBVbxi.HYmSHtLTDH4qHtq3dav04k/"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$BBfq5lEV$pXp7X7eWahqIJUSjTnJNZXNnVvZgmIS6pJnUZ403xneGFZo1fSOTXtcvaLK6YSpnFd5BdX84AZ1QX48g2gI3x1"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to dut"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.23.1/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 3.3.3.3/32
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 3.3.3.3
+set routing-options autonomous-system 65003
+set protocols bgp group FROM-DUT type external
+set protocols bgp group FROM-DUT peer-as 65002
+set protocols bgp group FROM-DUT neighbor 10.0.23.0

--- a/snapshots/junos_community_delete/configs/dut/show_configuration_|_display_set.txt
+++ b/snapshots/junos_community_delete/configs/dut/show_configuration_|_display_set.txt
@@ -1,0 +1,31 @@
+set version 25.4R1.12
+set system host-name dut
+set system root-authentication encrypted-password "$6$VgGPQ1yd$GBukvAN8LvCUQxzNv/2IQVUCtypslf.kVNdnmBKO9g8TEALvL7oTHnrLw9F6dtrpVdZxYMmIud6X/OTiwLi1K."
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$xqU5RBBY$2aJRpjgbi6KQ2U6QY2fVGgZ5TYp0qnsDwttjFti7oPfLGSHPyOnE91Rc3ZlCJO1m/76t757fQ7Jq6hn1dTJ4J1"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to sender"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.1/31
+set interfaces ge-0/0/1 description "link to collector"
+set interfaces ge-0/0/1 unit 0 family inet address 10.0.23.0/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 2.2.2.2/32
+set policy-options policy-statement PASS-ALL term ACCEPT then accept
+set policy-options policy-statement STRIP-COMMUNITIES term STRIP then community delete ALL-COMMUNITIES
+set policy-options policy-statement STRIP-COMMUNITIES term STRIP then accept
+set policy-options community ALL-COMMUNITIES members .*:.*
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 2.2.2.2
+set routing-options autonomous-system 65002
+set protocols bgp group FROM-SENDER type external
+set protocols bgp group FROM-SENDER peer-as 65001
+set protocols bgp group FROM-SENDER neighbor 10.0.12.0 import STRIP-COMMUNITIES
+set protocols bgp group TO-COLLECTOR type external
+set protocols bgp group TO-COLLECTOR peer-as 65003
+set protocols bgp group TO-COLLECTOR neighbor 10.0.23.1 export PASS-ALL

--- a/snapshots/junos_community_delete/configs/sender/show_configuration_|_display_set.txt
+++ b/snapshots/junos_community_delete/configs/sender/show_configuration_|_display_set.txt
@@ -1,0 +1,74 @@
+set version 25.4R1.12
+set system host-name sender
+set system root-authentication encrypted-password "$6$rDZSJmvo$Ngy6F4WsSTMrjMXKOAN/8RtUTRJI4h4rZXHX6BNHwVkjiT6QJ2NAhe5ZaFnBrPmEOa6EqTbdM6uV/cZlwOqjy/"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$iUst68m9$ZObF9EkFruVe8Wsc8O3fbyMCWk1F0xtlMYcAlIa6mS5pcwB3cvn3po0qQhnl9vVVtcWF1U/Ropz4lOL51C45v."
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to dut"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.0/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+set policy-options policy-statement EXPORT-TAGGED term CONTROL from route-filter 10.10.0.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term CONTROL then accept
+set policy-options policy-statement EXPORT-TAGGED term TAG-STANDARD from route-filter 10.10.1.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term TAG-STANDARD then community add STANDARD
+set policy-options policy-statement EXPORT-TAGGED term TAG-STANDARD then accept
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-EXPORT from route-filter 10.10.2.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-EXPORT then community add NO-EXPORT
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-EXPORT then accept
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-ADVERTISE from route-filter 10.10.3.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-ADVERTISE then community add NO-ADVERTISE
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-ADVERTISE then accept
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-EXPORT-SUBCONFED from route-filter 10.10.4.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-EXPORT-SUBCONFED then community add NO-EXPORT-SUBCONFED
+set policy-options policy-statement EXPORT-TAGGED term TAG-NO-EXPORT-SUBCONFED then accept
+set policy-options policy-statement EXPORT-TAGGED term TAG-EXT-TARGET from route-filter 10.10.5.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term TAG-EXT-TARGET then community add EXT-TARGET
+set policy-options policy-statement EXPORT-TAGGED term TAG-EXT-TARGET then accept
+set policy-options policy-statement EXPORT-TAGGED term TAG-EXT-ORIGIN from route-filter 10.10.6.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term TAG-EXT-ORIGIN then community add EXT-ORIGIN
+set policy-options policy-statement EXPORT-TAGGED term TAG-EXT-ORIGIN then accept
+set policy-options policy-statement EXPORT-TAGGED term TAG-LARGE from route-filter 10.10.7.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term TAG-LARGE then community add LARGE
+set policy-options policy-statement EXPORT-TAGGED term TAG-LARGE then accept
+set policy-options policy-statement EXPORT-TAGGED term TAG-KITCHEN-SINK from route-filter 10.10.8.0/24 exact
+set policy-options policy-statement EXPORT-TAGGED term TAG-KITCHEN-SINK then community add KITCHEN-SINK-STD
+set policy-options policy-statement EXPORT-TAGGED term TAG-KITCHEN-SINK then community add KITCHEN-SINK-EXT
+set policy-options policy-statement EXPORT-TAGGED term TAG-KITCHEN-SINK then community add KITCHEN-SINK-LARGE
+set policy-options policy-statement EXPORT-TAGGED term TAG-KITCHEN-SINK then accept
+set policy-options policy-statement EXPORT-TAGGED term REJECT then reject
+set policy-options community EXT-ORIGIN members origin:65001:300
+set policy-options community EXT-TARGET members target:65001:200
+set policy-options community KITCHEN-SINK-EXT members target:65001:999
+set policy-options community KITCHEN-SINK-EXT members origin:65001:888
+set policy-options community KITCHEN-SINK-LARGE members large:65001:9:9
+set policy-options community KITCHEN-SINK-STD members 65001:999
+set policy-options community KITCHEN-SINK-STD members no-export
+set policy-options community KITCHEN-SINK-STD members no-advertise
+set policy-options community KITCHEN-SINK-STD members no-export-subconfed
+set policy-options community LARGE members large:65001:1:1
+set policy-options community NO-ADVERTISE members no-advertise
+set policy-options community NO-EXPORT members no-export
+set policy-options community NO-EXPORT-SUBCONFED members no-export-subconfed
+set policy-options community STANDARD members 65001:100
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 1.1.1.1
+set routing-options autonomous-system 65001
+set routing-options static route 10.10.0.0/24 discard
+set routing-options static route 10.10.1.0/24 discard
+set routing-options static route 10.10.2.0/24 discard
+set routing-options static route 10.10.3.0/24 discard
+set routing-options static route 10.10.4.0/24 discard
+set routing-options static route 10.10.5.0/24 discard
+set routing-options static route 10.10.6.0/24 discard
+set routing-options static route 10.10.7.0/24 discard
+set routing-options static route 10.10.8.0/24 discard
+set protocols bgp group TO-DUT type external
+set protocols bgp group TO-DUT peer-as 65002
+set protocols bgp group TO-DUT neighbor 10.0.12.1 export EXPORT-TAGGED

--- a/snapshots/junos_community_delete/show/collector/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/collector/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,471 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.23.0+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.23.1+59612"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65003"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "FROM-DUT"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "3:39", 
+                "attributes" : {"junos:seconds" : "219"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-error" : [
+            {
+                "name" : [
+                {
+                    "data" : "Cease"
+                }
+                ], 
+                "send-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "receive-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "3.3.3.3"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "11"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "12"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "12"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "27"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "219"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "13"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "398"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "175"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/collector/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/collector/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to dut"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:6f:0c:73"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:6f:0c:73"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:22 ago)", 
+                "attributes" : {"junos:seconds" : "202"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "40"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "25"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "30"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.23.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.23.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:24 ago)", 
+                "attributes" : {"junos:seconds" : "204"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:25 ago)", 
+                "attributes" : {"junos:seconds" : "205"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:26 ago)", 
+                "attributes" : {"junos:seconds" : "206"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:26 ago)", 
+                "attributes" : {"junos:seconds" : "206"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:26 ago)", 
+                "attributes" : {"junos:seconds" : "206"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:27 ago)", 
+                "attributes" : {"junos:seconds" : "207"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:27 ago)", 
+                "attributes" : {"junos:seconds" : "207"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:28 ago)", 
+                "attributes" : {"junos:seconds" : "208"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:29 ago)", 
+                "attributes" : {"junos:seconds" : "209"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:29 ago)", 
+                "attributes" : {"junos:seconds" : "209"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:13 UTC (00:03:29 ago)", 
+                "attributes" : {"junos:seconds" : "209"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:f9:7b:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:7b:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:f9:7b:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 19:58:20 UTC (00:05:23 ago)", 
+                "attributes" : {"junos:seconds" : "323"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "53181"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "97078"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "52506"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "97080"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:0b:44:0a:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:0b:44:0a:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:0b:44:0a:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:0b:44:0a:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 19:58:20 UTC (00:05:23 ago)", 
+                "attributes" : {"junos:seconds" : "323"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "8302"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "8095"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "8272"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "8136"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:bff:fe44:a00"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:82:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:f9:82:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:82:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:f9:82:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "743"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "743"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "3.3.3.3"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "743"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "743"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:82:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:f9:82:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:f9:82:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:f9:82:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/collector/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/collector/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/collector/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/collector/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/collector/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/collector/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "14"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/collector/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/collector/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,1021 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "15"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2.2.2.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:30", 
+                        "attributes" : {"junos:seconds" : "210"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:30", 
+                        "attributes" : {"junos:seconds" : "210"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.23.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:30", 
+                        "attributes" : {"junos:seconds" : "210"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.5.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.6.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.7.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.8.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:29", 
+                        "attributes" : {"junos:seconds" : "209"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/collector/show_route_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/collector/show_route_|_display_json.txt
@@ -1,0 +1,1596 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "15"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2.2.2.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:26", 
+                        "attributes" : {"junos:seconds" : "206"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "3.3.3.3/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:55", 
+                        "attributes" : {"junos:seconds" : "295"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:26", 
+                        "attributes" : {"junos:seconds" : "206"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.23.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:34", 
+                        "attributes" : {"junos:seconds" : "214"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "active-tag" : [
+                    {
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:26", 
+                        "attributes" : {"junos:seconds" : "206"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.23.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:34", 
+                        "attributes" : {"junos:seconds" : "214"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.5.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.6.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.7.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.8.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:25", 
+                        "attributes" : {"junos:seconds" : "205"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:53", 
+                        "attributes" : {"junos:seconds" : "293"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:55", 
+                        "attributes" : {"junos:seconds" : "295"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:55", 
+                        "attributes" : {"junos:seconds" : "295"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:53", 
+                        "attributes" : {"junos:seconds" : "293"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:55", 
+                        "attributes" : {"junos:seconds" : "295"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:55", 
+                        "attributes" : {"junos:seconds" : "295"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:bff:fe44:a00/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:55", 
+                        "attributes" : {"junos:seconds" : "295"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/collector/show_version_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/collector/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "collector"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/dut/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/dut/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,905 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.1+54338"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "FROM-SENDER"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "import-policy" : [
+                {
+                    "data" : "STRIP-COMMUNITIES"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "4:34", 
+                "attributes" : {"junos:seconds" : "274"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "275"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "21"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "817"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "213"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.23.1+59612"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65003"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.23.0+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "TO-COLLECTOR"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "PASS-ALL"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "4:34", 
+                "attributes" : {"junos:seconds" : "274"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "3.3.3.3"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/1.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "541"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65003"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20001"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "12"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "24"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "274"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "276"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "13"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "354"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/dut/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/dut/show_interfaces_|_display_json.txt
@@ -1,0 +1,9408 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to sender"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:3e:88:e9"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:3e:88:e9"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:08 ago)", 
+                "attributes" : {"junos:seconds" : "248"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "80"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "537"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "33"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "33"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to collector"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:5f:49:b6"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:5f:49:b6"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:11 ago)", 
+                "attributes" : {"junos:seconds" : "251"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "56"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "31"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "27"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.23.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:12 ago)", 
+                "attributes" : {"junos:seconds" : "252"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:13 ago)", 
+                "attributes" : {"junos:seconds" : "253"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:13 ago)", 
+                "attributes" : {"junos:seconds" : "253"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:13 ago)", 
+                "attributes" : {"junos:seconds" : "253"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:14 ago)", 
+                "attributes" : {"junos:seconds" : "254"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:14 ago)", 
+                "attributes" : {"junos:seconds" : "254"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:15 ago)", 
+                "attributes" : {"junos:seconds" : "255"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:15 ago)", 
+                "attributes" : {"junos:seconds" : "255"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:15 ago)", 
+                "attributes" : {"junos:seconds" : "255"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:17 UTC (00:04:15 ago)", 
+                "attributes" : {"junos:seconds" : "255"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:03:62:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:62:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:03:62:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 19:58:24 UTC (00:06:09 ago)", 
+                "attributes" : {"junos:seconds" : "369"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "54440"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "98155"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "53713"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "98158"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:19:79:56:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:19:79:56:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:19:79:56:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:19:79:56:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 19:58:24 UTC (00:06:09 ago)", 
+                "attributes" : {"junos:seconds" : "369"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "9892"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "9799"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "9992"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "9919"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:19ff:fe79:5600"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:69:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:03:69:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:69:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:03:69:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "828"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "828"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2.2.2.2"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "828"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "828"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:69:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:03:69:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:03:69:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:03:69:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/dut/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/dut/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/dut/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/dut/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/dut/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/dut/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "14"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/dut/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/dut/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,801 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.5.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.6.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.7.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.8.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:20", 
+                        "attributes" : {"junos:seconds" : "260"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/dut/show_route_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/dut/show_route_|_display_json.txt
@@ -1,0 +1,1500 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2.2.2.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:40", 
+                        "attributes" : {"junos:seconds" : "340"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:19", 
+                        "attributes" : {"junos:seconds" : "259"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:19", 
+                        "attributes" : {"junos:seconds" : "259"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.23.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:19", 
+                        "attributes" : {"junos:seconds" : "259"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.23.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:19", 
+                        "attributes" : {"junos:seconds" : "259"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/1.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.5.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.6.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.7.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.8.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:04:15", 
+                        "attributes" : {"junos:seconds" : "255"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:40", 
+                        "attributes" : {"junos:seconds" : "340"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:40", 
+                        "attributes" : {"junos:seconds" : "340"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:40", 
+                        "attributes" : {"junos:seconds" : "340"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:40", 
+                        "attributes" : {"junos:seconds" : "340"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:40", 
+                        "attributes" : {"junos:seconds" : "340"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:40", 
+                        "attributes" : {"junos:seconds" : "340"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:19ff:fe79:5600/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:40", 
+                        "attributes" : {"junos:seconds" : "340"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/dut/show_version_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/dut/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "dut"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/host_nos.txt
+++ b/snapshots/junos_community_delete/show/host_nos.txt
@@ -1,0 +1,1 @@
+{"collector": "junos", "dut": "junos", "sender": "junos"}

--- a/snapshots/junos_community_delete/show/sender/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/sender/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,476 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.1+54338"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "TO-DUT"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "Cease"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "EXPORT-TAGGED"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "5:16", 
+                "attributes" : {"junos:seconds" : "316"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-error" : [
+            {
+                "name" : [
+                {
+                    "data" : "Cease"
+                }
+                ], 
+                "send-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "receive-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "9"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "15"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "317"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "14"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "314"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "21"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "773"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/sender/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/sender/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to dut"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:8e:bf:c7"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:8e:bf:c7"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:09 UTC (00:05:06 ago)", 
+                "attributes" : {"junos:seconds" : "306"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "264"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "40"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "38"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "42"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:07 UTC (00:05:10 ago)", 
+                "attributes" : {"junos:seconds" : "310"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:07 UTC (00:05:11 ago)", 
+                "attributes" : {"junos:seconds" : "311"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:07 UTC (00:05:11 ago)", 
+                "attributes" : {"junos:seconds" : "311"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:07 UTC (00:05:12 ago)", 
+                "attributes" : {"junos:seconds" : "312"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:08 UTC (00:05:11 ago)", 
+                "attributes" : {"junos:seconds" : "311"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:08 UTC (00:05:12 ago)", 
+                "attributes" : {"junos:seconds" : "312"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:08 UTC (00:05:12 ago)", 
+                "attributes" : {"junos:seconds" : "312"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:08 UTC (00:05:12 ago)", 
+                "attributes" : {"junos:seconds" : "312"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:08 UTC (00:05:12 ago)", 
+                "attributes" : {"junos:seconds" : "312"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:08 UTC (00:05:13 ago)", 
+                "attributes" : {"junos:seconds" : "313"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 20:00:08 UTC (00:05:13 ago)", 
+                "attributes" : {"junos:seconds" : "313"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b7:b5:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:b5:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b7:b5:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 19:58:17 UTC (00:07:04 ago)", 
+                "attributes" : {"junos:seconds" : "424"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "56112"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "99894"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "55341"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "99896"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:00:ed:8f:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:00:ed:8f:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:00:ed:8f:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:00:ed:8f:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-04-28 19:58:17 UTC (00:07:04 ago)", 
+                "attributes" : {"junos:seconds" : "424"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "5377"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "5301"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "5377"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "5414"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:ff:feed:8f00"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:bc:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b7:bc:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:bc:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b7:bc:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "914"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "914"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "1.1.1.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "914"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "914"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:bc:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b7:bc:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:b7:bc:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b7:bc:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/sender/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/sender/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/sender/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/sender/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/sender/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/sender/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "12"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/sender/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/sender/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,106 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/sender/show_route_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/sender/show_route_|_display_json.txt
@@ -1,0 +1,1125 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "1.1.1.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:34", 
+                        "attributes" : {"junos:seconds" : "394"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:17", 
+                        "attributes" : {"junos:seconds" : "317"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:05:17", 
+                        "attributes" : {"junos:seconds" : "317"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.5.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.6.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.7.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.8.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:34", 
+                        "attributes" : {"junos:seconds" : "394"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:34", 
+                        "attributes" : {"junos:seconds" : "394"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:25", 
+                        "attributes" : {"junos:seconds" : "385"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:34", 
+                        "attributes" : {"junos:seconds" : "394"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:34", 
+                        "attributes" : {"junos:seconds" : "394"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:ff:feed:8f00/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:06:34", 
+                        "attributes" : {"junos:seconds" : "394"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/show/sender/show_version_|_display_json.txt
+++ b/snapshots/junos_community_delete/show/sender/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "sender"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_community_delete/validation/sickbay.yaml
+++ b/snapshots/junos_community_delete/validation/sickbay.yaml
@@ -1,0 +1,5 @@
+entries:
+  - test_name: test_vi_model
+    skip:
+      skip_type: dont_run
+      reason: https://github.com/batfish/lab-validation/issues/160


### PR DESCRIPTION
Tests whether Junos `community delete` with `members .*:.*` removes all
community types: standard, well-known (no-export, no-advertise,
no-export-subconfed), extended (route-target, site-of-origin), and large.

Result: .*:.* successfully deletes all community types. Junos matches
well-known communities against their FFFF:FF01-style representation,
not the keyword form.

Topology: sender (AS 65001) -> dut (AS 65002) -> collector (AS 65003).
Sender tags 9 routes with different community types; dut strips them on
import; collector confirms behavioral removal (e.g., no-export routes
arrive, proving the community was removed).

----

Prompt:
```
set policy-options community ALL-COMMUNITIES members .*:.*
set policy-options policy-statement P term T then community delete ALL-COMMUNITIES
set policy-options policy-statement P term T then accept

I want to know if the above junos config actually deletes all communities,
including well-known communities like no-export and extended communities
of various forms. Create a lab testing the various corner cases to
decisively show whether this captures ALL communities.
```