### PR TITLE
junos: add 3 labs characterizing intermediate-attribute semantics

### DIFF
--- a/infra/examples/junos-cross-term-match/README.md
+++ b/infra/examples/junos-cross-term-match/README.md
@@ -1,0 +1,142 @@
+# Junos Cross-Term Match Lab
+
+Within a single Junos `policy-statement`, when an earlier term writes a
+route attribute and falls through (no `accept`/`reject`), can a later
+term `from`-match on that updated value? Or do later terms always match
+against the original attribute as it arrived from the protocol?
+
+This is the Junos analog of the FRR/Cumulus/Quagga "always-on
+intermediate attributes" concern in `working/intermediateAttributes.md`:
+those vendors are converted with `SetReadIntermediateBgpAttributes` so
+later route-map entries see the updates from earlier ones. For Junos,
+the question is empirical — and the answer drives whether the Junos
+conversion needs the same flag set.
+
+## Topology
+
+```
+sender (AS 65001) --- dut (AS 65002)
+       ge-0/0/0  <->  ge-0/0/0
+       10.0.12.0      10.0.12.1
+```
+
+No collector — observation is on `dut`.
+
+## Method
+
+Each test prefix is sent vanilla from `sender`. On `dut`, a single
+`policy-statement CROSS-TERM-IMPORT` contains, for each prefix:
+
+1. A "write" term that modifies the attribute and falls through.
+2. A "read" term that `from`-matches on the modified value and tags the
+   route with a marker community `MATCHED-*` if the match succeeded.
+3. A "default" term that runs only if the read term did not match, and
+   tags the route with `UNMATCHED-*`.
+
+The marker community on each route on `dut` reveals which path was taken.
+
+## Test Routes
+
+| Prefix       | Attribute under test | Write action                            | Read condition          |
+| ------------ | -------------------- | --------------------------------------- | ----------------------- |
+| 10.30.1.0/24 | community            | `community add RED;`                    | `community RED;`        |
+| 10.30.2.0/24 | local-preference     | `local-preference 250;`                 | `local-preference 250;` |
+| 10.30.3.0/24 | as-path              | `as-path-prepend 65099;`                | `as-path WITH-65099`    |
+| 10.30.4.0/24 | (control)            | `community add CONTROL-MARKER; accept;` | n/a                     |
+
+Marker community decoder:
+
+| Community    | Meaning                                              |
+| ------------ | ---------------------------------------------------- |
+| `65002:1001` | `MATCHED-COMMUNITY` — term 2 saw the community write |
+| `65002:1002` | `UNMATCHED-COMMUNITY`— term 2 did NOT see the write  |
+| `65002:2001` | `MATCHED-LOCALPREF`                                  |
+| `65002:2002` | `UNMATCHED-LOCALPREF`                                |
+| `65002:3001` | `MATCHED-ASPATH`                                     |
+| `65002:3002` | `UNMATCHED-ASPATH`                                   |
+| `65002:9999` | `CONTROL-MARKER` — confirms tagging mechanism works  |
+
+## What to Observe
+
+On `dut`:
+
+```
+show route 10.30.0.0/22 detail | display json
+```
+
+For each test prefix, read the `communities` field. Exactly one of the
+`MATCHED-*` / `UNMATCHED-*` markers (per attribute) should be present.
+
+Interpretation:
+
+- All `MATCHED-*` markers → Junos lets later terms see prior-term writes.
+  Batfish's Junos conversion likely needs `SetReadIntermediateBgpAttributes`
+  emitted between terms (or `useOutputAttributes` enabled).
+- All `UNMATCHED-*` markers → Junos terms read the original attribute.
+  Current Batfish behavior (no intermediate flag) matches the device.
+- Mixed → attribute-specific behavior. Worth filing per attribute.
+
+The control prefix (10.30.4.0/24) must show `CONTROL-MARKER`. If it
+doesn't, the marker mechanism itself has a problem and the rest of the
+results can't be trusted.
+
+## Running
+
+```
+lab_builder validate topology.clab.yml --checks checks.yaml
+```
+
+## Results
+
+Deployed 2026-05-19 on vJunos-router 25.4R1.12 (containerlab on EC2).
+All 6 checks passed. Substantive observations from
+`show route protocol bgp 10.30/16 detail` on `dut`:
+
+| Prefix       | Communities           | Localpref | AS path           | Decode                  |
+| ------------ | --------------------- | --------- | ----------------- | ----------------------- |
+| 10.30.1.0/24 | `65002:1, 65002:1001` | 100       | 65001 I           | RED + MATCHED-COMMUNITY |
+| 10.30.2.0/24 | `65002:2001`          | **250**   | 65001 I           | MATCHED-LOCALPREF       |
+| 10.30.3.0/24 | `65002:3001`          | 100       | **65099 65001 I** | MATCHED-ASPATH          |
+| 10.30.4.0/24 | `65002:9999`          | 100       | 65001 I           | CONTROL-MARKER          |
+
+### Interpretation
+
+For all three attribute types tested (community, local-preference,
+as-path), the **MATCHED-\* marker fired**, not UNMATCHED-\*. Junos terms
+within a single `policy-statement` **do see writes from earlier terms
+in the same policy**. This is the same semantics that Batfish currently
+emulates for FRR / Cumulus / Quagga via the always-on
+`SetReadIntermediateBgpAttributes` flag.
+
+The CONTROL-MARKER fired on the control prefix (10.30.4.0/24),
+confirming the marker mechanism itself is sound — so the matched / not-
+matched distinction in the other rows is meaningful evidence.
+
+### Batfish triage
+
+`pytest lab_tests/test_labs.py --labname=junos_cross_term_match`:
+**13 passed, 0 skipped, no sickbay**. Batfish's BGP-rib local-preference
+/ as-path predictions match the device for all four prefixes.
+Communities are not compared by the standard validator, so a separate
+probe was needed:
+
+`testRoutePolicies` against `dut`/`CROSS-TERM-IMPORT` with vanilla
+input routes for each test prefix produced these output communities:
+
+| Prefix       | Device communities    | Batfish communities   |
+| ------------ | --------------------- | --------------------- |
+| 10.30.1.0/24 | `65002:1, 65002:1001` | `65002:1, 65002:1001` |
+| 10.30.2.0/24 | `65002:2001`          | `65002:2001`          |
+| 10.30.3.0/24 | `65002:3001`          | `65002:3001`          |
+| 10.30.4.0/24 | `65002:9999`          | `65002:9999`          |
+
+Batfish's modeling of within-policy cross-term visibility for Junos
+matches the device exactly. **No bug here.** Batfish's Junos
+conversion already produces the correct cross-term-readable behavior,
+either via output-attribute writes or via implicit semantics of the
+policy evaluator (a Java-side detail this lab does not need to
+distinguish).
+
+### Companion data
+
+- Snapshot: `snapshots/junos_cross_term_match/`

--- a/infra/examples/junos-cross-term-match/checks.yaml
+++ b/infra/examples/junos-cross-term-match/checks.yaml
@@ -1,0 +1,34 @@
+# Validation checks for the Junos cross-term match lab.
+# Confirms BGP up and all 4 prefixes imported on dut.
+# The cross-term visibility result is read from communities on each route.
+
+checks:
+  - type: bgp_peer_established
+    node: sender
+    neighbor: 10.0.12.1
+    description: "sender -> dut eBGP"
+  - type: bgp_peer_established
+    node: dut
+    neighbor: 10.0.12.0
+    description: "dut -> sender eBGP"
+
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.30.1.0/24
+    description: "community-case route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.30.2.0/24
+    description: "localpref-case route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.30.3.0/24
+    description: "as-path-case route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.30.4.0/24
+    description: "control route present on dut"

