### PR TITLE
sickbay: retire issues/160 from junos_community_delete

### DIFF
--- a/snapshots/junos_community_delete/validation/sickbay.yaml
+++ b/snapshots/junos_community_delete/validation/sickbay.yaml
@@ -1,5 +1,0 @@
-entries:
-  - test_name: test_vi_model
-    skip:
-      skip_type: dont_run
-      reason: https://github.com/batfish/lab-validation/issues/160


### PR DESCRIPTION
Fixed upstream in batfish/batfish@5e32716d24 (LargeCommunity: add
@JsonValue for correct JSON serialization).

Closes #160

----

Prompt:
```
Batfish commit is merged, make a new lab-validation commit that
removes the sickbay and marks batfish/lab-validation#160 as closed
```