### PR TITLE
lab_builder: auto-generate layer1_topology.json from containerlab links

### DIFF
--- a/snapshots/eos_ceos_bgp_unnumbered/batfish/layer1_topology.json
+++ b/snapshots/eos_ceos_bgp_unnumbered/batfish/layer1_topology.json
@@ -1,12 +1,24 @@
 {
-  "edges": [
-    {
-      "node1": { "hostname": "spine", "interfaceName": "Ethernet1" },
-      "node2": { "hostname": "leaf", "interfaceName": "Ethernet1" }
-    },
-    {
-      "node1": { "hostname": "spine", "interfaceName": "Ethernet2" },
-      "node2": { "hostname": "leaf", "interfaceName": "Ethernet2" }
-    }
-  ]
+    "edges": [
+        {
+            "node1": {
+                "hostname": "spine",
+                "interfaceName": "Ethernet1"
+            },
+            "node2": {
+                "hostname": "leaf",
+                "interfaceName": "Ethernet1"
+            }
+        },
+        {
+            "node1": {
+                "hostname": "spine",
+                "interfaceName": "Ethernet2"
+            },
+            "node2": {
+                "hostname": "leaf",
+                "interfaceName": "Ethernet2"
+            }
+        }
+    ]
 }

--- a/snapshots/eos_ceos_bgp_weight_experiment/batfish/layer1_topology.json
+++ b/snapshots/eos_ceos_bgp_weight_experiment/batfish/layer1_topology.json
@@ -1,12 +1,24 @@
 {
-  "edges": [
-    {
-      "node1": { "hostname": "r-upstream", "interfaceName": "Ethernet1" },
-      "node2": { "hostname": "r-ma", "interfaceName": "Ethernet1" }
-    },
-    {
-      "node1": { "hostname": "r-upstream", "interfaceName": "Ethernet2" },
-      "node2": { "hostname": "r-ribd", "interfaceName": "Ethernet1" }
-    }
-  ]
+    "edges": [
+        {
+            "node1": {
+                "hostname": "r-upstream",
+                "interfaceName": "Ethernet1"
+            },
+            "node2": {
+                "hostname": "r-ma",
+                "interfaceName": "Ethernet1"
+            }
+        },
+        {
+            "node1": {
+                "hostname": "r-upstream",
+                "interfaceName": "Ethernet2"
+            },
+            "node2": {
+                "hostname": "r-ribd",
+                "interfaceName": "Ethernet1"
+            }
+        }
+    ]
 }

--- a/src/lab_builder/__main__.py
+++ b/src/lab_builder/__main__.py
@@ -102,6 +102,7 @@ def cmd_build_snapshot(args: argparse.Namespace) -> None:
         nodes=nodes,
         collected_dir=Path(args.collected_dir),
         snapshots_dir=Path(args.snapshots_dir),
+        topology_file=Path(args.topology),
     )
 
 

--- a/src/lab_builder/snapshot.py
+++ b/src/lab_builder/snapshot.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import json
+import re
 import shutil
 from pathlib import Path
+
+import yaml
 
 from lab_builder.config import command_to_filename
 from lab_builder.models import NodeInfo
