### PR TITLE
infra: add Cisco NX-OS (n9kv) to EC2 image bootstrap

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -426,7 +426,7 @@ For spot pricing (~70% cheaper), add `--spot`.
 --timeout-hours N      Auto-terminate after N hours (default: 4)
 --spot                 Request spot instance
 --images FILTER        Comma-separated list of images to load (default: all)
-                       Available: ceos, vjunos-router, vjunos-switch, vjunos-evolved
+                       Available: ceos, vjunos-router, vjunos-switch, vjunos-evolved, nxos
 ```
 
 For example, `--images ceos` loads only the Arista cEOS image, skipping

--- a/infra/ec2-launch.sh
+++ b/infra/ec2-launch.sh
@@ -46,7 +46,7 @@ Options:
   --timeout-hours N      Auto-terminate after N hours (default: 4)
   --spot                 Request a spot instance (~70% cheaper, may be interrupted)
   --images FILTER        Comma-separated list of images to load (default: all)
-                         Available: ceos, vjunos-router, vjunos-switch, vjunos-evolved, all
+                         Available: ceos, vjunos-router, vjunos-switch, vjunos-evolved, nxos, all
   --help                 Show this help
 
 Environment:

--- a/infra/ec2-setup.sh
+++ b/infra/ec2-setup.sh
@@ -98,82 +98,120 @@ apt-get install -y sshpass jq
 # --- Load network OS images ---
 echo "--- Loading network OS images ---"
 
+# Map a docker-tarball or qcow2 filename to (image_tag, image_grep, vrnetlab_dest).
+# Sets globals: image_tag, image_grep, dest. Returns 0 on match, 1 on unknown.
+classify_image() {
+    local name="$1"
+    case "${name}" in
+        vJunos-router-*|vjunos-router-*)
+            image_tag="vjunos-router"
+            image_grep="junos"
+            dest="/home/ubuntu/vrnetlab/juniper/vjunosrouter" ;;
+        vJunosEvolved-*|vjunosevolved-*)
+            image_tag="vjunos-evolved"
+            image_grep="junos"
+            dest="/home/ubuntu/vrnetlab/juniper/vjunosevolved" ;;
+        vJunos-switch-*|vjunosswitch-*)
+            image_tag="vjunos-switch"
+            image_grep="junos"
+            dest="/home/ubuntu/vrnetlab/juniper/vjunosswitch" ;;
+        nexus9300v*|nexus9500v*|nxosv*|n9kv*|*nxos*)
+            image_tag="nxos"
+            image_grep="n9kv|nxos"
+            dest="/home/ubuntu/vrnetlab/cisco/n9kv" ;;
+        *veos*|*arista*)
+            image_tag="veos"
+            image_grep="veos"
+            dest="" ;;
+        *)
+            return 1 ;;
+    esac
+    return 0
+}
+
+# Strategy 1: load any pre-built Docker tarballs that match the filter.
 DOCKER_TARBALLS=$(aws s3 ls "s3://${BUCKET_NAME}/docker-images/" 2>/dev/null \
     | awk '{print $4}' | grep '\.tar\.gz$' || true)
 
-if [[ -n "${DOCKER_TARBALLS}" ]]; then
-    # Strategy 1: Load pre-built Docker images
-    for tarball in ${DOCKER_TARBALLS}; do
-        # Derive image tag from tarball name for filtering
-        case "${tarball}" in
-            vjunos-router*) image_tag="vjunos-router" ;;
-            vjunos-switch*) image_tag="vjunos-switch" ;;
-            vjunos*evolved*) image_tag="vjunos-evolved" ;;
-            *veos*|*arista*) image_tag="veos" ;;
-            *) image_tag="unknown" ;;
-        esac
-        if ! image_wanted "${image_tag}"; then
-            echo "Skipping ${tarball} (not in filter: ${IMAGE_FILTER})"
-            continue
-        fi
-        echo "Loading Docker image: ${tarball}"
-        aws s3 cp "s3://${BUCKET_NAME}/docker-images/${tarball}" - | gunzip | docker load
-    done
-else
-    echo "No pre-built Docker images found. Checking for raw qcow2 images..."
+LOADED_TAGS=""
+for tarball in ${DOCKER_TARBALLS}; do
+    if ! classify_image "${tarball}"; then
+        echo "Skipping unknown docker-images/ tarball: ${tarball}"
+        continue
+    fi
+    if ! image_wanted "${image_tag}"; then
+        echo "Skipping ${tarball} (not in filter: ${IMAGE_FILTER})"
+        continue
+    fi
+    echo "Loading Docker image: ${tarball}"
+    aws s3 cp "s3://${BUCKET_NAME}/docker-images/${tarball}" - | gunzip | docker load
+    LOADED_TAGS="${LOADED_TAGS},${image_tag}"
+done
 
-    RAW_IMAGES=$(aws s3 ls "s3://${BUCKET_NAME}/images/" 2>/dev/null \
-        | awk '{print $4}' | grep '\.qcow2$' || true)
+# Strategy 2: for any wanted image lacking a pre-built tarball, build from qcow2.
+RAW_IMAGES=$(aws s3 ls "s3://${BUCKET_NAME}/images/" 2>/dev/null \
+    | awk '{print $4}' | grep '\.qcow2$' || true)
 
-    if [[ -n "${RAW_IMAGES}" ]]; then
-        # Strategy 2: Build from qcow2
+VRNETLAB_CLONED=false
+for qcow2 in ${RAW_IMAGES}; do
+    if ! classify_image "${qcow2}"; then
+        echo "Skipping unknown images/ qcow2: ${qcow2}"
+        continue
+    fi
+    if ! image_wanted "${image_tag}"; then
+        continue
+    fi
+    if [[ ",${LOADED_TAGS}," == *",${image_tag},"* ]]; then
+        echo "Skipping qcow2 build for ${qcow2}: ${image_tag} already loaded from docker-images/"
+        continue
+    fi
+
+    echo "Processing qcow2: ${qcow2}"
+    if [[ "${VRNETLAB_CLONED}" == false ]]; then
         echo "Cloning vrnetlab..."
         sudo -u ubuntu git clone https://github.com/hellt/vrnetlab.git /home/ubuntu/vrnetlab
-
-        for qcow2 in ${RAW_IMAGES}; do
-            echo "Processing: ${qcow2}"
-
-            case "${qcow2}" in
-                vJunos-router-*|vjunos-router-*)
-                    image_tag="vjunos-router"
-                    dest="/home/ubuntu/vrnetlab/juniper/vjunosrouter" ;;
-                vJunosEvolved-*|vjunosevolved-*)
-                    image_tag="vjunos-evolved"
-                    dest="/home/ubuntu/vrnetlab/juniper/vjunosevolved" ;;
-                vJunos-switch-*|vjunosswitch-*)
-                    image_tag="vjunos-switch"
-                    dest="/home/ubuntu/vrnetlab/juniper/vjunosswitch" ;;
-                *)
-                    echo "  Unknown image type: ${qcow2}, skipping"
-                    continue ;;
-            esac
-            if ! image_wanted "${image_tag}"; then
-                echo "  Skipping ${qcow2} (not in filter: ${IMAGE_FILTER})"
-                continue
-            fi
-
-            echo "  Downloading from S3..."
-            aws s3 cp "s3://${BUCKET_NAME}/images/${qcow2}" "${dest}/"
-
-            echo "  Building vrnetlab container..."
-            if (cd "${dest}" && make); then
-                # Upload the built image to S3 for next time
-                IMAGE_NAME=$(docker images --format '{{.Repository}}:{{.Tag}}' \
-                    | grep -i junos | head -1)
-                if [[ -n "${IMAGE_NAME}" ]]; then
-                    TARBALL_NAME=$(echo "${IMAGE_NAME}" | sed 's|.*/||; s|:|_|; s|juniper_||')
-                    echo "  Saving and uploading Docker image to S3..."
-                    docker save "${IMAGE_NAME}" | gzip \
-                        | aws s3 cp - "s3://${BUCKET_NAME}/docker-images/${TARBALL_NAME}.tar.gz"
-                    echo "  Uploaded: docker-images/${TARBALL_NAME}.tar.gz"
-                fi
-            else
-                echo "  WARNING: vrnetlab build failed for ${qcow2}"
-            fi
-        done
-    else
-        echo "No images found in S3. Upload images with upload-image.sh."
+        VRNETLAB_CLONED=true
     fi
+
+    mkdir -p "${dest}"
+
+    # vrnetlab's Cisco n9kv Makefile expects qcow2 named n9kv-<version>.qcow2
+    # so the resulting docker tag is vrnetlab/cisco_n9kv:<version>.
+    # Rename Cisco's nexus9300v64.<version>.qcow2 accordingly.
+    staged_name="${qcow2}"
+    if [[ "${image_tag}" == "nxos" ]]; then
+        staged_name=$(echo "${qcow2}" \
+            | sed -E 's/^nexus9[35]00v(64)?(-lite)?\.(.+)\.qcow2$/n9kv-\3.qcow2/')
+    fi
+
+    echo "  Downloading from S3 as ${staged_name}..."
+    aws s3 cp "s3://${BUCKET_NAME}/images/${qcow2}" "${dest}/${staged_name}"
+
+    echo "  Building vrnetlab container..."
+    if (cd "${dest}" && make); then
+        IMAGE_NAME=$(docker images --format '{{.Repository}}:{{.Tag}}' \
+            | { grep -iE "${image_grep}" || true; } | head -1)
+        if [[ -n "${IMAGE_NAME}" ]]; then
+            TARBALL_NAME=$(echo "${IMAGE_NAME}" \
+                | sed 's|.*/||; s|:|_|; s|juniper_||; s|cisco_||')
+            echo "  Saving and uploading ${IMAGE_NAME} to s3://${BUCKET_NAME}/docker-images/${TARBALL_NAME}.tar.gz..."
+            if docker save "${IMAGE_NAME}" | gzip \
+                    | aws s3 cp - "s3://${BUCKET_NAME}/docker-images/${TARBALL_NAME}.tar.gz"; then
+                echo "  Uploaded: docker-images/${TARBALL_NAME}.tar.gz"
+            else
+                echo "  WARNING: failed to upload ${IMAGE_NAME} to S3 (image is loaded locally; future launches will rebuild from qcow2)"
+            fi
+        else
+            echo "  WARNING: build succeeded but no docker image matched '${image_grep}'"
+        fi
+        LOADED_TAGS="${LOADED_TAGS},${image_tag}"
+    else
+        echo "  WARNING: vrnetlab build failed for ${qcow2}"
+    fi
+done
+
+if [[ -z "${DOCKER_TARBALLS}" && -z "${RAW_IMAGES}" ]]; then
+    echo "No images found in S3. Upload images with upload-image.sh."
 fi
 
 # --- Load pre-built container images (e.g., Arista cEOS) ---


### PR DESCRIPTION
Wires the lab builder for Cisco Nexus 9000v qcow2 images so a
nexus9300v64.<version>.qcow2 dropped in infra/images/ and uploaded to
S3 builds the vrnetlab/cisco_n9kv:<version> container on first launch
and is loaded directly thereafter.

ec2-setup.sh changes:

- Refactor image classification into a classify_image helper used by
both the docker-tarball load path and the qcow2 build path. Add the
Cisco mapping (nexus9300v*|nexus9500v*|nxosv*|n9kv*|*nxos* ->
vrnetlab/cisco/n9kv).
- vrnetlab's cisco/n9kv Makefile globs n9kv-<version>.qcow2; rename
Cisco's nexus9300v64.<version>.qcow2 to that form when staging into
the vrnetlab tree so the resulting docker tag is
vrnetlab/cisco_n9kv:<version>.
- Run the qcow2 build path in addition to (rather than instead of) the
pre-built tarball path, filtered by --images and what was already
loaded. Previously, presence of any pre-built tarball in S3 would
short-circuit qcow2 builds for other vendors.
- Tolerate `grep` no-match in the post-build docker-tag lookup
(`grep ... || true`) and treat upload failures as warnings rather
than aborting the bootstrap. Without this, set -euo pipefail killed
cloud-final after a successful build whenever the docker-tag grep
pattern did not match.

ec2-launch.sh / README: document `nxos` in the --images filter values.

Smoke-tested end to end on a fresh m8i.2xlarge: built
vrnetlab/cisco_n9kv:10.3.9.M from
nexus9300v64.10.3.9.M.qcow2, deployed it under containerlab as
cisco_n9kv, and confirmed `show version` reports NX-OS 10.3(9) over
SSH.

----

Prompt:
```
I want to add Cisco VMs to our setup. For NX-OS 10, I have:

[Cisco download page listing nexus9300v64-lite/full and nexus9500v64
in .box / .ova / .qcow2 / .vagrant variants]

I don't know what to look for for IOS XE, ASA, or IOS XR
```

Follow-ups in the same task: picked
nexus9300v64.10.3.9.M.qcow2 (full features, KVM); confirmed
infra/ec2-setup.sh + ec2-launch.sh did not yet recognize NX-OS;
authorized wiring it up end-to-end on a fresh EC2 instance separate
from another running lab-validation session, including upload to S3,
build, smoke-test, and teardown.

---
**Stack**:
- #181 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*