### PR TITLE
pre-commit: block deprecated pyparsing camelCase API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,6 +23,17 @@ repos:
       - id: prettier
         types_or: [markdown, yaml]
         exclude: ^snapshots/.*/show/
+  # Block deprecated pyparsing camelCase API. Each name in pyparsing 3.x is
+  # decorated with replaced_by_pep8(); the snake_case form must be used
+  # instead. See pyparsing/core.py for the authoritative list.
+  - repo: local
+    hooks:
+      - id: no-deprecated-pyparsing-camelcase
+        name: no deprecated pyparsing camelCase API
+        language: pygrep
+        types: [python]
+        entry: '\b(addCondition|addParseAction|canParseNext|conditionAsParseAction|convertToDate|convertToDatetime|convertToFloat|convertToInteger|countedArray|delimitedList|dictOf|disableMemoization|downcaseTokens|enableLeftRecursion|enablePackrat|ignoreWhitespace|infixNotation|inlineLiteralsUsing|leaveWhitespace|makeHTMLTags|makeXMLTags|markInputline|matchOnlyAtCol|matchPreviousExpr|matchPreviousLiteral|nestedExpr|nullDebugAction|oneOf|originalTextFor|parseFile|parseString|parseWithTabs|removeQuotes|replaceHTMLEntity|replaceWith|resetCache|runTests|scanString|searchString|setBreak|setDebug|setDebugActions|setDefaultKeywordChars|setDefaultWhitespaceChars|setFailAction|setName|setParseAction|setResultsName|setWhitespaceChars|stripHTMLTags|tokenMap|traceParseAction|transformString|tryParse|upcaseTokens|withAttribute|withClass)\b'
+
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.18.1
     hooks:

--- a/src/lab_validation/parsers/nxos/commands/bgp_route.py
+++ b/src/lab_validation/parsers/nxos/commands/bgp_route.py
@@ -15,7 +15,7 @@ from pyparsing import (
     Word,
     ZeroOrMore,
     alphanums,
-    oneOf,
+    one_of,
     stringEnd,
 )
 
@@ -106,7 +106,7 @@ def _vrf_af_routes() -> ParserElement:
 
 def _get_record() -> ParserElement:
     route_status = Combine(
-        oneOf(["*", "s", " "]) + oneOf([">", "|", " "])
+        one_of(["*", "s", " "]) + one_of([">", "|", " "])
     ).set_results_name("status")
     path_type = MatchFirst(
         [Literal("e"), Literal("l"), Literal("i"), Literal("a"), Literal("r")]

--- a/src/lab_validation/parsers/nxos/grammar/interface.py
+++ b/src/lab_validation/parsers/nxos/grammar/interface.py
@@ -6,7 +6,7 @@ from pyparsing import (
     ParserElement,
     SkipTo,
     Word,
-    oneOf,
+    one_of,
     printables,
     stringEnd,
 )
@@ -40,7 +40,7 @@ def _get_iface_line() -> ParserElement:
     ]
     return (
         Combine(
-            oneOf(["Ethernet", "loopback", "mgmt", "port-channel", "vasi", "Vlan"])
+            one_of(["Ethernet", "loopback", "mgmt", "port-channel", "vasi", "Vlan"])
             + Word(printables)
         ).set_results_name("name")
         + "is"


### PR DESCRIPTION
(setResultsName, parseString, setWhitespaceChars, ...), but four oneOf
calls in the NXOS parsers were missed and nothing prevents new uses
from creeping back in. pyparsing 3.x decorates every legacy name with
replaced_by_pep8() and the warnings.warn() in that wrapper is currently
commented out, so the deprecations are silent today but will surface as
DeprecationWarnings as soon as upstream uncomments them.

- Replace the four remaining oneOf calls with one_of in
parsers/nxos/grammar/interface.py and parsers/nxos/commands/bgp_route.py.
- Add a local pygrep pre-commit hook that fails on any of the ~55
deprecated names listed in pyparsing's replaced_by_pep8() table.

----

Prompt:
```
We've repeatedly in this project tried to get rid of deprecated methods
that throw pyparsign warnings, like oneOf does (look at git history and
current uses of oneOf to confirm). Yet it seems we still have them,
and/or introduced new ones. Can you write a pre-commit check that will
fail if we use them?
```

---
**Stack**:
- #177 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*