### PR TITLE
junos_commit_check: retire sickbay after batfish/batfish#9934 fix

### DIFF
--- a/snapshots/junos_commit_check/validation/sickbay.yaml
+++ b/snapshots/junos_commit_check/validation/sickbay.yaml
@@ -26,29 +26,3 @@ entries:
     skip:
       skip_type: dont_run
       reason: "commit check lab: configs are parse-warning test fixtures, not full devices"
-  # IPv6 prefix normalization not yet implemented in Batfish
-  - hostname: rejects-static-v6
-    test_name: test_parse_warnings
-    skip:
-      skip_type: xfail
-      reason: "https://github.com/batfish/batfish/issues/9934"
-  - hostname: rejects-aggregate-v6
-    test_name: test_parse_warnings
-    skip:
-      skip_type: xfail
-      reason: "https://github.com/batfish/batfish/issues/9934"
-  - hostname: rejects-generate-v6
-    test_name: test_parse_warnings
-    skip:
-      skip_type: xfail
-      reason: "https://github.com/batfish/batfish/issues/9934"
-  - hostname: rejects-ospf3-area-range
-    test_name: test_parse_warnings
-    skip:
-      skip_type: xfail
-      reason: "https://github.com/batfish/batfish/issues/9934"
-  - hostname: rejects-condition-v6
-    test_name: test_parse_warnings
-    skip:
-      skip_type: xfail
-      reason: "https://github.com/batfish/batfish/issues/9934"


### PR DESCRIPTION
Remove IPv6 prefix normalization sickbay entries now that Batfish
issues fatal red flags for unnormalized IPv6 prefixes.

----

Prompt:
```
Fix https://github.com/batfish/batfish/issues/9934 . Note that we just
fixed the similar issue for IPv4. Apply the fix in ./batfish and then
test it by running batfish again (./batfish/tools/bazel_run.sh) and
testing lab-validation junos-commit-checks lab in ./lab-validation
```