--- a/infra/examples/junos-cross-term-match/configs/dut.cfg
+++ b/infra/examples/junos-cross-term-match/configs/dut.cfg
@@ -1,0 +1,186 @@
+system {
+    host-name dut;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 2.2.2.2/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to sender";
+        unit 0 {
+            family inet {
+                address 10.0.12.1/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65002;
+    router-id 2.2.2.2;
+}
+policy-options {
+    /*
+     * Marker communities. After the policy runs, each prefix's community
+     * list reveals which terms matched.
+     *   RED:                 written by term 1 of the community case
+     *   MATCHED-COMMUNITY:   added if term 2 saw RED (i.e., cross-term reads ARE visible)
+     *   UNMATCHED-COMMUNITY: added if term 2 did NOT see RED (default Junos behavior)
+     *   MATCHED-LOCALPREF / UNMATCHED-LOCALPREF: same idea for local-preference
+     *   MATCHED-ASPATH    / UNMATCHED-ASPATH:    same idea for as-path-prepend
+     *   CONTROL-MARKER: confirms the marker mechanism itself works
+     */
+    community RED {
+        members 65002:1;
+    }
+    community MATCHED-COMMUNITY {
+        members 65002:1001;
+    }
+    community UNMATCHED-COMMUNITY {
+        members 65002:1002;
+    }
+    community MATCHED-LOCALPREF {
+        members 65002:2001;
+    }
+    community UNMATCHED-LOCALPREF {
+        members 65002:2002;
+    }
+    community MATCHED-ASPATH {
+        members 65002:3001;
+    }
+    community UNMATCHED-ASPATH {
+        members 65002:3002;
+    }
+    community CONTROL-MARKER {
+        members 65002:9999;
+    }
+
+    as-path WITH-65099 "65099 .*";
+
+    policy-statement CROSS-TERM-IMPORT {
+        /* ================ community case: 10.30.1.0/24 ================
+         * Term 1 adds community RED but does not terminate (falls through).
+         * Term 2 attempts to match `from community RED` on the same prefix.
+         * Term 3 (default) tags it UNMATCHED if term 2 did not match.
+         */
+        term WRITE-COMMUNITY {
+            from {
+                route-filter 10.30.1.0/24 exact;
+            }
+            then {
+                community add RED;
+                /* no flow control: fall through */
+            }
+        }
+        term READ-COMMUNITY {
+            from {
+                route-filter 10.30.1.0/24 exact;
+                community RED;
+            }
+            then {
+                community add MATCHED-COMMUNITY;
+                accept;
+            }
+        }
+        term DEFAULT-COMMUNITY {
+            from {
+                route-filter 10.30.1.0/24 exact;
+            }
+            then {
+                community add UNMATCHED-COMMUNITY;
+                accept;
+            }
+        }
+
+        /* ================ local-preference case: 10.30.2.0/24 ================ */
+        term WRITE-LOCALPREF {
+            from {
+                route-filter 10.30.2.0/24 exact;
+            }
+            then {
+                local-preference 250;
+                /* no flow control: fall through */
+            }
+        }
+        term READ-LOCALPREF {
+            from {
+                route-filter 10.30.2.0/24 exact;
+                local-preference 250;
+            }
+            then {
+                community add MATCHED-LOCALPREF;
+                accept;
+            }
+        }
+        term DEFAULT-LOCALPREF {
+            from {
+                route-filter 10.30.2.0/24 exact;
+            }
+            then {
+                community add UNMATCHED-LOCALPREF;
+                accept;
+            }
+        }
+
+        /* ================ as-path case: 10.30.3.0/24 ================ */
+        term WRITE-ASPATH {
+            from {
+                route-filter 10.30.3.0/24 exact;
+            }
+            then {
+                as-path-prepend 65099;
+                /* no flow control: fall through */
+            }
+        }
+        term READ-ASPATH {
+            from {
+                route-filter 10.30.3.0/24 exact;
+                as-path WITH-65099;
+            }
+            then {
+                community add MATCHED-ASPATH;
+                accept;
+            }
+        }
+        term DEFAULT-ASPATH {
+            from {
+                route-filter 10.30.3.0/24 exact;
+            }
+            then {
+                community add UNMATCHED-ASPATH;
+                accept;
+            }
+        }
+
+        /* ================ control: 10.30.4.0/24 ================
+         * Single term, single write, accept. Verifies the marker mechanism.
+         */
+        term CONTROL {
+            from {
+                route-filter 10.30.4.0/24 exact;
+            }
+            then {
+                community add CONTROL-MARKER;
+                accept;
+            }
+        }
+
+        term REJECT-OTHER {
+            then reject;
+        }
+    }
+}
+protocols {
+    bgp {
+        group FROM-SENDER {
+            type external;
+            peer-as 65001;
+            neighbor 10.0.12.0 {
+                import CROSS-TERM-IMPORT;
+            }
+        }
+    }
+}

--- a/infra/examples/junos-cross-term-match/configs/sender.cfg
+++ b/infra/examples/junos-cross-term-match/configs/sender.cfg
@@ -1,0 +1,53 @@
+system {
+    host-name sender;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 1.1.1.1/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to dut";
+        unit 0 {
+            family inet {
+                address 10.0.12.0/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65001;
+    router-id 1.1.1.1;
+    static {
+        /* term 1 adds community RED, term 2 from community RED */
+        route 10.30.1.0/24 discard;
+        /* term 1 sets local-preference 250, term 2 from local-preference 250 */
+        route 10.30.2.0/24 discard;
+        /* term 1 prepends 65099, term 2 from as-path WITH-65099 */
+        route 10.30.3.0/24 discard;
+        /* control: nothing matches, falls through */
+        route 10.30.4.0/24 discard;
+    }
+}
+policy-options {
+    policy-statement EXPORT-ALL {
+        term ACCEPT {
+            from protocol static;
+            then accept;
+        }
+    }
+}
+protocols {
+    bgp {
+        group TO-DUT {
+            type external;
+            peer-as 65002;
+            neighbor 10.0.12.1 {
+                export EXPORT-ALL;
+            }
+        }
+    }
+}

--- a/infra/examples/junos-cross-term-match/topology.clab.yml
+++ b/infra/examples/junos-cross-term-match/topology.clab.yml
@@ -1,0 +1,38 @@
+# Junos cross-term match lab.
+#
+# Question: within a single policy-statement, when an earlier term writes
+# to a route attribute (community, local-preference, AS-path) and the term
+# does NOT terminate (no accept/reject), can a later term `from`-match on
+# that updated attribute? Or do later terms always see the original value
+# of the attribute?
+#
+# This is the Junos analog of the FRR/Cumulus/Quagga "always-on intermediate
+# attributes" use case: those vendors set ReadIntermediate so that route-map
+# entries see updates from prior entries. The question for Junos is empirical.
+#
+# Topology:
+#   sender (AS 65001) --[ge-0/0/0]--[ge-0/0/0]-- dut (AS 65002)
+#     lo0: 1.1.1.1/32                             lo0: 2.2.2.2/32
+#     link: 10.0.12.0/31                          link: 10.0.12.1/31
+#
+# sender: originates 10.30.0-4.0/24 via static, advertises all to dut
+#         with no community / vanilla AS-path / default localpref.
+#
+# dut: imports from sender via a single policy whose terms test cross-term
+#      visibility of writes. Each prefix exercises a different scenario.
+
+name: junos-cross-term-match
+
+topology:
+  nodes:
+    sender:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/sender.cfg
+    dut:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/dut.cfg
+
+  links:
+    - endpoints: ["sender:eth1", "dut:eth1"]

--- a/infra/examples/junos-policy-chain-visibility/README.md
+++ b/infra/examples/junos-policy-chain-visibility/README.md
@@ -1,0 +1,148 @@
+# Junos Policy-Chain Visibility Lab
+
+When a BGP neighbor has `import [ POLICY-A POLICY-B POLICY-C ];`, can a
+later policy `from`-match on attributes that an earlier policy wrote?
+This is the Junos analog of the combined export-import policy case
+discussed in `working/intermediateAttributes.md`
+(`CiscoConversions.vrfExportImportPolicy` and the Cisco-XR / ASA
+variants), where Batfish currently emits intermediate-attribute flags
+to make the import side see export-side writes.
+
+## Hypothesis
+
+Either:
+
+- **Junos chains see writes.** A modification by POLICY-A is visible
+  to POLICY-B's `from` clauses. Then Batfish's Junos conversion would
+  need to set `ReadIntermediate` between policies (or use output
+  attributes) for chained imports to model correctly.
+
+- **Junos chains do not see writes.** Each policy in the chain
+  evaluates `from` clauses against the original attributes that
+  arrived from the protocol. Then the current Batfish behavior (no
+  intermediate flag on Junos) likely matches the device for chains.
+
+The answer is empirical and may differ per attribute (community vs.
+local-preference vs. as-path).
+
+## Topology
+
+```
+sender (AS 65001) --- dut (AS 65002)
+       ge-0/0/0  <->  ge-0/0/0
+       10.0.12.0      10.0.12.1
+```
+
+No collector — observation is on `dut`.
+
+## Method
+
+`dut`'s BGP session from `sender` carries `import [ POLICY-A-WRITE
+POLICY-B-READ POLICY-C-DEFAULT ];`. The three policies are layered:
+
+1. **POLICY-A-WRITE**: per prefix, modify a single attribute and fall
+   through (no `accept`/`reject`).
+2. **POLICY-B-READ**: per prefix, attempt to `from`-match on the
+   modified value. If matched, tag the route `MATCHED-*` and accept.
+3. **POLICY-C-DEFAULT**: per prefix, tag the route `UNMATCHED-*` and
+   accept.
+
+The marker community on each route reveals the path taken.
+
+## Test Routes
+
+| Prefix       | Attribute        | POLICY-A write           | POLICY-B read condition |
+| ------------ | ---------------- | ------------------------ | ----------------------- |
+| 10.40.1.0/24 | community        | `community add RED;`     | `community RED;`        |
+| 10.40.2.0/24 | local-preference | `local-preference 250;`  | `local-preference 250;` |
+| 10.40.3.0/24 | as-path          | `as-path-prepend 65099;` | `as-path WITH-65099`    |
+
+Marker decoder (same as `junos-cross-term-match`):
+
+| Community    | Meaning               |
+| ------------ | --------------------- |
+| `65002:1001` | `MATCHED-COMMUNITY`   |
+| `65002:1002` | `UNMATCHED-COMMUNITY` |
+| `65002:2001` | `MATCHED-LOCALPREF`   |
+| `65002:2002` | `UNMATCHED-LOCALPREF` |
+| `65002:3001` | `MATCHED-ASPATH`      |
+| `65002:3002` | `UNMATCHED-ASPATH`    |
+
+## What to Observe
+
+On `dut`:
+
+```
+show route 10.40.0.0/22 detail | display json
+```
+
+For each prefix, exactly one of the `MATCHED-*` / `UNMATCHED-*` marker
+communities (per attribute) should be present.
+
+## Companion Lab
+
+`junos-cross-term-match` asks the same question for _terms within one
+policy_. Reading the two together gives the Junos picture:
+
+| Setting        | Cross-term                         | Cross-policy |
+| -------------- | ---------------------------------- | ------------ |
+| Junos behavior | (this lab and its sibling tell us) | (this lab)   |
+
+## Running
+
+```
+lab_builder validate topology.clab.yml --checks checks.yaml
+```
+
+## Results
+
+Deployed 2026-05-19 on vJunos-router 25.4R1.12 (containerlab on EC2).
+All 5 checks passed. Substantive observations from
+`show route protocol bgp 10.40/16 detail` on `dut`:
+
+| Prefix       | Communities           | Localpref | AS path           | Decode                  |
+| ------------ | --------------------- | --------- | ----------------- | ----------------------- |
+| 10.40.1.0/24 | `65002:1, 65002:1001` | 100       | 65001 I           | RED + MATCHED-COMMUNITY |
+| 10.40.2.0/24 | `65002:2001`          | **250**   | 65001 I           | MATCHED-LOCALPREF       |
+| 10.40.3.0/24 | `65002:3001`          | 100       | **65099 65001 I** | MATCHED-ASPATH          |
+
+### Interpretation
+
+For all three attribute types tested, the **MATCHED-\* marker fired**
+across the policy chain. POLICY-B in `import [ POLICY-A POLICY-B
+POLICY-C ];` **does see** the writes that POLICY-A made for the same
+route. Junos chain visibility is the same as within-policy term
+visibility: writes propagate to downstream policies in the chain.
+
+This matches the semantics that `CiscoConversions.vrfExportImportPolicy`
+emulates via `SetReadIntermediateBgpAttributes` between the two
+combined policies.
+
+### Batfish triage
+
+`pytest lab_tests/test_labs.py --labname=junos_policy_chain_visibility`:
+**13 passed, 0 skipped, no sickbay**. Batfish's BGP-rib local-preference
+/ as-path predictions match the device for all three prefixes.
+
+The richer probe is `bgpRib` against the dataplane, which exposes
+the predicted communities. Querying it produced:
+
+| Prefix       | Device communities    | Batfish bgpRib communities |
+| ------------ | --------------------- | -------------------------- |
+| 10.40.1.0/24 | `65002:1, 65002:1001` | `65002:1, 65002:1001`      |
+| 10.40.2.0/24 | `65002:2001`          | `65002:2001`               |
+| 10.40.3.0/24 | `65002:3001`          | `65002:3001`               |
+
+**No discrepancy.** Batfish's modeling of Junos `import [ A B C ]`
+chains correctly gives B visibility into A's writes, exactly as the
+device does.
+
+For curiosity: testRoutePolicies on each policy in isolation yields
+DENY for A and B (no terminating accept; Junos default is reject), and
+PERMIT with the UNMATCHED-\* markers for C (because in isolation there
+is no prior write to read). It is only the _chain_ execution that
+produces the MATCHED-\* result, and Batfish gets that right.
+
+### Companion data
+
+- Snapshot: `snapshots/junos_policy_chain_visibility/`

--- a/infra/examples/junos-policy-chain-visibility/checks.yaml
+++ b/infra/examples/junos-policy-chain-visibility/checks.yaml
@@ -1,0 +1,29 @@
+# Validation checks for the Junos policy-chain visibility lab.
+# Confirms BGP up and the 3 test prefixes imported on dut.
+# The chain-visibility result is read from communities on each route.
+
+checks:
+  - type: bgp_peer_established
+    node: sender
+    neighbor: 10.0.12.1
+    description: "sender -> dut eBGP"
+  - type: bgp_peer_established
+    node: dut
+    neighbor: 10.0.12.0
+    description: "dut -> sender eBGP"
+
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.40.1.0/24
+    description: "community-case route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.40.2.0/24
+    description: "localpref-case route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.40.3.0/24
+    description: "as-path-case route present on dut"

--- a/infra/examples/junos-policy-chain-visibility/configs/dut.cfg
+++ b/infra/examples/junos-policy-chain-visibility/configs/dut.cfg
@@ -1,0 +1,167 @@
+system {
+    host-name dut;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 2.2.2.2/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to sender";
+        unit 0 {
+            family inet {
+                address 10.0.12.1/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65002;
+    router-id 2.2.2.2;
+}
+policy-options {
+    /*
+     * Marker communities, same scheme as junos-cross-term-match:
+     *   RED:                 written by POLICY-A for the community case
+     *   MATCHED-COMMUNITY:   added if POLICY-B saw RED (chain reads visible)
+     *   UNMATCHED-COMMUNITY: added if POLICY-B did NOT see RED
+     *   MATCHED-LOCALPREF / UNMATCHED-LOCALPREF: same idea for local-preference
+     *   MATCHED-ASPATH    / UNMATCHED-ASPATH:    same idea for as-path
+     */
+    community RED {
+        members 65002:1;
+    }
+    community MATCHED-COMMUNITY {
+        members 65002:1001;
+    }
+    community UNMATCHED-COMMUNITY {
+        members 65002:1002;
+    }
+    community MATCHED-LOCALPREF {
+        members 65002:2001;
+    }
+    community UNMATCHED-LOCALPREF {
+        members 65002:2002;
+    }
+    community MATCHED-ASPATH {
+        members 65002:3001;
+    }
+    community UNMATCHED-ASPATH {
+        members 65002:3002;
+    }
+
+    as-path WITH-65099 "65099 .*";
+
+    /*
+     * POLICY-A: write attributes per prefix; do NOT terminate so the
+     * chain proceeds to POLICY-B.
+     */
+    policy-statement POLICY-A-WRITE {
+        term WRITE-COMMUNITY {
+            from {
+                route-filter 10.40.1.0/24 exact;
+            }
+            then community add RED;
+        }
+        term WRITE-LOCALPREF {
+            from {
+                route-filter 10.40.2.0/24 exact;
+            }
+            then local-preference 250;
+        }
+        term WRITE-ASPATH {
+            from {
+                route-filter 10.40.3.0/24 exact;
+            }
+            then as-path-prepend 65099;
+        }
+    }
+
+    /*
+     * POLICY-B: attempt to read POLICY-A's writes. If the read succeeds,
+     * tag the route MATCHED-* and accept; otherwise fall through.
+     */
+    policy-statement POLICY-B-READ {
+        term READ-COMMUNITY {
+            from {
+                route-filter 10.40.1.0/24 exact;
+                community RED;
+            }
+            then {
+                community add MATCHED-COMMUNITY;
+                accept;
+            }
+        }
+        term READ-LOCALPREF {
+            from {
+                route-filter 10.40.2.0/24 exact;
+                local-preference 250;
+            }
+            then {
+                community add MATCHED-LOCALPREF;
+                accept;
+            }
+        }
+        term READ-ASPATH {
+            from {
+                route-filter 10.40.3.0/24 exact;
+                as-path WITH-65099;
+            }
+            then {
+                community add MATCHED-ASPATH;
+                accept;
+            }
+        }
+    }
+
+    /*
+     * POLICY-C: default. Tag whatever fell through with the
+     * UNMATCHED-* marker and accept.
+     */
+    policy-statement POLICY-C-DEFAULT {
+        term DEFAULT-COMMUNITY {
+            from {
+                route-filter 10.40.1.0/24 exact;
+            }
+            then {
+                community add UNMATCHED-COMMUNITY;
+                accept;
+            }
+        }
+        term DEFAULT-LOCALPREF {
+            from {
+                route-filter 10.40.2.0/24 exact;
+            }
+            then {
+                community add UNMATCHED-LOCALPREF;
+                accept;
+            }
+        }
+        term DEFAULT-ASPATH {
+            from {
+                route-filter 10.40.3.0/24 exact;
+            }
+            then {
+                community add UNMATCHED-ASPATH;
+                accept;
+            }
+        }
+        term REJECT-OTHER {
+            then reject;
+        }
+    }
+}
+protocols {
+    bgp {
+        group FROM-SENDER {
+            type external;
+            peer-as 65001;
+            neighbor 10.0.12.0 {
+                import [ POLICY-A-WRITE POLICY-B-READ POLICY-C-DEFAULT ];
+            }
+        }
+    }
+}

--- a/infra/examples/junos-policy-chain-visibility/configs/sender.cfg
+++ b/infra/examples/junos-policy-chain-visibility/configs/sender.cfg
@@ -1,0 +1,51 @@
+system {
+    host-name sender;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 1.1.1.1/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to dut";
+        unit 0 {
+            family inet {
+                address 10.0.12.0/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65001;
+    router-id 1.1.1.1;
+    static {
+        /* community: POLICY-A adds RED, POLICY-B from community RED */
+        route 10.40.1.0/24 discard;
+        /* local-preference: POLICY-A sets 250, POLICY-B from local-preference 250 */
+        route 10.40.2.0/24 discard;
+        /* as-path: POLICY-A prepends 65099, POLICY-B from as-path WITH-65099 */
+        route 10.40.3.0/24 discard;
+    }
+}
+policy-options {
+    policy-statement EXPORT-ALL {
+        term ACCEPT {
+            from protocol static;
+            then accept;
+        }
+    }
+}
+protocols {
+    bgp {
+        group TO-DUT {
+            type external;
+            peer-as 65002;
+            neighbor 10.0.12.1 {
+                export EXPORT-ALL;
+            }
+        }
+    }
+}

--- a/infra/examples/junos-policy-chain-visibility/topology.clab.yml
+++ b/infra/examples/junos-policy-chain-visibility/topology.clab.yml
@@ -1,0 +1,37 @@
+# Junos policy-chain visibility lab.
+#
+# Question: when a BGP neighbor has `import [ POLICY-A POLICY-B ];`, can
+# POLICY-B `from`-match on attributes that POLICY-A wrote? This is the
+# Junos analog of the combined export-import policy case discussed in
+# working/intermediateAttributes.md (CiscoConversions.vrfExportImportPolicy
+# and friends), where Batfish currently uses intermediate-attribute flags
+# to make the import-side see export-side writes.
+#
+# Topology:
+#   sender (AS 65001) --[ge-0/0/0]--[ge-0/0/0]-- dut (AS 65002)
+#     lo0: 1.1.1.1/32                             lo0: 2.2.2.2/32
+#     link: 10.0.12.0/31                          link: 10.0.12.1/31
+#
+# sender: originates 10.40.1-3.0/24 vanilla; advertises all to dut.
+#
+# dut: imports from sender via `import [ POLICY-A POLICY-B POLICY-C ];`
+#      where POLICY-A writes attributes (no terminating action), POLICY-B
+#      attempts to read those writes via `from` matches, and POLICY-C
+#      tags the unmatched default. Marker communities reveal which
+#      branch fired.
+
+name: junos-policy-chain-visibility
+
+topology:
+  nodes:
+    sender:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/sender.cfg
+    dut:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/dut.cfg
+
+  links:
+    - endpoints: ["sender:eth1", "dut:eth1"]

--- a/infra/examples/junos-rmw-localpref/README.md
+++ b/infra/examples/junos-rmw-localpref/README.md
@@ -1,0 +1,145 @@
+# Junos Read-Modify-Write Local-Preference Lab
+
+When a single Junos `then` block contains multiple arithmetic actions on
+the same attribute, does each later action see the running (in-progress)
+value, or does it always read the original attribute? This is the
+"Suspicious Omission" raised in
+`working/intermediateAttributes.md` for read-modify-write operations.
+
+## Hypothesis
+
+Junos composes within-term actions sequentially — i.e., later actions
+read the value left by earlier actions. The TRP (Targeted Route Policy)
+implementation in Batfish, on platforms where `useOutputAttributes` is
+false and intermediate attributes are not enabled, instead reads the
+_original_ attribute for each action. If that hypothesis is right, this
+lab will show a divergence between Junos and the current Batfish model
+for any policy that chains arithmetic operations.
+
+## Topology
+
+```
+sender (AS 65001) --- dut (AS 65002)
+       ge-0/0/0  <->  ge-0/0/0
+       10.0.12.0      10.0.12.1
+```
+
+No collector is needed: local-preference and metric are both either
+non-transitive across eBGP or not the question we're asking. The
+observation is on `dut` only.
+
+## Test Routes
+
+`sender` originates these prefixes via static and exports all to `dut`
+without modification (so they all arrive with localpref=100, metric=0,
+AS-path `65001`).
+
+| Prefix       | dut import term     | Compound action(s)                                    |
+| ------------ | ------------------- | ----------------------------------------------------- |
+| 10.20.0.0/24 | `BASELINE`          | (none — baseline)                                     |
+| 10.20.1.0/24 | `TWO-ADDS`          | `local-preference add 50; local-preference add 50;`   |
+| 10.20.2.0/24 | `SET-THEN-ADD`      | `local-preference 300; local-preference add 50;`      |
+| 10.20.3.0/24 | `SET-THEN-SUBTRACT` | `local-preference 300; local-preference subtract 50;` |
+| 10.20.4.0/24 | `METRIC-SET-ADD`    | `metric 200; metric add 50;`                          |
+| 10.20.5.0/24 | `DOUBLE-PREPEND`    | `as-path-prepend "65002 65002";`                      |
+
+## What to Observe
+
+For each prefix, run on `dut`:
+
+```
+show route 10.20.X.0/24 extensive | display json
+```
+
+and read off `local-preference`, `metric`, and `as-path`. The expected
+values under each interpretation are:
+
+| Prefix       | If sequential RMW (Junos hypothesis) | If read-original each time                         |
+| ------------ | ------------------------------------ | -------------------------------------------------- |
+| 10.20.0.0/24 | localpref=100                        | localpref=100                                      |
+| 10.20.1.0/24 | localpref=200                        | localpref=150                                      |
+| 10.20.2.0/24 | localpref=350                        | localpref=150                                      |
+| 10.20.3.0/24 | localpref=250                        | localpref=50                                       |
+| 10.20.4.0/24 | metric=250                           | metric=50                                          |
+| 10.20.5.0/24 | as-path `65002 65002 65001`          | as-path `65002 65002 65001` (same — single action) |
+
+The `DOUBLE-PREPEND` row is included as a baseline: a multi-ASN
+`as-path-prepend` is a single action (one read, one write), so both
+interpretations agree. It is here to confirm that prepend itself
+behaves as expected before we read into divergent results elsewhere.
+
+If the actual values match the sequential-RMW column, that is empirical
+evidence that Batfish should chain reads for these compound actions on
+Junos (or, equivalently, set `useOutputAttributes` for Junos so that
+output and intermediate become the same store).
+
+## Running
+
+```
+lab_builder validate topology.clab.yml --checks checks.yaml
+```
+
+The checks confirm BGP comes up and all 6 routes land in `inet.0` on
+`dut`. The substantive results live in `show route extensive` output;
+see Results below for what was observed.
+
+## Results
+
+Deployed 2026-05-19 on vJunos-router 25.4R1.12 (containerlab on EC2).
+All 8 checks passed. Substantive observations from
+`show route <prefix> extensive | display json` on `dut`:
+
+| Prefix       | Compound action(s)                                    | localpref | metric | AS path                                            |
+| ------------ | ----------------------------------------------------- | --------- | ------ | -------------------------------------------------- |
+| 10.20.0.0/24 | (none — baseline)                                     | 100       | —      | 65001 I                                            |
+| 10.20.1.0/24 | `local-preference add 50; local-preference add 50;`   | **150**   | —      | 65001 I                                            |
+| 10.20.2.0/24 | `local-preference 300; local-preference add 50;`      | **150**   | —      | 65001 I                                            |
+| 10.20.3.0/24 | `local-preference 300; local-preference subtract 50;` | **50**    | —      | 65001 I                                            |
+| 10.20.4.0/24 | `metric 200; metric add 50;`                          | 100       | **50** | 65001 I                                            |
+| 10.20.5.0/24 | `as-path-prepend "65002 65002";`                      | 100       | —      | 65002 65002 65001 I (Looped: 65002 — still active) |
+
+### Interpretation
+
+Junos exhibits **read-original-each-action** semantics for the
+arithmetic and set actions in this lab. Concretely:
+
+- `add 50; add 50` produced **150**, not 200 — each `add` reads the
+  original local-pref (100) rather than chaining off the running value.
+- `set 300; add 50` produced **150**, not 350 — even when an explicit
+  `set` writes 300, the later `add 50` still reads the _original_ 100
+  and the result is 150 (effectively, the later write wins because it
+  is also based on the original input).
+- `set 300; subtract 50` produced **50**, not 250 — same shape as above.
+- `metric 200; metric add 50` produced **50**, not 250 — same behavior
+  on MED.
+
+The multi-ASN `as-path-prepend "65002 65002"` worked as a single action,
+producing `65002 65002 65001`. (Junos flagged the loop but kept the
+route active since the prepend was self-applied at import.)
+
+This empirical result aligns with the current Batfish TRP behavior for
+platforms where `useOutputAttributes` is false and intermediate
+attributes are _not_ enabled — i.e., the Junos conversion's current
+default. So for these specific within-`then` compound writes, the
+"Suspicious Omission" raised in `working/intermediateAttributes.md`
+is **not actually a bug for Junos** (whatever it is for IOS, where
+the same hypothesis was confirmed).
+
+The absolute values match the read-original column in this README's
+hypothesis table. There is no divergence between Junos and the
+existing Batfish model for this case — Batfish's modeling appears
+correct for Junos here.
+
+### Batfish triage
+
+`pytest lab_tests/test_labs.py --labname=junos_rmw_localpref` against
+local Batfish: **13 passed, 0 skipped, no sickbay**. The BGP-rib-routes
+test compares Batfish-predicted local_preference / MED / as-path
+against the device's actual values per prefix; all match. So Batfish's
+Junos conversion already produces the same 150 / 50 / 150 / 50 that the
+device produces — there is no modeling discrepancy to file for this
+case.
+
+### Companion data
+
+- Snapshot: `snapshots/junos_rmw_localpref/`

--- a/infra/examples/junos-rmw-localpref/checks.yaml
+++ b/infra/examples/junos-rmw-localpref/checks.yaml
@@ -1,0 +1,48 @@
+# Validation checks for the Junos RMW local-preference lab.
+# Run after health-check, before collection:
+#   lab_builder validate topology.clab.yml --checks checks.yaml
+#
+# These checks confirm the lab is healthy enough to collect (BGP up,
+# all 6 prefixes imported on dut). The actual RMW semantics are read
+# off `show route ... extensive | display json` — see README.
+
+checks:
+  - type: bgp_peer_established
+    node: sender
+    neighbor: 10.0.12.1
+    description: "sender -> dut eBGP"
+  - type: bgp_peer_established
+    node: dut
+    neighbor: 10.0.12.0
+    description: "dut -> sender eBGP"
+
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.20.0.0/24
+    description: "baseline route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.20.1.0/24
+    description: "two-adds route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.20.2.0/24
+    description: "set-then-add route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.20.3.0/24
+    description: "set-then-subtract route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.20.4.0/24
+    description: "metric-set-add route present on dut"
+  - type: route_exists
+    node: dut
+    table: inet.0
+    prefix: 10.20.5.0/24
+    description: "double-prepend route present on dut"

--- a/infra/examples/junos-rmw-localpref/configs/dut.cfg
+++ b/infra/examples/junos-rmw-localpref/configs/dut.cfg
@@ -1,0 +1,110 @@
+system {
+    host-name dut;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 2.2.2.2/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to sender";
+        unit 0 {
+            family inet {
+                address 10.0.12.1/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65002;
+    router-id 2.2.2.2;
+}
+policy-options {
+    /*
+     * Each term targets one prefix and applies a different compound set of
+     * actions on local-preference (and on metric for the kitchen-sink term).
+     * All actions are within a single `then` block — this lab is about
+     * within-term read-modify-write semantics. Cross-term and cross-policy
+     * cases live in junos-cross-term-match and junos-policy-chain-visibility.
+     */
+    policy-statement RMW-IMPORT {
+        /* baseline: no localpref/metric manipulation, just accept */
+        term BASELINE {
+            from {
+                route-filter 10.20.0.0/24 exact;
+            }
+            then accept;
+        }
+        /* two `add 50` in one then: compound = 200, read-original = 150 */
+        term TWO-ADDS {
+            from {
+                route-filter 10.20.1.0/24 exact;
+            }
+            then {
+                local-preference add 50;
+                local-preference add 50;
+                accept;
+            }
+        }
+        /* set 300 then add 50: compound = 350, read-original = 150 */
+        term SET-THEN-ADD {
+            from {
+                route-filter 10.20.2.0/24 exact;
+            }
+            then {
+                local-preference 300;
+                local-preference add 50;
+                accept;
+            }
+        }
+        /* set 300 then subtract 50: compound = 250, read-original = 50 */
+        term SET-THEN-SUBTRACT {
+            from {
+                route-filter 10.20.3.0/24 exact;
+            }
+            then {
+                local-preference 300;
+                local-preference subtract 50;
+                accept;
+            }
+        }
+        /* compound on metric (MED): set 200 then add 50 */
+        term METRIC-SET-ADD {
+            from {
+                route-filter 10.20.4.0/24 exact;
+            }
+            then {
+                metric 200;
+                metric add 50;
+                accept;
+            }
+        }
+        /* two as-path-prepends in one then; expect both to take effect */
+        term DOUBLE-PREPEND {
+            from {
+                route-filter 10.20.5.0/24 exact;
+            }
+            then {
+                as-path-prepend "65002 65002";
+                accept;
+            }
+        }
+        term REJECT-OTHER {
+            then reject;
+        }
+    }
+}
+protocols {
+    bgp {
+        group FROM-SENDER {
+            type external;
+            peer-as 65001;
+            neighbor 10.0.12.0 {
+                import RMW-IMPORT;
+            }
+        }
+    }
+}

--- a/infra/examples/junos-rmw-localpref/configs/sender.cfg
+++ b/infra/examples/junos-rmw-localpref/configs/sender.cfg
@@ -1,0 +1,57 @@
+system {
+    host-name sender;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 1.1.1.1/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to dut";
+        unit 0 {
+            family inet {
+                address 10.0.12.0/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65001;
+    router-id 1.1.1.1;
+    static {
+        /* baseline: nothing modifies localpref/metric on dut */
+        route 10.20.0.0/24 discard;
+        /* two `local-preference add 50` actions in one then */
+        route 10.20.1.0/24 discard;
+        /* `local-preference 300` then `local-preference add 50` in one then */
+        route 10.20.2.0/24 discard;
+        /* `local-preference 300` then `local-preference subtract 50` in one then */
+        route 10.20.3.0/24 discard;
+        /* `metric 200` then `metric add 50` in one then */
+        route 10.20.4.0/24 discard;
+        /* `as-path-prepend "65002 65002"` (multiple ASNs in one prepend) */
+        route 10.20.5.0/24 discard;
+    }
+}
+policy-options {
+    policy-statement EXPORT-ALL {
+        term ACCEPT {
+            from protocol static;
+            then accept;
+        }
+    }
+}
+protocols {
+    bgp {
+        group TO-DUT {
+            type external;
+            peer-as 65002;
+            neighbor 10.0.12.1 {
+                export EXPORT-ALL;
+            }
+        }
+    }
+}

--- a/infra/examples/junos-rmw-localpref/topology.clab.yml
+++ b/infra/examples/junos-rmw-localpref/topology.clab.yml
@@ -1,0 +1,38 @@
+# Junos read-modify-write local-preference lab.
+#
+# Question: when a Junos route policy contains compound arithmetic actions on
+# `local-preference` (e.g., `local-preference 300; local-preference add 50`),
+# does each later action see the running value, or does it read the original
+# attribute? This is the "Suspicious Omission" called out in
+# working/intermediateAttributes.md (read-modify-write semantics).
+#
+# Topology:
+#   sender (AS 65001) --[ge-0/0/0]--[ge-0/0/0]-- dut (AS 65002)
+#     lo0: 1.1.1.1/32                              lo0: 2.2.2.2/32
+#     link: 10.0.12.0/31                           link: 10.0.12.1/31
+#
+# sender: originates 10.20.0-5.0/24 via static; advertises all to dut.
+#
+# dut: imports from sender via a policy whose terms each apply a different
+#      compound local-preference manipulation. Resulting Localpref on each
+#      route in inet.0 is what we measure.
+#
+# No collector is needed — local-preference is non-transitive across eBGP,
+# and the question is purely about how Junos resolves chained writes.
+
+name: junos-rmw-localpref
+
+topology:
+  nodes:
+    sender:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/sender.cfg
+    dut:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/dut.cfg
+
+  links:
+    # sender ge-0/0/0 (eth1) <-> dut ge-0/0/0 (eth1)
+    - endpoints: ["sender:eth1", "dut:eth1"]

--- a/snapshots/junos_cross_term_match/batfish/layer1_topology.json
+++ b/snapshots/junos_cross_term_match/batfish/layer1_topology.json
@@ -1,0 +1,14 @@
+{
+    "edges": [
+        {
+            "node1": {
+                "hostname": "sender",
+                "interfaceName": "ge-0/0/0"
+            },
+            "node2": {
+                "hostname": "dut",
+                "interfaceName": "ge-0/0/0"
+            }
+        }
+    ]
+}

--- a/snapshots/junos_cross_term_match/configs/dut/show_configuration_|_display_set.txt
+++ b/snapshots/junos_cross_term_match/configs/dut/show_configuration_|_display_set.txt
@@ -1,0 +1,62 @@
+set version 25.4R1.12
+set system host-name dut
+set system root-authentication encrypted-password "$6$vqh43mXL$F./lKrO.vayo5.NYzXDtq9d6g6Xyih4mmUmKnob4zkindX2nFfbe/hoifPDkXxJ2gDXQAbig0BAkFCB8cuG4D1"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$GB/LiV2a$RRlnt3zo4EbGhQDkFGWBmDW2V.0Oy4Uz1WdZhMODeATyVc7p4niC8z3HWcdxQqrdzo45g64ezk8OzreO81AzV/"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to sender"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.1/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 2.2.2.2/32
+set policy-options policy-statement CROSS-TERM-IMPORT term WRITE-COMMUNITY from route-filter 10.30.1.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term WRITE-COMMUNITY then community add RED
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-COMMUNITY from community RED
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-COMMUNITY from route-filter 10.30.1.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-COMMUNITY then community add MATCHED-COMMUNITY
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-COMMUNITY then accept
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-COMMUNITY from route-filter 10.30.1.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-COMMUNITY then community add UNMATCHED-COMMUNITY
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-COMMUNITY then accept
+set policy-options policy-statement CROSS-TERM-IMPORT term WRITE-LOCALPREF from route-filter 10.30.2.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term WRITE-LOCALPREF then local-preference 250
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-LOCALPREF from local-preference 250
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-LOCALPREF from route-filter 10.30.2.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-LOCALPREF then community add MATCHED-LOCALPREF
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-LOCALPREF then accept
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-LOCALPREF from route-filter 10.30.2.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-LOCALPREF then community add UNMATCHED-LOCALPREF
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-LOCALPREF then accept
+set policy-options policy-statement CROSS-TERM-IMPORT term WRITE-ASPATH from route-filter 10.30.3.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term WRITE-ASPATH then as-path-prepend 65099
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-ASPATH from as-path WITH-65099
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-ASPATH from route-filter 10.30.3.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-ASPATH then community add MATCHED-ASPATH
+set policy-options policy-statement CROSS-TERM-IMPORT term READ-ASPATH then accept
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-ASPATH from route-filter 10.30.3.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-ASPATH then community add UNMATCHED-ASPATH
+set policy-options policy-statement CROSS-TERM-IMPORT term DEFAULT-ASPATH then accept
+set policy-options policy-statement CROSS-TERM-IMPORT term CONTROL from route-filter 10.30.4.0/24 exact
+set policy-options policy-statement CROSS-TERM-IMPORT term CONTROL then community add CONTROL-MARKER
+set policy-options policy-statement CROSS-TERM-IMPORT term CONTROL then accept
+set policy-options policy-statement CROSS-TERM-IMPORT term REJECT-OTHER then reject
+set policy-options community CONTROL-MARKER members 65002:9999
+set policy-options community MATCHED-ASPATH members 65002:3001
+set policy-options community MATCHED-COMMUNITY members 65002:1001
+set policy-options community MATCHED-LOCALPREF members 65002:2001
+set policy-options community RED members 65002:1
+set policy-options community UNMATCHED-ASPATH members 65002:3002
+set policy-options community UNMATCHED-COMMUNITY members 65002:1002
+set policy-options community UNMATCHED-LOCALPREF members 65002:2002
+set policy-options as-path WITH-65099 "65099 .*"
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 2.2.2.2
+set routing-options autonomous-system 65002
+set protocols bgp group FROM-SENDER type external
+set protocols bgp group FROM-SENDER peer-as 65001
+set protocols bgp group FROM-SENDER neighbor 10.0.12.0 import CROSS-TERM-IMPORT

--- a/snapshots/junos_cross_term_match/configs/sender/show_configuration_|_display_set.txt
+++ b/snapshots/junos_cross_term_match/configs/sender/show_configuration_|_display_set.txt
@@ -1,0 +1,28 @@
+set version 25.4R1.12
+set system host-name sender
+set system root-authentication encrypted-password "$6$kF3b3g3v$6mMdKx/ZoP0RppiISDBNN6mVgwBKMkRXhwJUS7E.k13T72kXu4.SKw95N/lT7SBWYQ9LXZG.hejUT6mrGhvm30"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$kYRjl7FI$yWQgwIDtoFZf/tFkEeuheCUHv1YzFIW1n2NBdob3cd.S.NBmxf9k6i/sPhBswKevm7w3dsbQ/nQNhapbTy0Ba."
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to dut"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.0/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+set policy-options policy-statement EXPORT-ALL term ACCEPT from protocol static
+set policy-options policy-statement EXPORT-ALL term ACCEPT then accept
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 1.1.1.1
+set routing-options autonomous-system 65001
+set routing-options static route 10.30.1.0/24 discard
+set routing-options static route 10.30.2.0/24 discard
+set routing-options static route 10.30.3.0/24 discard
+set routing-options static route 10.30.4.0/24 discard
+set protocols bgp group TO-DUT type external
+set protocols bgp group TO-DUT peer-as 65002
+set protocols bgp group TO-DUT neighbor 10.0.12.1 export EXPORT-ALL

--- a/snapshots/junos_cross_term_match/show/dut/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/dut/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,457 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.1+56660"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "FROM-SENDER"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "import-policy" : [
+                {
+                    "data" : "CROSS-TERM-IMPORT"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "43", 
+                "attributes" : {"junos:seconds" : "43"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "18"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "18"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "43"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "183"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "61"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/dut/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/dut/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to sender"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:c8:da:e0"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:c8:da:e0"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:39 ago)", 
+                "attributes" : {"junos:seconds" : "39"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "32"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "539"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "16"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "18"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:39 ago)", 
+                "attributes" : {"junos:seconds" : "39"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:10 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e9:6e:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:6e:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e9:6e:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:17:37 UTC (00:02:13 ago)", 
+                "attributes" : {"junos:seconds" : "133"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "49128"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "92765"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "48700"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "92766"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:33:57:ec:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:33:57:ec:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:33:57:ec:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:33:57:ec:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:17:37 UTC (00:02:13 ago)", 
+                "attributes" : {"junos:seconds" : "133"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "8323"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "8095"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "8274"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "8097"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:33ff:fe57:ec00"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:75:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e9:75:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:75:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e9:75:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "459"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "459"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2.2.2.2"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "459"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "459"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:75:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e9:75:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e9:75:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e9:75:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/dut/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/dut/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/dut/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/dut/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/dut/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/dut/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "7"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/dut/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/dut/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,416 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:39", 
+                        "attributes" : {"junos:seconds" : "39"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:39", 
+                        "attributes" : {"junos:seconds" : "39"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "250"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:39", 
+                        "attributes" : {"junos:seconds" : "39"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65099 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:39", 
+                        "attributes" : {"junos:seconds" : "39"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/dut/show_route_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/dut/show_route_|_display_json.txt
@@ -1,0 +1,1001 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2.2.2.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:37", 
+                        "attributes" : {"junos:seconds" : "97"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:41", 
+                        "attributes" : {"junos:seconds" : "41"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:41", 
+                        "attributes" : {"junos:seconds" : "41"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:38", 
+                        "attributes" : {"junos:seconds" : "38"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:38", 
+                        "attributes" : {"junos:seconds" : "38"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "250"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:38", 
+                        "attributes" : {"junos:seconds" : "38"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65099 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:38", 
+                        "attributes" : {"junos:seconds" : "38"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:35", 
+                        "attributes" : {"junos:seconds" : "95"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:37", 
+                        "attributes" : {"junos:seconds" : "97"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:37", 
+                        "attributes" : {"junos:seconds" : "97"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:35", 
+                        "attributes" : {"junos:seconds" : "95"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:37", 
+                        "attributes" : {"junos:seconds" : "97"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:37", 
+                        "attributes" : {"junos:seconds" : "97"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:33ff:fe57:ec00/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:37", 
+                        "attributes" : {"junos:seconds" : "97"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/dut/show_version_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/dut/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "dut"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/host_nos.txt
+++ b/snapshots/junos_cross_term_match/show/host_nos.txt
@@ -1,0 +1,1 @@
+{"dut": "junos", "sender": "junos"}

--- a/snapshots/junos_cross_term_match/show/sender/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/sender/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,457 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.1+56660"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "TO-DUT"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "EXPORT-ALL"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "54", 
+                "attributes" : {"junos:seconds" : "54"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "29"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "29"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "54"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "124"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "101"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/sender/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/sender/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to dut"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:49:3e:1f"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:49:3e:1f"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:00 ago)", 
+                "attributes" : {"junos:seconds" : "60"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "18"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "22"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:00 ago)", 
+                "attributes" : {"junos:seconds" : "60"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:00 ago)", 
+                "attributes" : {"junos:seconds" : "60"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:19:00 UTC (00:01:01 ago)", 
+                "attributes" : {"junos:seconds" : "61"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:09:9b:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:9b:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:09:9b:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:17:35 UTC (00:02:26 ago)", 
+                "attributes" : {"junos:seconds" : "146"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "49136"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "93211"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "48697"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "93212"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:c9:d1:61:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:c9:d1:61:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:c9:d1:61:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:c9:d1:61:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:17:35 UTC (00:02:26 ago)", 
+                "attributes" : {"junos:seconds" : "146"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "7887"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "7818"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "7887"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "7971"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:c9ff:fed1:6100"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:a2:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:09:a2:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:a2:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:09:a2:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "516"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "516"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "1.1.1.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "516"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "516"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:a2:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:09:a2:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:09:a2:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:09:a2:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/sender/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/sender/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/sender/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/sender/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/sender/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/sender/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "7"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/sender/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/sender/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,106 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/sender/show_route_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/sender/show_route_|_display_json.txt
@@ -1,0 +1,885 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "1.1.1.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:57", 
+                        "attributes" : {"junos:seconds" : "117"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:02", 
+                        "attributes" : {"junos:seconds" : "62"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:02", 
+                        "attributes" : {"junos:seconds" : "62"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:56", 
+                        "attributes" : {"junos:seconds" : "116"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:56", 
+                        "attributes" : {"junos:seconds" : "116"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:56", 
+                        "attributes" : {"junos:seconds" : "116"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.30.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:56", 
+                        "attributes" : {"junos:seconds" : "116"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:56", 
+                        "attributes" : {"junos:seconds" : "116"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:57", 
+                        "attributes" : {"junos:seconds" : "117"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:57", 
+                        "attributes" : {"junos:seconds" : "117"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:56", 
+                        "attributes" : {"junos:seconds" : "116"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:57", 
+                        "attributes" : {"junos:seconds" : "117"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:57", 
+                        "attributes" : {"junos:seconds" : "117"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:c9ff:fed1:6100/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:57", 
+                        "attributes" : {"junos:seconds" : "117"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/show/sender/show_version_|_display_json.txt
+++ b/snapshots/junos_cross_term_match/show/sender/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "sender"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_cross_term_match/validation/parse_warnings.yaml
+++ b/snapshots/junos_cross_term_match/validation/parse_warnings.yaml
@@ -1,0 +1,3 @@
+expects_no_fatal_warning:
+  - dut
+  - sender

--- a/snapshots/junos_policy_chain_visibility/batfish/layer1_topology.json
+++ b/snapshots/junos_policy_chain_visibility/batfish/layer1_topology.json
@@ -1,0 +1,14 @@
+{
+    "edges": [
+        {
+            "node1": {
+                "hostname": "sender",
+                "interfaceName": "ge-0/0/0"
+            },
+            "node2": {
+                "hostname": "dut",
+                "interfaceName": "ge-0/0/0"
+            }
+        }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/configs/dut/show_configuration_|_display_set.txt
+++ b/snapshots/junos_policy_chain_visibility/configs/dut/show_configuration_|_display_set.txt
@@ -1,0 +1,60 @@
+set version 25.4R1.12
+set system host-name dut
+set system root-authentication encrypted-password "$6$jVcXBaQ6$dl6ZPmT5yG5ogeweyzaI2s7W.wykU9MrAEtYjWFOiBgbtyl9FYSWq5Vj8ohIjBrwt8IdxKJ4IB5EwsbempTZc1"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$wuCAkxzr$iTq/vo1Fs/FGfiD5ngfHtC7NnpTPa0kGHPAjG5Z1V.tstobQZO4.ugJr5GJMvbvISxTiVBhx/Nb1a0m6QOvz70"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to sender"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.1/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 2.2.2.2/32
+set policy-options policy-statement POLICY-A-WRITE term WRITE-COMMUNITY from route-filter 10.40.1.0/24 exact
+set policy-options policy-statement POLICY-A-WRITE term WRITE-COMMUNITY then community add RED
+set policy-options policy-statement POLICY-A-WRITE term WRITE-LOCALPREF from route-filter 10.40.2.0/24 exact
+set policy-options policy-statement POLICY-A-WRITE term WRITE-LOCALPREF then local-preference 250
+set policy-options policy-statement POLICY-A-WRITE term WRITE-ASPATH from route-filter 10.40.3.0/24 exact
+set policy-options policy-statement POLICY-A-WRITE term WRITE-ASPATH then as-path-prepend 65099
+set policy-options policy-statement POLICY-B-READ term READ-COMMUNITY from community RED
+set policy-options policy-statement POLICY-B-READ term READ-COMMUNITY from route-filter 10.40.1.0/24 exact
+set policy-options policy-statement POLICY-B-READ term READ-COMMUNITY then community add MATCHED-COMMUNITY
+set policy-options policy-statement POLICY-B-READ term READ-COMMUNITY then accept
+set policy-options policy-statement POLICY-B-READ term READ-LOCALPREF from local-preference 250
+set policy-options policy-statement POLICY-B-READ term READ-LOCALPREF from route-filter 10.40.2.0/24 exact
+set policy-options policy-statement POLICY-B-READ term READ-LOCALPREF then community add MATCHED-LOCALPREF
+set policy-options policy-statement POLICY-B-READ term READ-LOCALPREF then accept
+set policy-options policy-statement POLICY-B-READ term READ-ASPATH from as-path WITH-65099
+set policy-options policy-statement POLICY-B-READ term READ-ASPATH from route-filter 10.40.3.0/24 exact
+set policy-options policy-statement POLICY-B-READ term READ-ASPATH then community add MATCHED-ASPATH
+set policy-options policy-statement POLICY-B-READ term READ-ASPATH then accept
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-COMMUNITY from route-filter 10.40.1.0/24 exact
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-COMMUNITY then community add UNMATCHED-COMMUNITY
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-COMMUNITY then accept
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-LOCALPREF from route-filter 10.40.2.0/24 exact
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-LOCALPREF then community add UNMATCHED-LOCALPREF
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-LOCALPREF then accept
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-ASPATH from route-filter 10.40.3.0/24 exact
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-ASPATH then community add UNMATCHED-ASPATH
+set policy-options policy-statement POLICY-C-DEFAULT term DEFAULT-ASPATH then accept
+set policy-options policy-statement POLICY-C-DEFAULT term REJECT-OTHER then reject
+set policy-options community MATCHED-ASPATH members 65002:3001
+set policy-options community MATCHED-COMMUNITY members 65002:1001
+set policy-options community MATCHED-LOCALPREF members 65002:2001
+set policy-options community RED members 65002:1
+set policy-options community UNMATCHED-ASPATH members 65002:3002
+set policy-options community UNMATCHED-COMMUNITY members 65002:1002
+set policy-options community UNMATCHED-LOCALPREF members 65002:2002
+set policy-options as-path WITH-65099 "65099 .*"
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 2.2.2.2
+set routing-options autonomous-system 65002
+set protocols bgp group FROM-SENDER type external
+set protocols bgp group FROM-SENDER peer-as 65001
+set protocols bgp group FROM-SENDER neighbor 10.0.12.0 import POLICY-A-WRITE
+set protocols bgp group FROM-SENDER neighbor 10.0.12.0 import POLICY-B-READ
+set protocols bgp group FROM-SENDER neighbor 10.0.12.0 import POLICY-C-DEFAULT

--- a/snapshots/junos_policy_chain_visibility/configs/sender/show_configuration_|_display_set.txt
+++ b/snapshots/junos_policy_chain_visibility/configs/sender/show_configuration_|_display_set.txt
@@ -1,0 +1,27 @@
+set version 25.4R1.12
+set system host-name sender
+set system root-authentication encrypted-password "$6$erp9Tw8r$lZxekLVpk/Gl0a5whxr.mMccitg2QuCI.RmOYd8opoqer66Bo0OLll6jrf3cM7DbjMYSCRnHufrLPU3QK/Gn0/"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$4LUhrnIj$KiNRnKPhROsJzdsE2Iq6Jf9l9uXA9sLNoO.NIA5KAMtv9KouA4P.S3rXeToA4nCfWU8LbFja4dYJLQ3ErX92U/"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to dut"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.0/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+set policy-options policy-statement EXPORT-ALL term ACCEPT from protocol static
+set policy-options policy-statement EXPORT-ALL term ACCEPT then accept
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 1.1.1.1
+set routing-options autonomous-system 65001
+set routing-options static route 10.40.1.0/24 discard
+set routing-options static route 10.40.2.0/24 discard
+set routing-options static route 10.40.3.0/24 discard
+set protocols bgp group TO-DUT type external
+set protocols bgp group TO-DUT peer-as 65002
+set protocols bgp group TO-DUT neighbor 10.0.12.1 export EXPORT-ALL

--- a/snapshots/junos_policy_chain_visibility/show/dut/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/dut/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,457 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.1+59191"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "FROM-SENDER"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "import-policy" : [
+                {
+                    "data" : "POLICY-A-WRITE POLICY-B-READ POLICY-C-DEFAULT"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "37", 
+                "attributes" : {"junos:seconds" : "37"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "37"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "179"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "61"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/dut/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/dut/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to sender"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:50:b7:33"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:50:b7:33"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:39 ago)", 
+                "attributes" : {"junos:seconds" : "39"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "112"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "15"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "24"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:08 UTC (00:00:40 ago)", 
+                "attributes" : {"junos:seconds" : "40"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e3:e6:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:e6:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e3:e6:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:23:36 UTC (00:02:12 ago)", 
+                "attributes" : {"junos:seconds" : "132"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "49082"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "92715"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "48665"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "92717"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:cf:9d:05:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:cf:9d:05:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:cf:9d:05:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:cf:9d:05:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:23:36 UTC (00:02:12 ago)", 
+                "attributes" : {"junos:seconds" : "132"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "6363"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "6146"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "6317"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "6151"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:cfff:fe9d:500"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:ed:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e3:ed:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:ed:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e3:ed:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "502"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "502"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2.2.2.2"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "502"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "502"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:ed:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e3:ed:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:e3:ed:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:e3:ed:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/dut/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/dut/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/dut/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/dut/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/dut/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/dut/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/dut/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/dut/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,339 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:33", 
+                        "attributes" : {"junos:seconds" : "33"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:33", 
+                        "attributes" : {"junos:seconds" : "33"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "250"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:33", 
+                        "attributes" : {"junos:seconds" : "33"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65099 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/dut/show_route_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/dut/show_route_|_display_json.txt
@@ -1,0 +1,924 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2.2.2.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:39", 
+                        "attributes" : {"junos:seconds" : "99"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:40", 
+                        "attributes" : {"junos:seconds" : "40"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:41", 
+                        "attributes" : {"junos:seconds" : "41"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:33", 
+                        "attributes" : {"junos:seconds" : "33"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:33", 
+                        "attributes" : {"junos:seconds" : "33"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "250"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:33", 
+                        "attributes" : {"junos:seconds" : "33"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65099 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:39", 
+                        "attributes" : {"junos:seconds" : "99"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:40", 
+                        "attributes" : {"junos:seconds" : "100"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:40", 
+                        "attributes" : {"junos:seconds" : "100"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:39", 
+                        "attributes" : {"junos:seconds" : "99"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:40", 
+                        "attributes" : {"junos:seconds" : "100"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:40", 
+                        "attributes" : {"junos:seconds" : "100"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:cfff:fe9d:500/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:40", 
+                        "attributes" : {"junos:seconds" : "100"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/dut/show_version_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/dut/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "dut"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/host_nos.txt
+++ b/snapshots/junos_policy_chain_visibility/show/host_nos.txt
@@ -1,0 +1,1 @@
+{"dut": "junos", "sender": "junos"}

--- a/snapshots/junos_policy_chain_visibility/show/sender/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/sender/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,476 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.1+59191"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "TO-DUT"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "Cease"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "EXPORT-ALL"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "46", 
+                "attributes" : {"junos:seconds" : "46"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-error" : [
+            {
+                "name" : [
+                {
+                    "data" : "Cease"
+                }
+                ], 
+                "send-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "receive-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "3"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "22"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "21"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "47"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "124"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "97"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/sender/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/sender/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to dut"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:f7:ed:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:f7:ed:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:43 ago)", 
+                "attributes" : {"junos:seconds" : "43"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "18"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "15"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:43 ago)", 
+                "attributes" : {"junos:seconds" : "43"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:43 ago)", 
+                "attributes" : {"junos:seconds" : "43"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:43 ago)", 
+                "attributes" : {"junos:seconds" : "43"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:43 ago)", 
+                "attributes" : {"junos:seconds" : "43"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:44 ago)", 
+                "attributes" : {"junos:seconds" : "44"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:44 ago)", 
+                "attributes" : {"junos:seconds" : "44"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:44 ago)", 
+                "attributes" : {"junos:seconds" : "44"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:44 ago)", 
+                "attributes" : {"junos:seconds" : "44"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:44 ago)", 
+                "attributes" : {"junos:seconds" : "44"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:44 ago)", 
+                "attributes" : {"junos:seconds" : "44"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:25:14 UTC (00:00:44 ago)", 
+                "attributes" : {"junos:seconds" : "44"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:43:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:43:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:43:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:23:41 UTC (00:02:17 ago)", 
+                "attributes" : {"junos:seconds" : "137"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "49114"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "92916"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "48684"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "92917"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:5f:7b:6f:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:5f:7b:6f:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:5f:7b:6f:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:5f:7b:6f:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:23:41 UTC (00:02:17 ago)", 
+                "attributes" : {"junos:seconds" : "137"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "6167"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "6118"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "6167"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "6249"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:5fff:fe7b:6f00"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:4a:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:4a:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:4a:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:4a:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "464"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "464"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "1.1.1.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "464"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "464"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:4a:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:4a:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:8a:4a:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:8a:4a:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/sender/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/sender/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/sender/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/sender/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/sender/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/sender/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/sender/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/sender/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,106 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/sender/show_route_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/sender/show_route_|_display_json.txt
@@ -1,0 +1,837 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "1.1.1.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:41", 
+                        "attributes" : {"junos:seconds" : "101"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:45", 
+                        "attributes" : {"junos:seconds" : "45"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:45", 
+                        "attributes" : {"junos:seconds" : "45"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:39", 
+                        "attributes" : {"junos:seconds" : "99"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:39", 
+                        "attributes" : {"junos:seconds" : "99"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.40.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:39", 
+                        "attributes" : {"junos:seconds" : "99"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:39", 
+                        "attributes" : {"junos:seconds" : "99"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:41", 
+                        "attributes" : {"junos:seconds" : "101"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:41", 
+                        "attributes" : {"junos:seconds" : "101"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:39", 
+                        "attributes" : {"junos:seconds" : "99"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:41", 
+                        "attributes" : {"junos:seconds" : "101"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:41", 
+                        "attributes" : {"junos:seconds" : "101"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:5fff:fe7b:6f00/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:41", 
+                        "attributes" : {"junos:seconds" : "101"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/show/sender/show_version_|_display_json.txt
+++ b/snapshots/junos_policy_chain_visibility/show/sender/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "sender"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_policy_chain_visibility/validation/parse_warnings.yaml
+++ b/snapshots/junos_policy_chain_visibility/validation/parse_warnings.yaml
@@ -1,0 +1,3 @@
+expects_no_fatal_warning:
+  - dut
+  - sender

--- a/snapshots/junos_rmw_localpref/batfish/layer1_topology.json
+++ b/snapshots/junos_rmw_localpref/batfish/layer1_topology.json
@@ -1,0 +1,14 @@
+{
+    "edges": [
+        {
+            "node1": {
+                "hostname": "sender",
+                "interfaceName": "ge-0/0/0"
+            },
+            "node2": {
+                "hostname": "dut",
+                "interfaceName": "ge-0/0/0"
+            }
+        }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/configs/dut/show_configuration_|_display_set.txt
+++ b/snapshots/junos_rmw_localpref/configs/dut/show_configuration_|_display_set.txt
@@ -1,0 +1,40 @@
+set version 25.4R1.12
+set system host-name dut
+set system root-authentication encrypted-password "$6$JPcRv3dI$E57Xd9Klp3WS50LQGjS9fjLdCy9e.GFzpIhGkZQo6oIB9kSwSJzlPYfLnnakYKsYhB/WBEjgo.emAtPPt6v5B0"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$YoDBaCjq$1TTpj/F9XaMU1cI2JzQ7aFr1P9YuVrfeEfNRUJAs.GVED1JZA4z8vP8EYe6qNLHvLBz0YX0.E5p24fe7oXD4u1"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to sender"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.1/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 2.2.2.2/32
+set policy-options policy-statement RMW-IMPORT term BASELINE from route-filter 10.20.0.0/24 exact
+set policy-options policy-statement RMW-IMPORT term BASELINE then accept
+set policy-options policy-statement RMW-IMPORT term TWO-ADDS from route-filter 10.20.1.0/24 exact
+set policy-options policy-statement RMW-IMPORT term TWO-ADDS then local-preference add 50
+set policy-options policy-statement RMW-IMPORT term TWO-ADDS then accept
+set policy-options policy-statement RMW-IMPORT term SET-THEN-ADD from route-filter 10.20.2.0/24 exact
+set policy-options policy-statement RMW-IMPORT term SET-THEN-ADD then local-preference add 50
+set policy-options policy-statement RMW-IMPORT term SET-THEN-ADD then accept
+set policy-options policy-statement RMW-IMPORT term SET-THEN-SUBTRACT from route-filter 10.20.3.0/24 exact
+set policy-options policy-statement RMW-IMPORT term SET-THEN-SUBTRACT then local-preference subtract 50
+set policy-options policy-statement RMW-IMPORT term SET-THEN-SUBTRACT then accept
+set policy-options policy-statement RMW-IMPORT term METRIC-SET-ADD from route-filter 10.20.4.0/24 exact
+set policy-options policy-statement RMW-IMPORT term METRIC-SET-ADD then metric add 50
+set policy-options policy-statement RMW-IMPORT term METRIC-SET-ADD then accept
+set policy-options policy-statement RMW-IMPORT term DOUBLE-PREPEND from route-filter 10.20.5.0/24 exact
+set policy-options policy-statement RMW-IMPORT term DOUBLE-PREPEND then as-path-prepend "65002 65002"
+set policy-options policy-statement RMW-IMPORT term DOUBLE-PREPEND then accept
+set policy-options policy-statement RMW-IMPORT term REJECT-OTHER then reject
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 2.2.2.2
+set routing-options autonomous-system 65002
+set protocols bgp group FROM-SENDER type external
+set protocols bgp group FROM-SENDER peer-as 65001
+set protocols bgp group FROM-SENDER neighbor 10.0.12.0 import RMW-IMPORT

--- a/snapshots/junos_rmw_localpref/configs/sender/show_configuration_|_display_set.txt
+++ b/snapshots/junos_rmw_localpref/configs/sender/show_configuration_|_display_set.txt
@@ -1,0 +1,30 @@
+set version 25.4R1.12
+set system host-name sender
+set system root-authentication encrypted-password "$6$szukqCbZ$Mge2GDyHZjX9Qt3VGbTHYlj2ZkO5aEhLkxNXRPn/.1lX5t46MsNby6057DkcDOi8heTQGffkdHjlspih7eSAW0"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$hIDPGU0t$szJrpoS0lZmZ9kbVHgEZYJDjGA4WmKlTzLua32L37h2kA56/jckmuw8RHrzl4d3v69i4K2dfLYYt7IKKz3Gd81"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to dut"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.0/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+set policy-options policy-statement EXPORT-ALL term ACCEPT from protocol static
+set policy-options policy-statement EXPORT-ALL term ACCEPT then accept
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 1.1.1.1
+set routing-options autonomous-system 65001
+set routing-options static route 10.20.0.0/24 discard
+set routing-options static route 10.20.1.0/24 discard
+set routing-options static route 10.20.2.0/24 discard
+set routing-options static route 10.20.3.0/24 discard
+set routing-options static route 10.20.4.0/24 discard
+set routing-options static route 10.20.5.0/24 discard
+set protocols bgp group TO-DUT type external
+set protocols bgp group TO-DUT peer-as 65002
+set protocols bgp group TO-DUT neighbor 10.0.12.1 export EXPORT-ALL

--- a/snapshots/junos_rmw_localpref/show/dut/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/dut/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,457 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.1+60593"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "FROM-SENDER"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "import-policy" : [
+                {
+                    "data" : "RMW-IMPORT"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "47", 
+                "attributes" : {"junos:seconds" : "47"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "6"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "22"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "22"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "47"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "191"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "61"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/dut/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/dut/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to sender"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:1a:3d:7c"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:1a:3d:7c"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:47 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "288"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "16"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "26"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:47 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:54 ago)", 
+                "attributes" : {"junos:seconds" : "54"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:54 ago)", 
+                "attributes" : {"junos:seconds" : "54"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:54 ago)", 
+                "attributes" : {"junos:seconds" : "54"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:54 ago)", 
+                "attributes" : {"junos:seconds" : "54"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:48 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:12:4b:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:4b:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:12:4b:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:11:19 UTC (00:02:24 ago)", 
+                "attributes" : {"junos:seconds" : "144"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "49550"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "93233"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "49117"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "93234"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:b8:6d:9f:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:b8:6d:9f:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:b8:6d:9f:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:b8:6d:9f:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:11:19 UTC (00:02:24 ago)", 
+                "attributes" : {"junos:seconds" : "144"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "9070"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "8807"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "9021"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "8808"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:b8ff:fe6d:9f00"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:52:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:12:52:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:52:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:12:52:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "504"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "504"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2.2.2.2"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "504"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "504"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:52:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:12:52:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:12:52:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:12:52:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/dut/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/dut/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/dut/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/dut/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/dut/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/dut/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/dut/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/dut/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,575 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:44", 
+                        "attributes" : {"junos:seconds" : "44"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:44", 
+                        "attributes" : {"junos:seconds" : "44"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "150"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:44", 
+                        "attributes" : {"junos:seconds" : "44"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "150"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:44", 
+                        "attributes" : {"junos:seconds" : "44"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "50"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:44", 
+                        "attributes" : {"junos:seconds" : "44"}
+                    }
+                    ], 
+                    "med" : [
+                    {
+                        "data" : "50"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.5.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:44", 
+                        "attributes" : {"junos:seconds" : "44"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/dut/show_route_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/dut/show_route_|_display_json.txt
@@ -1,0 +1,1160 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2.2.2.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:57", 
+                        "attributes" : {"junos:seconds" : "57"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:57", 
+                        "attributes" : {"junos:seconds" : "57"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:43", 
+                        "attributes" : {"junos:seconds" : "43"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:43", 
+                        "attributes" : {"junos:seconds" : "43"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "150"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:43", 
+                        "attributes" : {"junos:seconds" : "43"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "150"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:43", 
+                        "attributes" : {"junos:seconds" : "43"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "50"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:43", 
+                        "attributes" : {"junos:seconds" : "43"}
+                    }
+                    ], 
+                    "med" : [
+                    {
+                        "data" : "50"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.5.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:43", 
+                        "attributes" : {"junos:seconds" : "43"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:50", 
+                        "attributes" : {"junos:seconds" : "110"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:50", 
+                        "attributes" : {"junos:seconds" : "110"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:b8ff:fe6d:9f00/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/dut/show_version_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/dut/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "dut"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/host_nos.txt
+++ b/snapshots/junos_rmw_localpref/show/host_nos.txt
@@ -1,0 +1,1 @@
+{"dut": "junos", "sender": "junos"}

--- a/snapshots/junos_rmw_localpref/show/sender/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/sender/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,476 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.1+60593"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "TO-DUT"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "Cease"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "EXPORT-ALL"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "59", 
+                "attributes" : {"junos:seconds" : "59"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-error" : [
+            {
+                "name" : [
+                {
+                    "data" : "Cease"
+                }
+                ], 
+                "send-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "receive-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "6"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "59"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/sender/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/sender/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to dut"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:7e:29:63"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:7e:29:63"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "539"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "21"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "16"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:55 ago)", 
+                "attributes" : {"junos:seconds" : "55"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:56 ago)", 
+                "attributes" : {"junos:seconds" : "56"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:56 ago)", 
+                "attributes" : {"junos:seconds" : "56"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:56 ago)", 
+                "attributes" : {"junos:seconds" : "56"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:56 ago)", 
+                "attributes" : {"junos:seconds" : "56"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:56 ago)", 
+                "attributes" : {"junos:seconds" : "56"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:56 ago)", 
+                "attributes" : {"junos:seconds" : "56"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:12:59 UTC (00:00:56 ago)", 
+                "attributes" : {"junos:seconds" : "56"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:54:a6:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:a6:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:54:a6:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:11:26 UTC (00:02:29 ago)", 
+                "attributes" : {"junos:seconds" : "149"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "49611"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "93227"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "49161"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "93228"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:a9:1e:de:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:a9:1e:de:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:a9:1e:de:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:a9:1e:de:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-05-19 07:11:26 UTC (00:02:29 ago)", 
+                "attributes" : {"junos:seconds" : "149"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "8887"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "8784"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "8887"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "8902"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:a9ff:fe1e:de00"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:ad:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:54:ad:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:ad:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:54:ad:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "519"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "519"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "1.1.1.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "519"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "519"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:ad:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:54:ad:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:54:ad:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:54:ad:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/sender/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/sender/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/sender/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/sender/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/sender/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/sender/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "9"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/sender/show_route_protocol_bgp_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/sender/show_route_protocol_bgp_|_display_json.txt
@@ -1,0 +1,106 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/sender/show_route_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/sender/show_route_|_display_json.txt
@@ -1,0 +1,981 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "1.1.1.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:57", 
+                        "attributes" : {"junos:seconds" : "57"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:00:57", 
+                        "attributes" : {"junos:seconds" : "57"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:51", 
+                        "attributes" : {"junos:seconds" : "111"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:51", 
+                        "attributes" : {"junos:seconds" : "111"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:51", 
+                        "attributes" : {"junos:seconds" : "111"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:51", 
+                        "attributes" : {"junos:seconds" : "111"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.4.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:51", 
+                        "attributes" : {"junos:seconds" : "111"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.20.5.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:51", 
+                        "attributes" : {"junos:seconds" : "111"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:51", 
+                        "attributes" : {"junos:seconds" : "111"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:51", 
+                        "attributes" : {"junos:seconds" : "111"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:a9ff:fe1e:de00/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:01:54", 
+                        "attributes" : {"junos:seconds" : "114"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/show/sender/show_version_|_display_json.txt
+++ b/snapshots/junos_rmw_localpref/show/sender/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "sender"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_rmw_localpref/validation/parse_warnings.yaml
+++ b/snapshots/junos_rmw_localpref/validation/parse_warnings.yaml
@@ -1,0 +1,3 @@
+expects_no_fatal_warning:
+  - dut
+  - sender


### PR DESCRIPTION
Adds three Junos labs that empirically answer the questions raised
about how intermediate attributes flow through Junos route policies:

junos_rmw_localpref — within a single `then` block, multiple
arithmetic actions on the same attribute (e.g., `local-preference
300; local-preference add 50;`, `metric 200; metric add 50;`) each
evaluate against the original pre-term value, and the last write
wins. So `set 300; add 50` yields 150 (not 350), and `metric 200;
metric add 50` yields 50 (not 250).

junos_cross_term_match — within a single `policy-statement`, a later
term `from`-matching on community / local-preference / as-path DOES
see the writes from an earlier term that fell through. Marker
communities (`MATCHED-*` / `UNMATCHED-*`) on each test prefix encode
which path the device took.

junos_policy_chain_visibility — `import [ POLICY-A POLICY-B
POLICY-C ];` chains behave the same as cross-term: POLICY-B sees
attributes that POLICY-A wrote. Same marker scheme as the cross-term
lab.

For each lab, Batfish's modeling agrees with the device on every
test prefix: `pytest lab_tests/test_labs.py --labname=<lab>` returns
13/13 passed with no sickbay needed. Community comparison is not
part of the standard validator, so the cross-term and chain labs
also include `testRoutePolicies` / `bgpRib` results in the README to
confirm marker communities match end-to-end.

Each snapshot includes a `validation/parse_warnings.yaml` asserting
zero FATAL parse warnings on every host.

----

Prompt:
```
A year ago, I had a long disussion with Todd about intermediate
attributes. He did this large analysis, summarized below. [...]
working/intermediateAttributes.md.

Can we now make the labs we need to verify that the real device
(Juniper) will do what we expect?
```

---
**Stack**:
- #175 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*