### PR TITLE
junos_commit_check: retire sickbay after batfish/batfish#9928 fix

### DIFF
--- a/infra/examples/junos-commit-check/checks.yaml
+++ b/infra/examples/junos-commit-check/checks.yaml
@@ -84,13 +84,15 @@ checks:
   - type: commit_check_rejects
     node: dut
     config_lines:
-      - "set policy-options condition TEST if-route-exists 192.168.1.111/24 table inet.0"
+      - "set policy-options condition TEST if-route-exists 192.168.1.111/24"
+      - "set policy-options condition TEST if-route-exists table inet.0"
     description: "condition if-route-exists with host bits set"
 
   - type: commit_check_accepts
     node: dut
     config_lines:
-      - "set policy-options condition TEST if-route-exists 192.168.1.0/24 table inet.0"
+      - "set policy-options condition TEST if-route-exists 192.168.1.0/24"
+      - "set policy-options condition TEST if-route-exists table inet.0"
     description: "condition if-route-exists with valid prefix"
 
   # --- Contexts where Junos ACCEPTS host bits ---

--- a/snapshots/junos_commit_check/configs/rejects-condition/show_configuration_|_display_set.txt
+++ b/snapshots/junos_commit_check/configs/rejects-condition/show_configuration_|_display_set.txt
@@ -1,2 +1,3 @@
 set system host-name rejects-condition
-set policy-options condition TEST if-route-exists 192.168.1.111/24 table inet.0
+set policy-options condition TEST if-route-exists 192.168.1.111/24
+set policy-options condition TEST if-route-exists table inet.0

--- a/snapshots/junos_commit_check/validation/sickbay.yaml
+++ b/snapshots/junos_commit_check/validation/sickbay.yaml
@@ -26,32 +26,3 @@ entries:
     skip:
       skip_type: dont_run
       reason: "commit check lab: configs are parse-warning test fixtures, not full devices"
-  # parse_warnings: Batfish does not yet flag unnormalized prefixes in these contexts
-  - hostname: rejects-static
-    test_name: test_parse_warnings
-    skip:
-      reason: "Batfish does not yet flag unnormalized static route prefixes (batfish/batfish#9928)"
-  - hostname: rejects-aggregate
-    test_name: test_parse_warnings
-    skip:
-      reason: "Batfish does not yet flag unnormalized aggregate route prefixes (batfish/batfish#9928)"
-  - hostname: rejects-generate
-    test_name: test_parse_warnings
-    skip:
-      reason: "Batfish does not yet flag unnormalized generate route prefixes (batfish/batfish#9928)"
-  - hostname: rejects-ospf-area-range
-    test_name: test_parse_warnings
-    skip:
-      reason: "Batfish does not yet flag unnormalized OSPF area-range prefixes (batfish/batfish#9928)"
-  - hostname: rejects-firewall-address
-    test_name: test_parse_warnings
-    skip:
-      reason: "Batfish does not yet flag unnormalized firewall address prefixes (batfish/batfish#9928)"
-  - hostname: rejects-firewall-next-ip
-    test_name: test_parse_warnings
-    skip:
-      reason: "Batfish does not yet flag unnormalized firewall next-ip prefixes (batfish/batfish#9928)"
-  - hostname: rejects-condition
-    test_name: test_parse_warnings
-    skip:
-      reason: "Batfish does not yet flag unnormalized condition if-route-exists prefixes (batfish/batfish#9928)"


### PR DESCRIPTION
batfish/batfish@2dbe572 added fatalRedFlag warnings for unnormalized
prefixes in all tested contexts. Remove the sickbay entries and fix the
rejects-condition config to use split flat lines (prefix and table
separately) since Batfish doesn't parse combined flat lines.

----

Prompt:
```
https://github.com/batfish/batfish/commit/2dbe572f817bfe9e52568272a5d0cf2427a74f9d
mostly fixed junos_commit_check lab.

1. Why didn't it fix the rejects-condition-junos test? Looks like
that's in there.
2. Fix the sickbay file for the now XFAIL tests.
```