@@ -15,6 +18,7 @@ def build_snapshot(
     nodes: list[NodeInfo],
     collected_dir: Path,
     snapshots_dir: Path,
+    topology_file: Path | None = None,
 ) -> Path:
     """Build a lab-validation snapshot from collected data.
 
@@ -23,6 +27,7 @@ def build_snapshot(
         ├── configs/<hostname>/show_configuration_|_display_set.txt
         ├── show/host_nos.txt
         ├── show/<hostname>/<show_command>.txt
+        ├── batfish/layer1_topology.json  (if topology_file provided)
         └── validation/
 
     Returns the path to the created snapshot directory.
@@ -71,5 +76,64 @@ def build_snapshot(
         file_count = len(list(show_node_dir.iterdir()))
         print(f"  {node.name}: {file_count} show files -> show/{node.name}/")
 
+    # Generate layer1_topology.json from containerlab topology
+    if topology_file is not None:
+        _generate_layer1_topology(topology_file, nodes, snapshot_dir)
+
     print(f"Snapshot created at: {snapshot_dir}")
     return snapshot_dir
+
+
+def _eth_to_vendor_interface(eth_name: str, profile: NodeInfo) -> str:
+    """Convert containerlab ethN name to vendor interface name.
+
+    eth1 maps to <prefix><offset>, eth2 to <prefix><offset+1>, etc.
+    """
+    match = re.match(r"eth(\d+)", eth_name)
+    if not match:
+        return eth_name
+    eth_num = int(match.group(1))
+    vendor_num = eth_num - 1 + profile.profile.interface_offset
+    prefix = profile.profile.interface_prefix
+    return f"{prefix}{vendor_num}"
+
+
+def _generate_layer1_topology(
+    topology_file: Path, nodes: list[NodeInfo], snapshot_dir: Path
+) -> None:
+    """Generate batfish/layer1_topology.json from containerlab topology links."""
+    topo = yaml.safe_load(topology_file.read_text())
+    links = topo.get("topology", {}).get("links", [])
+    if not links:
+        return
+
+    nodes_by_name = {n.name: n for n in nodes}
+    edges = []
+    for link in links:
+        endpoints = link.get("endpoints", [])
+        if len(endpoints) != 2:
+            continue
+        parts = [ep.split(":", 1) for ep in endpoints]
+        if any(len(p) != 2 for p in parts):
+            continue
+        node1_name, eth1 = parts[0]
+        node2_name, eth2 = parts[1]
+        node1 = nodes_by_name.get(node1_name)
+        node2 = nodes_by_name.get(node2_name)
+        if node1 is None or node2 is None:
+            continue
+        iface1 = _eth_to_vendor_interface(eth1, node1)
+        iface2 = _eth_to_vendor_interface(eth2, node2)
+        edges.append(
+            {
+                "node1": {"hostname": node1_name, "interfaceName": iface1},
+                "node2": {"hostname": node2_name, "interfaceName": iface2},
+            }
+        )
+
+    if edges:
+        batfish_dir = snapshot_dir / "batfish"
+        batfish_dir.mkdir(parents=True, exist_ok=True)
+        l1_file = batfish_dir / "layer1_topology.json"
+        l1_file.write_text(json.dumps({"edges": edges}, indent=4) + "\n")
+        print(f"  Generated layer1_topology.json with {len(edges)} edges")

--- a/tests/lab_builder/test_snapshot.py
+++ b/tests/lab_builder/test_snapshot.py
@@ -1,0 +1,123 @@
+"""Tests for lab_builder.snapshot, focused on layer1_topology generation."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from lab_builder.config import ARISTA_CEOS, VJUNOS_ROUTER
+from lab_builder.models import NodeInfo
+from lab_builder.snapshot import _eth_to_vendor_interface, _generate_layer1_topology
+
+
+@pytest.fixture()
+def arista_node() -> NodeInfo:
+    return NodeInfo(
+        name="r1", kind="arista_ceos", profile=ARISTA_CEOS, management_ip="1.2.3.4"
+    )
+
+
+@pytest.fixture()
+def junos_node() -> NodeInfo:
+    return NodeInfo(
+        name="r2",
+        kind="juniper_vjunosrouter",
+        profile=VJUNOS_ROUTER,
+        management_ip="1.2.3.5",
+    )
+
+
+class TestEthToVendorInterface:
+    def test_arista_eth1(self, arista_node: NodeInfo) -> None:
+        assert _eth_to_vendor_interface("eth1", arista_node) == "Ethernet1"
+
+    def test_arista_eth3(self, arista_node: NodeInfo) -> None:
+        assert _eth_to_vendor_interface("eth3", arista_node) == "Ethernet3"
+
+    def test_junos_eth1(self, junos_node: NodeInfo) -> None:
+        assert _eth_to_vendor_interface("eth1", junos_node) == "ge-0/0/0"
+
+    def test_junos_eth3(self, junos_node: NodeInfo) -> None:
+        assert _eth_to_vendor_interface("eth3", junos_node) == "ge-0/0/2"
+
+    def test_passthrough(self, arista_node: NodeInfo) -> None:
+        assert _eth_to_vendor_interface("Loopback0", arista_node) == "Loopback0"
+
+
+class TestGenerateLayer1Topology:
+    def test_basic(self, tmp_path: Path, arista_node: NodeInfo) -> None:
+        topo = tmp_path / "topology.clab.yml"
+        topo.write_text(
+            """
+name: test
+topology:
+  nodes:
+    r1:
+      kind: arista_ceos
+      image: ceos:4.36.0.1F
+    r2:
+      kind: arista_ceos
+      image: ceos:4.36.0.1F
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+"""
+        )
+        r2 = NodeInfo(
+            name="r2", kind="arista_ceos", profile=ARISTA_CEOS, management_ip="1.2.3.5"
+        )
+        snapshot_dir = tmp_path / "snapshot"
+        snapshot_dir.mkdir()
+        _generate_layer1_topology(topo, [arista_node, r2], snapshot_dir)
+
+        l1 = json.loads((snapshot_dir / "batfish" / "layer1_topology.json").read_text())
+        assert len(l1["edges"]) == 1
+        edge = l1["edges"][0]
+        assert edge["node1"] == {"hostname": "r1", "interfaceName": "Ethernet1"}
+        assert edge["node2"] == {"hostname": "r2", "interfaceName": "Ethernet1"}
+
+    def test_mixed_vendors(
+        self, tmp_path: Path, arista_node: NodeInfo, junos_node: NodeInfo
+    ) -> None:
+        topo = tmp_path / "topology.clab.yml"
+        topo.write_text(
+            """
+name: test
+topology:
+  nodes:
+    r1:
+      kind: arista_ceos
+    r2:
+      kind: juniper_vjunosrouter
+  links:
+    - endpoints: ["r1:eth1", "r2:eth1"]
+    - endpoints: ["r1:eth2", "r2:eth2"]
+"""
+        )
+        snapshot_dir = tmp_path / "snapshot"
+        snapshot_dir.mkdir()
+        _generate_layer1_topology(topo, [arista_node, junos_node], snapshot_dir)
+
+        l1 = json.loads((snapshot_dir / "batfish" / "layer1_topology.json").read_text())
+        assert len(l1["edges"]) == 2
+        assert l1["edges"][0]["node1"]["interfaceName"] == "Ethernet1"
+        assert l1["edges"][0]["node2"]["interfaceName"] == "ge-0/0/0"
+        assert l1["edges"][1]["node1"]["interfaceName"] == "Ethernet2"
+        assert l1["edges"][1]["node2"]["interfaceName"] == "ge-0/0/1"
+
+    def test_no_links(self, tmp_path: Path, arista_node: NodeInfo) -> None:
+        topo = tmp_path / "topology.clab.yml"
+        topo.write_text(
+            """
+name: test
+topology:
+  nodes:
+    r1:
+      kind: arista_ceos
+"""
+        )
+        snapshot_dir = tmp_path / "snapshot"
+        snapshot_dir.mkdir()
+        _generate_layer1_topology(topo, [arista_node], snapshot_dir)
+        assert not (snapshot_dir / "batfish" / "layer1_topology.json").exists()


### PR DESCRIPTION
`build-snapshot` now reads links from the containerlab topology file
and generates `batfish/layer1_topology.json`, converting containerlab
ethN names to vendor interface names using each node's profile.

This is required for Batfish to form OSPF adjacencies on unnumbered
point-to-point interfaces and for BGP unnumbered (link-local
addresses), since neither participates in subnet-based L3 topology
synthesis.

Regenerated L1 topology files for eos_ceos_bgp_unnumbered and
eos_ceos_bgp_weight_experiment to confirm builder output matches the
manually-created originals.

----

Prompt:
```
let's make that part of the lab infrastructure
```