### PR TITLE
sickbay: retire issues/164 from eos_ospf_unnumbered

### DIFF
--- a/snapshots/eos_ospf_bgp/validation/sickbay.yaml
+++ b/snapshots/eos_ospf_bgp/validation/sickbay.yaml
@@ -4,7 +4,7 @@ entries:
     skip:
       reason: locally-originated path attribute divergence, https://github.com/batfish/lab-validation/issues/152
 
-  - hostname: dlh15|np01|np02
+  - hostname: dlh15|np02
     test_name: test_main_rib_routes
     skip:
       reason: https://github.com/batfish/lab-validation/issues/29

--- a/snapshots/eos_ospf_unnumbered/validation/sickbay.yaml
+++ b/snapshots/eos_ospf_unnumbered/validation/sickbay.yaml
@@ -1,5 +1,0 @@
-entries:
-  - hostname: ".*"
-    test_name: test_main_rib_routes
-    skip:
-      reason: https://github.com/batfish/lab-validation/issues/164

--- a/src/lab_validation/validators/AristaValidator.py
+++ b/src/lab_validation/validators/AristaValidator.py
@@ -183,6 +183,15 @@ class AristaValidator(VendorValidator):
             arista_route, batfish_route.next_hop
         )
 
+        # EOS reports directly-connected OSPF neighbor routes (e.g., on unnumbered p2p links)
+        # with no preference, metric, or next-hop IP. Skip those comparisons when all are absent.
+        _directly_connected = (
+            arista_route.preference is None
+            and arista_route.metric is None
+            and arista_route.next_hop_ip is None
+            and arista_protocol == "ospf"
+        )
+
         arista_preference = arista_route.preference
         if arista_preference is None:
             if arista_protocol == "connected":
@@ -193,12 +202,13 @@ class AristaValidator(VendorValidator):
                 # local BGP route admin distance
                 arista_preference = 200
 
-        if arista_preference != batfish_route.admin:
+        if not _directly_connected and arista_preference != batfish_route.admin:
             cost.append(("admin", 2.0))
 
-        arista_metric = 0 if arista_route.metric is None else arista_route.metric
-        if arista_metric != batfish_route.metric:
-            cost.append(("metric", 1.0))
+        if not _directly_connected:
+            arista_metric = 0 if arista_route.metric is None else arista_route.metric
+            if arista_metric != batfish_route.metric:
+                cost.append(("metric", 1.0))
 
         return cost
 
@@ -267,6 +277,7 @@ class AristaValidator(VendorValidator):
                 cost.append(("nhint", 5.0))
             if (
                 next_hop.ip
+                and arista_route.next_hop_ip is not None
                 and next_hop.ip != arista_route.next_hop_ip
                 and not _is_rfc5549_unnumbered_match(
                     arista_route.next_hop_ip, next_hop.ip


### PR DESCRIPTION
The directly-connected OSPF neighbor route representation mismatch is
now handled by the cost-based matcher. EOS reports these routes with
no preference, metric, or next-hop IP (directlyConnected: true in the
JSON). The matcher now skips admin/metric/nhip comparisons when all
three are absent on an OSPF route, and skips the nhip penalty when
the device reports no next-hop IP but the interface matches.

The underlying OSPF cost bug was fixed in batfish/batfish#9923.

Closes batfish/lab-validation#164

Prompt:
\`\`\`
Let's try to fix the batfish issue first.
\`\`\`
(continued into lab-validation matcher fix after Batfish PR merged)
