### PR TITLE
junos_then_action_conflicts: resolve next-term vs next-policy precedence

### DIFF
--- a/snapshots/junos_then_action_conflicts/README.md
+++ b/snapshots/junos_then_action_conflicts/README.md
@@ -13,7 +13,7 @@ sender (AS 65001) --- dut (AS 65002) --- collector (AS 65003)
        10.0.12.0      10.0.12.1  10.0.23.0      10.0.23.1
 ```
 
-Sender originates 108 `/24` test prefixes, each tagged with a unique
+Sender originates 112 `/24` test prefixes, each tagged with a unique
 marker community `65001:<term-id>`. Dut's import policy has one term
 per conflict shape. Collector observes what propagates (§5 flow-control
 terms).
@@ -60,10 +60,12 @@ sequentially in source order (see below).
 For any attribute family where Junos's data model holds at most one
 value per route — origin, preference, tag, color, priority, next-hop
 (IP form), source-class, external, local-preference, metric, metric2,
-load-balance, install-nexthop, and the same-family `as-path-prepend×2`
-or `as-path-expand×2` — when two actions in the same `then` target the
-same attribute, the **last action wins** at commit time and the prior
-is silently dropped. Identical duplicates collapse to one (dedup).
+load-balance, install-nexthop, the same-family `as-path-prepend×2`
+or `as-path-expand×2`, and the named-disposition family containing
+both `next term` and `next policy` — when two actions in the same
+`then` target the same attribute, the **last action wins** at commit
+time and the prior is silently dropped. Identical duplicates collapse
+to one (dedup).
 
 Within numeric attributes (lp/metric/metric2), this absorbs every
 combination of `set`/`add`/`subtract` and the metric-only `expression`
@@ -109,9 +111,20 @@ both commit time and runtime:
    `accept; community add X` retains as `community add X; accept`.
 2. **Same-family last-wins among bare terminators.** `accept; reject`
    keeps `reject` only; `reject; accept` keeps `accept` only (§5
-   rows 4001, 4002). Different-family pairings (e.g.,
-   `default-action accept; bare reject`) keep both lines in retained
-   config.
+   rows 4001, 4002).
+3. **`next term` and `next policy` are the same family.** A `then`
+   block holds at most one of them: dedup collapses `next term;
+next term` to one `next term`, and `next policy; next policy` to
+   one `next policy` (rows 4011, 4012). When both forms appear in
+   the same `then`, last-wins applies — `next term; next policy`
+   retains `next policy`, and `next policy; next term` retains
+   `next term` (rows 4013, 4014). The retained line, not the
+   author's first line, is what runs.
+4. **Different-family pairings.** `default-action accept` paired with
+   a bare `accept`/`reject` keeps both lines in retained config; the
+   bare terminator wins at runtime. `next term`/`next policy` paired
+   with a bare `accept`/`reject` keeps both lines as well; the
+   `next term`/`next policy` wins at runtime.
 
 **Runtime ordering** observable from §5's collector RIB:
 
@@ -120,6 +133,12 @@ both commit time and runtime:
 - `next term` beats bare `accept` regardless of source order — both
   lines exist in retained config but the route falls through (rows
   4003, 4004 do not propagate to collector).
+- `next term` (alone or as the surviving NT/NP collapse) jumps to the
+  next term, where `REJECT-OTHER` drops the route — no propagation
+  to collector (rows 4011, 4014).
+- `next policy` (alone or as the surviving NT/NP collapse) returns
+  the route to BGP processing; with no further policies, the route
+  is accepted and propagates to collector (rows 4012, 4013).
 - `default-action *` is overridden by any bare terminator in the same
   `then`. `accept; default-action reject` → route propagates (accept
   fires, default-action reject is a no-op when a terminator already
@@ -281,6 +300,10 @@ next-hop-map NAME { ... }` to be defined (not the more obvious
 | 4008 | 10.50.167.0 | FC-REJECT-THEN-DEFAULT-ACTION-ACCEPT | community add MARK-A; reject; community add MARK-B; default-action accept | community add MARK-A; community add MARK-B; default-action accept; reject | partial collapse |
 | 4009 | 10.50.168.0 | FC-ACCEPT-THEN-SIDE-EFFECT           | community add MARK-A; accept; community add MARK-B                        | community add MARK-A; community add MARK-B; accept                        | all retained     |
 | 4010 | 10.50.169.0 | FC-TWO-SIDE-EFFECTS-THEN-ACCEPT      | community add MARK-A; community add MARK-B; accept                        | community add MARK-A; community add MARK-B; accept                        | all retained     |
+| 4011 | 10.50.170.0 | FC-NEXT-TERM-DEDUP                   | community add MARK-A; next term; community add MARK-B; next term          | community add MARK-A; community add MARK-B; next term                     | dedup            |
+| 4012 | 10.50.171.0 | FC-NEXT-POLICY-DEDUP                 | community add MARK-A; next policy; community add MARK-B; next policy      | community add MARK-A; community add MARK-B; next policy                   | dedup            |
+| 4013 | 10.50.172.0 | FC-NEXT-TERM-THEN-NEXT-POLICY        | community add MARK-A; next term; community add MARK-B; next policy        | community add MARK-A; community add MARK-B; next policy                   | last-wins        |
+| 4014 | 10.50.173.0 | FC-NEXT-POLICY-THEN-NEXT-TERM        | community add MARK-A; next policy; community add MARK-B; next term        | community add MARK-A; community add MARK-B; next term                     | last-wins        |
 
 ### §6
 
@@ -300,8 +323,11 @@ next-hop-map NAME { ... }` to be defined (not the more obvious
 
 - **Source configs (post-push, full)**:
   `source/configs/{dut,sender,collector}.cfg` — what the lab device
-  actually loaded, with the 7 commit-rejected terms preserved as
-  `/* COMMIT-REJECTED */` comment blocks.
+  actually loaded. Any commit-rejected terms would be preserved as
+  `/* COMMIT-REJECTED */` comment blocks (none on the current
+  vJunos-router build; the BGP-OUTPUT-QUEUE-PRIORITY actions are
+  dropped at load time, not commit time, so the term itself commits
+  with only its `accept` surviving).
 - **Bootstrap configs (minimal)**:
   `source/build/bootstrap/{dut,sender,collector}.cfg` — what
   containerlab boots with. The full IMPORT/EXPORT terms are pushed

--- a/snapshots/junos_then_action_conflicts/configs/collector/show_configuration_|_display_set.txt
+++ b/snapshots/junos_then_action_conflicts/configs/collector/show_configuration_|_display_set.txt
@@ -1,9 +1,9 @@
 set version 25.4R1.12
 set system host-name collector
-set system root-authentication encrypted-password "$6$UCQdHt3z$mnBkidyllnUwzvy7C.uGkr8z0WGu4/CCfcse0ZraVJG/ifny78BEtFx8Pwxks4eon8RWjpK2SFeUt7My7G6X1."
+set system root-authentication encrypted-password "$6$5ThV9Pk1$2Kk5GNukpXn1aR/cpAR.1QOW4UHaohU0AVGwPt7Oa.HMb6NVhTQVusF1H1l2qU7xx9KZLCuymEH27yyN3pkdv."
 set system login user admin uid 2000
 set system login user admin class super-user
-set system login user admin authentication encrypted-password "$6$kl.yc4ER$lTXycrxiQc8zebRcQwDTuEqCqS6YOcGJwbmmiFZDZiSisvPFUqXAnMMO7TefjcnBvE.oZl24.Z5CFZvvEykhn."
+set system login user admin authentication encrypted-password "$6$8bxm1/Xb$HSqJ57a7S7IMzLkEfUbv7voOCvmRN5ewg0pgr6L49Rk/t22YllA/kepSRT.HU3ewPzPb4/XDuKIoxcZ9Vfrc.0"
 set system services netconf ssh
 set system services ssh root-login allow
 set system management-instance

--- a/snapshots/junos_then_action_conflicts/configs/dut/show_configuration_|_display_set.txt
+++ b/snapshots/junos_then_action_conflicts/configs/dut/show_configuration_|_display_set.txt
@@ -1,9 +1,9 @@
 set version 25.4R1.12
 set system host-name dut
-set system root-authentication encrypted-password "$6$bnzmSlSK$wX4DmWSSCcmTQqVrwRwDid8c6EtRfV55M6USV71zaTfc3PvkvNdJfb3B6Wk.KS5kmIjlp8C/Bkkt9QGL74HDn1"
+set system root-authentication encrypted-password "$6$vwpCs/Us$u.QipSxB/PtgHjOt2OFcmAwzVn/ag7Eais1jpaM5038Ys.H18zW3dHNSx/MPyQW1HSyZnAO0vG.Wh01.Z6GpX0"
 set system login user admin uid 2000
 set system login user admin class super-user
-set system login user admin authentication encrypted-password "$6$dDOoC83.$1mGTdbqzHOFejDP0Mmzri4lvEj2IQw7J4ORDWTdHgPZlChJVZw/Ul80PNiNmIXTnUVr3xdSJjjHhnfGQZxsKY/"
+set system login user admin authentication encrypted-password "$6$yse7ioXf$rGF6bBoSnRlNVhuQkNfIzF7Mthbr8eBjLWJGvjzz2Ud9hOFo45d4oxLBbZuGxtRT9qBvDMv5jz1obzFf94ASg0"
 set system services netconf ssh
 set system services ssh root-login allow
 set system management-instance
@@ -369,6 +369,22 @@ set policy-options policy-statement IMPORT term FC-TWO-SIDE-EFFECTS-THEN-ACCEPT 
 set policy-options policy-statement IMPORT term FC-TWO-SIDE-EFFECTS-THEN-ACCEPT then community add MARK-A
 set policy-options policy-statement IMPORT term FC-TWO-SIDE-EFFECTS-THEN-ACCEPT then community add MARK-B
 set policy-options policy-statement IMPORT term FC-TWO-SIDE-EFFECTS-THEN-ACCEPT then accept
+set policy-options policy-statement IMPORT term FC-NEXT-TERM-DEDUP from route-filter 10.50.170.0/24 exact
+set policy-options policy-statement IMPORT term FC-NEXT-TERM-DEDUP then community add MARK-A
+set policy-options policy-statement IMPORT term FC-NEXT-TERM-DEDUP then community add MARK-B
+set policy-options policy-statement IMPORT term FC-NEXT-TERM-DEDUP then next term
+set policy-options policy-statement IMPORT term FC-NEXT-POLICY-DEDUP from route-filter 10.50.171.0/24 exact
+set policy-options policy-statement IMPORT term FC-NEXT-POLICY-DEDUP then community add MARK-A
+set policy-options policy-statement IMPORT term FC-NEXT-POLICY-DEDUP then community add MARK-B
+set policy-options policy-statement IMPORT term FC-NEXT-POLICY-DEDUP then next policy
+set policy-options policy-statement IMPORT term FC-NEXT-TERM-THEN-NEXT-POLICY from route-filter 10.50.172.0/24 exact
+set policy-options policy-statement IMPORT term FC-NEXT-TERM-THEN-NEXT-POLICY then community add MARK-A
+set policy-options policy-statement IMPORT term FC-NEXT-TERM-THEN-NEXT-POLICY then community add MARK-B
+set policy-options policy-statement IMPORT term FC-NEXT-TERM-THEN-NEXT-POLICY then next policy
+set policy-options policy-statement IMPORT term FC-NEXT-POLICY-THEN-NEXT-TERM from route-filter 10.50.173.0/24 exact
+set policy-options policy-statement IMPORT term FC-NEXT-POLICY-THEN-NEXT-TERM then community add MARK-A
+set policy-options policy-statement IMPORT term FC-NEXT-POLICY-THEN-NEXT-TERM then community add MARK-B
+set policy-options policy-statement IMPORT term FC-NEXT-POLICY-THEN-NEXT-TERM then next term
 set policy-options policy-statement IMPORT term FWD-LOAD-BALANCE-DUPLICATE-DIFF from route-filter 10.50.180.0/24 exact
 set policy-options policy-statement IMPORT term FWD-LOAD-BALANCE-DUPLICATE-DIFF then load-balance consistent-hash
 set policy-options policy-statement IMPORT term FWD-LOAD-BALANCE-DUPLICATE-DIFF then accept

--- a/snapshots/junos_then_action_conflicts/configs/sender/show_configuration_|_display_set.txt
+++ b/snapshots/junos_then_action_conflicts/configs/sender/show_configuration_|_display_set.txt
@@ -1,9 +1,9 @@
 set version 25.4R1.12
 set system host-name sender
-set system root-authentication encrypted-password "$6$oBQkSH1K$7HtBgvlCycZpvxPjwLfW7H1pg38nCvbCXhNIKTbqzX/7mSmPXzsSXeL.xvQxxaTVXyUwqRtpSMtqch40xstWN/"
+set system root-authentication encrypted-password "$6$nUyU/vR0$6UWXdgRRshQavZ/laWtJsH.T80EEgf1H3aiu.nnT8VPo/YcmpE9S3Ch.M1qD4IrkrMPFVwkUlfi7nVtigVh3C0"
 set system login user admin uid 2000
 set system login user admin class super-user
-set system login user admin authentication encrypted-password "$6$PQ/yQQ9p$dM2kx5L8c2j7mYXtuG5UTePOrevQ5TfzCKtoIaEksAwwx7lqjs7QMONlrEkluPwSrZdflk0wfpRF2dnVt8lM/."
+set system login user admin authentication encrypted-password "$6$ApwNwNt7$WNnCfn4T.n6iyktszWwwJ3RRMIGDIL8xwtlV9OqKTxIZLQUiMT4X.L7k/36rfnXbZ9HekY3vuivswMbO4oypF1"
 set system services netconf ssh
 set system services ssh root-login allow
 set system management-instance
@@ -438,6 +438,22 @@ set policy-options policy-statement EXPORT-TO-DUT term TAG-4010 from protocol st
 set policy-options policy-statement EXPORT-TO-DUT term TAG-4010 from route-filter 10.50.169.0/24 exact
 set policy-options policy-statement EXPORT-TO-DUT term TAG-4010 then community add MARK-4010
 set policy-options policy-statement EXPORT-TO-DUT term TAG-4010 then accept
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4011 from protocol static
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4011 from route-filter 10.50.170.0/24 exact
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4011 then community add MARK-4011
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4011 then accept
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4012 from protocol static
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4012 from route-filter 10.50.171.0/24 exact
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4012 then community add MARK-4012
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4012 then accept
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4013 from protocol static
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4013 from route-filter 10.50.172.0/24 exact
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4013 then community add MARK-4013
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4013 then accept
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4014 from protocol static
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4014 from route-filter 10.50.173.0/24 exact
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4014 then community add MARK-4014
+set policy-options policy-statement EXPORT-TO-DUT term TAG-4014 then accept
 set policy-options policy-statement EXPORT-TO-DUT term TAG-5001 from protocol static
 set policy-options policy-statement EXPORT-TO-DUT term TAG-5001 from route-filter 10.50.180.0/24 exact
 set policy-options policy-statement EXPORT-TO-DUT term TAG-5001 then community add MARK-5001
@@ -556,6 +572,10 @@ set policy-options community MARK-4007 members 65001:4007
 set policy-options community MARK-4008 members 65001:4008
 set policy-options community MARK-4009 members 65001:4009
 set policy-options community MARK-4010 members 65001:4010
+set policy-options community MARK-4011 members 65001:4011
+set policy-options community MARK-4012 members 65001:4012
+set policy-options community MARK-4013 members 65001:4013
+set policy-options community MARK-4014 members 65001:4014
 set policy-options community MARK-5 members 65001:5
 set policy-options community MARK-5001 members 65001:5001
 set policy-options community MARK-5002 members 65001:5002
@@ -675,6 +695,10 @@ set routing-options static route 10.50.166.0/24 discard
 set routing-options static route 10.50.167.0/24 discard
 set routing-options static route 10.50.168.0/24 discard
 set routing-options static route 10.50.169.0/24 discard
+set routing-options static route 10.50.170.0/24 discard
+set routing-options static route 10.50.171.0/24 discard
+set routing-options static route 10.50.172.0/24 discard
+set routing-options static route 10.50.173.0/24 discard
 set routing-options static route 10.50.180.0/24 discard
 set routing-options static route 10.50.181.0/24 discard
 set routing-options static route 10.50.182.0/24 discard

--- a/snapshots/junos_then_action_conflicts/show/collector/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/collector/show_bgp_neighbor_|_display_json.txt
@@ -7,7 +7,7 @@
             "attributes" : {"junos:style" : "detail"}, 
             "peer-address" : [
             {
-                "data" : "10.0.23.0+179"
+                "data" : "10.0.23.0+61140"
             }
             ], 
             "peer-as" : [
@@ -17,7 +17,7 @@
             ], 
             "local-address" : [
             {
-                "data" : "10.0.23.1+62704"
+                "data" : "10.0.23.1+179"
             }
             ], 
             "local-as" : [
@@ -127,8 +127,8 @@
             ], 
             "elapsed-time" : [
             {
-                "data" : "8:08", 
-                "attributes" : {"junos:seconds" : "488"}
+                "data" : "6:20", 
+                "attributes" : {"junos:seconds" : "380"}
             }
             ], 
             "recv-ebgp-origin-validation-state" : [
@@ -287,17 +287,17 @@
                 ], 
                 "active-prefix-count" : [
                 {
-                    "data" : "99"
+                    "data" : "101"
                 }
                 ], 
                 "received-prefix-count" : [
                 {
-                    "data" : "100"
+                    "data" : "102"
                 }
                 ], 
                 "accepted-prefix-count" : [
                 {
-                    "data" : "100"
+                    "data" : "102"
                 }
                 ], 
                 "suppressed-prefix-count" : [
@@ -366,34 +366,34 @@
                 ], 
                 "bgp-nlri-recv-time" : [
                 {
-                    "data" : "1"
+                    "data" : "0"
                 }
                 ]
             }
             ], 
             "last-received" : [
             {
-                "data" : "4"
+                "data" : "12"
             }
             ], 
             "last-sent" : [
             {
-                "data" : "2"
+                "data" : "25"
             }
             ], 
             "last-checked" : [
             {
-                "data" : "488"
+                "data" : "381"
             }
             ], 
             "input-messages" : [
             {
-                "data" : "115"
+                "data" : "113"
             }
             ], 
             "input-updates" : [
             {
-                "data" : "96"
+                "data" : "98"
             }
             ], 
             "input-refreshes" : [
@@ -403,12 +403,12 @@
             ], 
             "input-octets" : [
             {
-                "data" : "6095"
+                "data" : "6151"
             }
             ], 
             "output-messages" : [
             {
-                "data" : "19"
+                "data" : "15"
             }
             ], 
             "output-updates" : [
@@ -423,7 +423,7 @@
             ], 
             "output-octets" : [
             {
-                "data" : "365"
+                "data" : "289"
             }
             ], 
             "bgp-output-queue" : [

--- a/snapshots/junos_then_action_conflicts/show/collector/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/collector/show_interfaces_|_display_json.txt
@@ -179,18 +179,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "aa:c1:ab:fa:b2:e3"
+                "data" : "aa:c1:ab:9f:09:af"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "aa:c1:ab:fa:b2:e3"
+                "data" : "aa:c1:ab:9f:09:af"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:45 ago)", 
-                "attributes" : {"junos:seconds" : "465"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:53 ago)", 
+                "attributes" : {"junos:seconds" : "353"}
             }
             ], 
             "traffic-statistics" : [
@@ -208,7 +208,7 @@
                 ], 
                 "output-bps" : [
                 {
-                    "data" : "48"
+                    "data" : "72"
                 }
                 ], 
                 "output-pps" : [
@@ -314,12 +314,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "45"
+                        "data" : "49"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "45"
+                        "data" : "44"
                     }
                     ]
                 }
@@ -1372,18 +1372,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:01"
+                "data" : "2c:6b:f5:94:da:01"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:01"
+                "data" : "2c:6b:f5:94:da:01"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:47 ago)", 
-                "attributes" : {"junos:seconds" : "467"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:56 ago)", 
+                "attributes" : {"junos:seconds" : "356"}
             }
             ], 
             "traffic-statistics" : [
@@ -1703,18 +1703,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:02"
+                "data" : "2c:6b:f5:94:da:02"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:02"
+                "data" : "2c:6b:f5:94:da:02"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:47 ago)", 
-                "attributes" : {"junos:seconds" : "467"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:56 ago)", 
+                "attributes" : {"junos:seconds" : "356"}
             }
             ], 
             "traffic-statistics" : [
@@ -2034,18 +2034,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:03"
+                "data" : "2c:6b:f5:94:da:03"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:03"
+                "data" : "2c:6b:f5:94:da:03"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:47 ago)", 
-                "attributes" : {"junos:seconds" : "467"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:56 ago)", 
+                "attributes" : {"junos:seconds" : "356"}
             }
             ], 
             "traffic-statistics" : [
@@ -2365,18 +2365,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:04"
+                "data" : "2c:6b:f5:94:da:04"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:04"
+                "data" : "2c:6b:f5:94:da:04"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:48 ago)", 
-                "attributes" : {"junos:seconds" : "468"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:57 ago)", 
+                "attributes" : {"junos:seconds" : "357"}
             }
             ], 
             "traffic-statistics" : [
@@ -2696,18 +2696,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:05"
+                "data" : "2c:6b:f5:94:da:05"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:05"
+                "data" : "2c:6b:f5:94:da:05"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:48 ago)", 
-                "attributes" : {"junos:seconds" : "468"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:58 ago)", 
+                "attributes" : {"junos:seconds" : "358"}
             }
             ], 
             "traffic-statistics" : [
@@ -3027,18 +3027,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:06"
+                "data" : "2c:6b:f5:94:da:06"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:06"
+                "data" : "2c:6b:f5:94:da:06"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:48 ago)", 
-                "attributes" : {"junos:seconds" : "468"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:58 ago)", 
+                "attributes" : {"junos:seconds" : "358"}
             }
             ], 
             "traffic-statistics" : [
@@ -3358,18 +3358,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:07"
+                "data" : "2c:6b:f5:94:da:07"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:07"
+                "data" : "2c:6b:f5:94:da:07"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:49 ago)", 
-                "attributes" : {"junos:seconds" : "469"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:58 ago)", 
+                "attributes" : {"junos:seconds" : "358"}
             }
             ], 
             "traffic-statistics" : [
@@ -3689,18 +3689,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:08"
+                "data" : "2c:6b:f5:94:da:08"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:08"
+                "data" : "2c:6b:f5:94:da:08"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:49 ago)", 
-                "attributes" : {"junos:seconds" : "469"}
+                "data" : "2026-05-20 22:10:13 UTC (00:05:59 ago)", 
+                "attributes" : {"junos:seconds" : "359"}
             }
             ], 
             "traffic-statistics" : [
@@ -4020,18 +4020,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:09"
+                "data" : "2c:6b:f5:94:da:09"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:09"
+                "data" : "2c:6b:f5:94:da:09"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:49 ago)", 
-                "attributes" : {"junos:seconds" : "469"}
+                "data" : "2026-05-20 22:10:13 UTC (00:06:00 ago)", 
+                "attributes" : {"junos:seconds" : "360"}
             }
             ], 
             "traffic-statistics" : [
@@ -4351,18 +4351,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:0a"
+                "data" : "2c:6b:f5:94:da:0a"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:0a"
+                "data" : "2c:6b:f5:94:da:0a"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:49 ago)", 
-                "attributes" : {"junos:seconds" : "469"}
+                "data" : "2026-05-20 22:10:13 UTC (00:06:00 ago)", 
+                "attributes" : {"junos:seconds" : "360"}
             }
             ], 
             "traffic-statistics" : [
@@ -4682,18 +4682,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:0b"
+                "data" : "2c:6b:f5:94:da:0b"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:0b"
+                "data" : "2c:6b:f5:94:da:0b"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:07:50 ago)", 
-                "attributes" : {"junos:seconds" : "470"}
+                "data" : "2026-05-20 22:10:13 UTC (00:06:00 ago)", 
+                "attributes" : {"junos:seconds" : "360"}
             }
             ], 
             "traffic-statistics" : [
@@ -4924,14 +4924,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:11", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b9:5e:11"}
+                "data" : "2c:6b:f5:94:da:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:94:da:11"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:5e:11", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b9:5e:11"}
+                "data" : "2c:6b:f5:94:da:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:94:da:11"}
             }
             ], 
             "interface-flapped" : [
@@ -5378,8 +5378,8 @@
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:46:07 UTC (00:09:41 ago)", 
-                "attributes" : {"junos:seconds" : "581"}
+                "data" : "2026-05-20 22:08:13 UTC (00:08:00 ago)", 
+                "attributes" : {"junos:seconds" : "480"}
             }
             ], 
             "traffic-statistics" : [
@@ -5387,12 +5387,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "59373"
+                    "data" : "56554"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "103872"
+                    "data" : "100603"
                 }
                 ]
             }
@@ -5447,12 +5447,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "58448"
+                        "data" : "55705"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "103873"
+                        "data" : "100604"
                     }
                     ]
                 }
@@ -6901,20 +6901,20 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "0c:00:db:1f:75:00", 
-                "attributes" : {"junos:format" : "MAC 0c:00:db:1f:75:00"}
+                "data" : "0c:00:0c:d6:72:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:0c:d6:72:00"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "0c:00:db:1f:75:00", 
-                "attributes" : {"junos:format" : "MAC 0c:00:db:1f:75:00"}
+                "data" : "0c:00:0c:d6:72:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:0c:d6:72:00"}
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:46:07 UTC (00:09:41 ago)", 
-                "attributes" : {"junos:seconds" : "581"}
+                "data" : "2026-05-20 22:08:13 UTC (00:08:01 ago)", 
+                "attributes" : {"junos:seconds" : "481"}
             }
             ], 
             "traffic-statistics" : [
@@ -6922,12 +6922,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "4359"
+                    "data" : "5010"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "4358"
+                    "data" : "4847"
                 }
                 ]
             }
@@ -6982,12 +6982,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "4332"
+                        "data" : "4955"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "4359"
+                        "data" : "4963"
                     }
                     ]
                 }
@@ -7194,7 +7194,7 @@
                         ], 
                         "ifa-local" : [
                         {
-                            "data" : "fe80::e00:dbff:fe1f:7500"
+                            "data" : "fe80::e00:cff:fed6:7200"
                         }
                         ], 
                         "in6-addr-flags" : [
@@ -7498,14 +7498,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:65:f0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b9:65:f0"}
+                "data" : "2c:6b:f5:94:e1:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:94:e1:f0"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:65:f0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b9:65:f0"}
+                "data" : "2c:6b:f5:94:e1:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:94:e1:f0"}
             }
             ], 
             "interface-flapped" : [
@@ -7912,12 +7912,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "1182"
+                    "data" : "1009"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "1182"
+                    "data" : "1009"
                 }
                 ]
             }
@@ -8204,12 +8204,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "1182"
+                        "data" : "1009"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "1182"
+                        "data" : "1009"
                     }
                     ]
                 }
@@ -8849,14 +8849,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:65:b0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b9:65:b0"}
+                "data" : "2c:6b:f5:94:e1:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:94:e1:b0"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:b9:65:b0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:b9:65:b0"}
+                "data" : "2c:6b:f5:94:e1:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:94:e1:b0"}
             }
             ], 
             "interface-flapped" : [

--- a/snapshots/junos_then_action_conflicts/show/collector/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/collector/show_route_instance_|_display_json.txt
@@ -25,7 +25,7 @@
                 ], 
                 "irib-active-count" : [
                 {
-                    "data" : "102"
+                    "data" : "104"
                 }
                 ], 
                 "irib-holddown-count" : [

--- a/snapshots/junos_then_action_conflicts/show/collector/show_route_protocol_bgp_detail_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/collector/show_route_protocol_bgp_detail_|_display_json.txt
@@ -12,17 +12,17 @@
             ], 
             "destination-count" : [
             {
-                "data" : "102"
+                "data" : "104"
             }
             ], 
             "total-route-count" : [
             {
-                "data" : "103"
+                "data" : "105"
             }
             ], 
             "active-route-count" : [
             {
-                "data" : "102"
+                "data" : "104"
             }
             ], 
             "holddown-route-count" : [
@@ -110,12 +110,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -182,8 +182,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "7:54", 
-                        "attributes" : {"junos:seconds" : "474"}
+                        "data" : "6:03", 
+                        "attributes" : {"junos:seconds" : "363"}
                     }
                     ], 
                     "validation-state" : [
@@ -326,12 +326,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -398,8 +398,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "7:54", 
-                        "attributes" : {"junos:seconds" : "474"}
+                        "data" : "6:03", 
+                        "attributes" : {"junos:seconds" : "363"}
                     }
                     ], 
                     "validation-state" : [
@@ -531,12 +531,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -608,8 +608,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "7:54", 
-                        "attributes" : {"junos:seconds" : "474"}
+                        "data" : "6:03", 
+                        "attributes" : {"junos:seconds" : "363"}
                     }
                     ], 
                     "validation-state" : [
@@ -742,12 +742,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -814,8 +814,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -967,12 +967,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1039,8 +1039,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -1192,12 +1192,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1264,8 +1264,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -1417,12 +1417,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1489,8 +1489,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -1642,12 +1642,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1714,8 +1714,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -1867,12 +1867,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1939,8 +1939,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -2092,12 +2092,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -2164,8 +2164,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -2317,12 +2317,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -2389,8 +2389,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -2542,12 +2542,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -2614,8 +2614,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -2767,12 +2767,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -2839,8 +2839,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -2992,12 +2992,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3064,8 +3064,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -3217,12 +3217,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3289,8 +3289,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -3442,12 +3442,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3514,8 +3514,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -3667,12 +3667,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3739,8 +3739,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -3892,12 +3892,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3964,8 +3964,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -4117,12 +4117,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -4189,8 +4189,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -4342,12 +4342,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -4414,8 +4414,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -4567,12 +4567,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -4639,8 +4639,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -4792,12 +4792,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -4864,8 +4864,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -5017,12 +5017,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5089,8 +5089,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -5242,12 +5242,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5314,8 +5314,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -5467,12 +5467,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5539,8 +5539,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -5692,12 +5692,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5764,8 +5764,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -5917,12 +5917,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5989,8 +5989,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -6142,12 +6142,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6214,8 +6214,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -6367,12 +6367,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6439,8 +6439,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -6592,12 +6592,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6664,8 +6664,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -6817,12 +6817,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6889,8 +6889,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -7042,12 +7042,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -7114,8 +7114,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -7267,12 +7267,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -7339,8 +7339,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -7492,12 +7492,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -7564,8 +7564,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -7717,12 +7717,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -7789,8 +7789,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -7942,12 +7942,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8014,8 +8014,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -8167,12 +8167,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8239,8 +8239,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -8392,12 +8392,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8464,8 +8464,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -8617,12 +8617,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8689,8 +8689,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -8842,12 +8842,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8914,8 +8914,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -9067,12 +9067,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9139,8 +9139,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -9292,12 +9292,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9364,8 +9364,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -9517,12 +9517,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9589,8 +9589,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -9742,12 +9742,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9814,8 +9814,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:12", 
-                        "attributes" : {"junos:seconds" : "132"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -9967,12 +9967,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10039,8 +10039,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -10192,12 +10192,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10264,8 +10264,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -10417,12 +10417,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10489,8 +10489,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -10642,12 +10642,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10714,8 +10714,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -10867,12 +10867,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10939,8 +10939,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -11092,12 +11092,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11164,8 +11164,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -11317,12 +11317,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11389,8 +11389,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -11542,12 +11542,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11614,8 +11614,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -11767,12 +11767,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11839,8 +11839,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -11992,12 +11992,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12064,8 +12064,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -12217,12 +12217,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12289,8 +12289,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -12442,12 +12442,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12514,8 +12514,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -12667,12 +12667,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12739,8 +12739,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -12892,12 +12892,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12964,8 +12964,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -13117,12 +13117,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -13189,8 +13189,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -13342,12 +13342,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -13414,8 +13414,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -13567,12 +13567,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -13639,8 +13639,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -13792,12 +13792,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -13864,8 +13864,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -14017,12 +14017,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14089,8 +14089,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -14242,12 +14242,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14314,8 +14314,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -14467,12 +14467,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14539,8 +14539,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -14692,12 +14692,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14764,8 +14764,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:34", 
+                        "attributes" : {"junos:seconds" : "154"}
                     }
                     ], 
                     "validation-state" : [
@@ -14917,12 +14917,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14989,8 +14989,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -15142,12 +15142,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -15214,8 +15214,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -15367,12 +15367,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -15439,8 +15439,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -15592,12 +15592,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -15664,8 +15664,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -15817,12 +15817,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -15889,8 +15889,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -16042,12 +16042,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -16114,8 +16114,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -16267,12 +16267,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -16339,8 +16339,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -16492,12 +16492,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -16564,8 +16564,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -16717,12 +16717,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -16789,8 +16789,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -16942,12 +16942,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17014,8 +17014,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:36", 
+                        "attributes" : {"junos:seconds" : "156"}
                     }
                     ], 
                     "validation-state" : [
@@ -17167,12 +17167,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17239,8 +17239,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -17398,12 +17398,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17470,8 +17470,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -17626,12 +17626,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17698,8 +17698,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -17851,12 +17851,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17923,8 +17923,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -18079,12 +18079,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -18151,8 +18151,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -18304,12 +18304,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -18376,8 +18376,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -18529,12 +18529,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -18601,8 +18601,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -18754,12 +18754,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -18826,8 +18826,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -18982,12 +18982,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19054,8 +19054,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -19210,12 +19210,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19282,8 +19282,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -19426,12 +19426,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19498,8 +19498,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -19651,12 +19651,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19723,8 +19723,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -19879,12 +19879,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19951,8 +19951,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -20104,12 +20104,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -20176,8 +20176,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -20329,12 +20329,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -20401,8 +20401,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -20560,12 +20560,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -20632,8 +20632,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -20791,12 +20791,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -20863,8 +20863,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -21022,12 +21022,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21094,8 +21094,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -21253,12 +21253,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21325,8 +21325,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -21484,12 +21484,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21556,8 +21556,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -21608,6 +21608,468 @@
                         "community" : [
                         {
                             "data" : "65001:4010"
+                        }, 
+                        {
+                            "data" : "65001:9100"
+                        }, 
+                        {
+                            "data" : "65001:9101"
+                        }
+                        ]
+                    }
+                    ], 
+                    "bgp-rt-flag" : [
+                    {
+                        "data" : "Accepted"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "peer-id" : [
+                    {
+                        "data" : "2.2.2.2"
+                    }
+                    ], 
+                    "thread-name" : [
+                    {
+                        "data" : "junos-main"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.171.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "rt-entry-count" : [
+                {
+                    "data" : "1", 
+                    "attributes" : {"junos:format" : "1 entry"}
+                }
+                ], 
+                "rt-announced-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-state" : [
+                {
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "preference2" : [
+                    {
+                        "data" : "-101"
+                    }
+                    ], 
+                    "nhh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-type" : [
+                        {
+                            "data" : "Router"
+                        }
+                        ], 
+                        "nh-index" : [
+                        {
+                            "data" : "587"
+                        }
+                        ], 
+                        "nh-address" : [
+                        {
+                            "data" : "0x91c0a94"
+                        }
+                        ], 
+                        "nh-reference-count" : [
+                        {
+                            "data" : "203"
+                        }
+                        ], 
+                        "nh-session-id" : [
+                        {
+                            "data" : "320"
+                        }
+                        ], 
+                        "nh-kernel-id" : [
+                        {
+                            "data" : "0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "gateway" : [
+                    {
+                        "data" : "10.0.23.0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-string" : [
+                        {
+                            "data" : "Next hop"
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "session" : [
+                        {
+                            "data" : "320"
+                        }
+                        ]
+                    }
+                    ], 
+                    "rt-entry-state" : [
+                    {
+                        "data" : "Active Ext"
+                    }
+                    ], 
+                    "local-as" : [
+                    {
+                        "data" : "65003"
+                    }
+                    ], 
+                    "peer-as" : [
+                    {
+                        "data" : "65002"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "task-name" : [
+                    {
+                        "data" : "BGP_65002.10.0.23.0"
+                    }
+                    ], 
+                    "announce-bits" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "announce-tasks" : [
+                    {
+                        "data" : "0-KRT "
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "AS path: 65002 65001 I"
+                    }
+                    ], 
+                    "bgp-path-attributes" : [
+                    {
+                        "attr-as-path-effective" : [
+                        {
+                            "aspath-effective-string" : [
+                            {
+                                "data" : "AS path: "
+                            }
+                            ], 
+                            "attr-value" : [
+                            {
+                                "data" : "65002 65001 I"
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ], 
+                    "communities" : [
+                    {
+                        "community" : [
+                        {
+                            "data" : "65001:4012"
+                        }, 
+                        {
+                            "data" : "65001:9100"
+                        }, 
+                        {
+                            "data" : "65001:9101"
+                        }
+                        ]
+                    }
+                    ], 
+                    "bgp-rt-flag" : [
+                    {
+                        "data" : "Accepted"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "peer-id" : [
+                    {
+                        "data" : "2.2.2.2"
+                    }
+                    ], 
+                    "thread-name" : [
+                    {
+                        "data" : "junos-main"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.172.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "rt-entry-count" : [
+                {
+                    "data" : "1", 
+                    "attributes" : {"junos:format" : "1 entry"}
+                }
+                ], 
+                "rt-announced-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-state" : [
+                {
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "preference2" : [
+                    {
+                        "data" : "-101"
+                    }
+                    ], 
+                    "nhh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-type" : [
+                        {
+                            "data" : "Router"
+                        }
+                        ], 
+                        "nh-index" : [
+                        {
+                            "data" : "587"
+                        }
+                        ], 
+                        "nh-address" : [
+                        {
+                            "data" : "0x91c0a94"
+                        }
+                        ], 
+                        "nh-reference-count" : [
+                        {
+                            "data" : "203"
+                        }
+                        ], 
+                        "nh-session-id" : [
+                        {
+                            "data" : "320"
+                        }
+                        ], 
+                        "nh-kernel-id" : [
+                        {
+                            "data" : "0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "gateway" : [
+                    {
+                        "data" : "10.0.23.0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-string" : [
+                        {
+                            "data" : "Next hop"
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "session" : [
+                        {
+                            "data" : "320"
+                        }
+                        ]
+                    }
+                    ], 
+                    "rt-entry-state" : [
+                    {
+                        "data" : "Active Ext"
+                    }
+                    ], 
+                    "local-as" : [
+                    {
+                        "data" : "65003"
+                    }
+                    ], 
+                    "peer-as" : [
+                    {
+                        "data" : "65002"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "task-name" : [
+                    {
+                        "data" : "BGP_65002.10.0.23.0"
+                    }
+                    ], 
+                    "announce-bits" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "announce-tasks" : [
+                    {
+                        "data" : "0-KRT "
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "AS path: 65002 65001 I"
+                    }
+                    ], 
+                    "bgp-path-attributes" : [
+                    {
+                        "attr-as-path-effective" : [
+                        {
+                            "aspath-effective-string" : [
+                            {
+                                "data" : "AS path: "
+                            }
+                            ], 
+                            "attr-value" : [
+                            {
+                                "data" : "65002 65001 I"
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ], 
+                    "communities" : [
+                    {
+                        "community" : [
+                        {
+                            "data" : "65001:4013"
                         }, 
                         {
                             "data" : "65001:9100"
@@ -21715,12 +22177,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21787,8 +22249,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -21940,12 +22402,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -22012,8 +22474,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -22165,12 +22627,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -22237,8 +22699,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [
@@ -22390,12 +22852,12 @@
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91bd994"
+                            "data" : "0x91c0a94"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "199"
+                            "data" : "203"
                         }
                         ], 
                         "nh-session-id" : [
@@ -22462,8 +22924,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:11", 
-                        "attributes" : {"junos:seconds" : "131"}
+                        "data" : "2:35", 
+                        "attributes" : {"junos:seconds" : "155"}
                     }
                     ], 
                     "validation-state" : [

--- a/snapshots/junos_then_action_conflicts/show/collector/show_route_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/collector/show_route_|_display_json.txt
@@ -12,17 +12,17 @@
             ], 
             "destination-count" : [
             {
-                "data" : "102"
+                "data" : "104"
             }
             ], 
             "total-route-count" : [
             {
-                "data" : "103"
+                "data" : "105"
             }
             ], 
             "active-route-count" : [
             {
-                "data" : "102"
+                "data" : "104"
             }
             ], 
             "holddown-route-count" : [
@@ -72,8 +72,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:07:50", 
-                        "attributes" : {"junos:seconds" : "470"}
+                        "data" : "00:05:58", 
+                        "attributes" : {"junos:seconds" : "358"}
                     }
                     ], 
                     "local-preference" : [
@@ -149,8 +149,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:13", 
-                        "attributes" : {"junos:seconds" : "553"}
+                        "data" : "00:07:26", 
+                        "attributes" : {"junos:seconds" : "446"}
                     }
                     ], 
                     "nh" : [
@@ -206,8 +206,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:07:50", 
-                        "attributes" : {"junos:seconds" : "470"}
+                        "data" : "00:05:58", 
+                        "attributes" : {"junos:seconds" : "358"}
                     }
                     ], 
                     "local-preference" : [
@@ -283,8 +283,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:07:54", 
-                        "attributes" : {"junos:seconds" : "474"}
+                        "data" : "00:06:04", 
+                        "attributes" : {"junos:seconds" : "364"}
                     }
                     ], 
                     "nh" : [
@@ -319,8 +319,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:07:50", 
-                        "attributes" : {"junos:seconds" : "470"}
+                        "data" : "00:05:58", 
+                        "attributes" : {"junos:seconds" : "358"}
                     }
                     ], 
                     "local-preference" : [
@@ -396,8 +396,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:07:54", 
-                        "attributes" : {"junos:seconds" : "474"}
+                        "data" : "00:06:04", 
+                        "attributes" : {"junos:seconds" : "364"}
                     }
                     ], 
                     "nh-type" : [
@@ -453,8 +453,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -530,8 +530,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -607,8 +607,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -684,8 +684,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -761,8 +761,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -838,8 +838,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -915,8 +915,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -992,8 +992,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1069,8 +1069,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1146,8 +1146,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1223,8 +1223,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1300,8 +1300,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1377,8 +1377,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1454,8 +1454,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1531,8 +1531,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1608,8 +1608,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1685,8 +1685,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1762,8 +1762,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1839,8 +1839,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1916,8 +1916,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -1993,8 +1993,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2070,8 +2070,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2147,8 +2147,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2224,8 +2224,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2301,8 +2301,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2378,8 +2378,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2455,8 +2455,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2532,8 +2532,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2609,8 +2609,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2686,8 +2686,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2763,8 +2763,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2840,8 +2840,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2917,8 +2917,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -2994,8 +2994,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3071,8 +3071,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3148,8 +3148,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3225,8 +3225,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3302,8 +3302,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3379,8 +3379,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3456,8 +3456,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3533,8 +3533,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3610,8 +3610,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3687,8 +3687,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3764,8 +3764,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3841,8 +3841,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3918,8 +3918,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -3995,8 +3995,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4072,8 +4072,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4149,8 +4149,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4226,8 +4226,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4303,8 +4303,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4380,8 +4380,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4457,8 +4457,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4534,8 +4534,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4611,8 +4611,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4688,8 +4688,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4765,8 +4765,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4842,8 +4842,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4919,8 +4919,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -4996,8 +4996,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5073,8 +5073,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5150,8 +5150,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5227,8 +5227,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5304,8 +5304,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5381,8 +5381,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5458,8 +5458,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5535,8 +5535,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5612,8 +5612,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5689,8 +5689,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5766,8 +5766,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5843,8 +5843,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5920,8 +5920,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:07", 
-                        "attributes" : {"junos:seconds" : "127"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -5997,8 +5997,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -6074,8 +6074,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6151,8 +6151,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6228,8 +6228,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6305,8 +6305,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6382,8 +6382,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6459,8 +6459,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6536,8 +6536,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6613,8 +6613,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6690,8 +6690,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6767,8 +6767,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6844,8 +6844,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6921,8 +6921,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -6998,8 +6998,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7075,8 +7075,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7152,8 +7152,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7229,8 +7229,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7306,8 +7306,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7383,8 +7383,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7460,8 +7460,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7537,8 +7537,162 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.171.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65002 65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.23.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.172.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7614,8 +7768,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:28", 
+                        "attributes" : {"junos:seconds" : "148"}
                     }
                     ], 
                     "local-preference" : [
@@ -7691,8 +7845,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -7768,8 +7922,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -7845,8 +7999,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:08", 
-                        "attributes" : {"junos:seconds" : "128"}
+                        "data" : "00:02:29", 
+                        "attributes" : {"junos:seconds" : "149"}
                     }
                     ], 
                     "local-preference" : [
@@ -7956,8 +8110,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:01", 
-                        "attributes" : {"junos:seconds" : "541"}
+                        "data" : "00:07:01", 
+                        "attributes" : {"junos:seconds" : "421"}
                     }
                     ], 
                     "nh" : [
@@ -8018,8 +8172,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:14", 
-                        "attributes" : {"junos:seconds" : "554"}
+                        "data" : "00:07:27", 
+                        "attributes" : {"junos:seconds" : "447"}
                     }
                     ], 
                     "nh" : [
@@ -8075,8 +8229,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:14", 
-                        "attributes" : {"junos:seconds" : "554"}
+                        "data" : "00:07:27", 
+                        "attributes" : {"junos:seconds" : "447"}
                     }
                     ], 
                     "nh-type" : [
@@ -8166,8 +8320,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:01", 
-                        "attributes" : {"junos:seconds" : "541"}
+                        "data" : "00:07:01", 
+                        "attributes" : {"junos:seconds" : "421"}
                     }
                     ], 
                     "nh" : [
@@ -8228,8 +8382,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:14", 
-                        "attributes" : {"junos:seconds" : "554"}
+                        "data" : "00:07:27", 
+                        "attributes" : {"junos:seconds" : "447"}
                     }
                     ], 
                     "nh" : [
@@ -8285,8 +8439,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:14", 
-                        "attributes" : {"junos:seconds" : "554"}
+                        "data" : "00:07:27", 
+                        "attributes" : {"junos:seconds" : "447"}
                     }
                     ], 
                     "nh-type" : [
@@ -8310,7 +8464,7 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "rt-destination" : [
                 {
-                    "data" : "fe80::e00:dbff:fe1f:7500/128", 
+                    "data" : "fe80::e00:cff:fed6:7200/128", 
                     "attributes" : {"junos:emit" : "emit"}
                 }
                 ], 
@@ -8343,8 +8497,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:14", 
-                        "attributes" : {"junos:seconds" : "554"}
+                        "data" : "00:07:27", 
+                        "attributes" : {"junos:seconds" : "447"}
                     }
                     ], 
                     "nh-type" : [

--- a/snapshots/junos_then_action_conflicts/show/dut/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/dut/show_bgp_neighbor_|_display_json.txt
@@ -7,7 +7,7 @@
             "attributes" : {"junos:style" : "detail"}, 
             "peer-address" : [
             {
-                "data" : "10.0.12.0+179"
+                "data" : "10.0.12.0+64680"
             }
             ], 
             "peer-as" : [
@@ -17,7 +17,7 @@
             ], 
             "local-address" : [
             {
-                "data" : "10.0.12.1+50390"
+                "data" : "10.0.12.1+179"
             }
             ], 
             "local-as" : [
@@ -127,8 +127,8 @@
             ], 
             "elapsed-time" : [
             {
-                "data" : "8:44", 
-                "attributes" : {"junos:seconds" : "524"}
+                "data" : "7:23", 
+                "attributes" : {"junos:seconds" : "443"}
             }
             ], 
             "recv-ebgp-origin-validation-state" : [
@@ -272,7 +272,7 @@
                 ], 
                 "rib-bit" : [
                 {
-                    "data" : "20001"
+                    "data" : "20000"
                 }
                 ], 
                 "bgp-rib-state" : [
@@ -287,17 +287,17 @@
                 ], 
                 "active-prefix-count" : [
                 {
-                    "data" : "97"
+                    "data" : "99"
                 }
                 ], 
                 "received-prefix-count" : [
                 {
-                    "data" : "108"
+                    "data" : "112"
                 }
                 ], 
                 "accepted-prefix-count" : [
                 {
-                    "data" : "104"
+                    "data" : "106"
                 }
                 ], 
                 "suppressed-prefix-count" : [
@@ -366,24 +366,24 @@
                 ], 
                 "bgp-nlri-recv-time" : [
                 {
-                    "data" : "0"
+                    "data" : "1"
                 }
                 ]
             }
             ], 
             "last-received" : [
             {
-                "data" : "1"
+                "data" : "25"
             }
             ], 
             "last-sent" : [
             {
-                "data" : "13"
+                "data" : "7"
             }
             ], 
             "last-checked" : [
             {
-                "data" : "524"
+                "data" : "443"
             }
             ], 
             "input-messages" : [
@@ -393,7 +393,7 @@
             ], 
             "input-updates" : [
             {
-                "data" : "109"
+                "data" : "113"
             }
             ], 
             "input-refreshes" : [
@@ -403,12 +403,12 @@
             ], 
             "input-octets" : [
             {
-                "data" : "6334"
+                "data" : "6474"
             }
             ], 
             "output-messages" : [
             {
-                "data" : "21"
+                "data" : "17"
             }
             ], 
             "output-updates" : [
@@ -423,7 +423,7 @@
             ], 
             "output-octets" : [
             {
-                "data" : "403"
+                "data" : "327"
             }
             ], 
             "bgp-output-queue" : [
@@ -455,7 +455,7 @@
             "attributes" : {"junos:style" : "detail"}, 
             "peer-address" : [
             {
-                "data" : "10.0.23.1+62704"
+                "data" : "10.0.23.1+179"
             }
             ], 
             "peer-as" : [
@@ -465,7 +465,7 @@
             ], 
             "local-address" : [
             {
-                "data" : "10.0.23.0+179"
+                "data" : "10.0.23.0+61140"
             }
             ], 
             "local-as" : [
@@ -575,8 +575,8 @@
             ], 
             "elapsed-time" : [
             {
-                "data" : "8:44", 
-                "attributes" : {"junos:seconds" : "524"}
+                "data" : "6:58", 
+                "attributes" : {"junos:seconds" : "418"}
             }
             ], 
             "recv-ebgp-origin-validation-state" : [
@@ -720,7 +720,7 @@
                 ], 
                 "rib-bit" : [
                 {
-                    "data" : "20000"
+                    "data" : "20001"
                 }
                 ], 
                 "bgp-rib-state" : [
@@ -755,7 +755,7 @@
                 ], 
                 "advertised-prefix-count" : [
                 {
-                    "data" : "100"
+                    "data" : "102"
                 }
                 ]
             }
@@ -814,29 +814,29 @@
                 ], 
                 "bgp-nlri-recv-time" : [
                 {
-                    "data" : "0"
+                    "data" : "1"
                 }
                 ]
             }
             ], 
             "last-received" : [
             {
-                "data" : "14"
+                "data" : "7"
             }
             ], 
             "last-sent" : [
             {
-                "data" : "14"
+                "data" : "24"
             }
             ], 
             "last-checked" : [
             {
-                "data" : "525"
+                "data" : "418"
             }
             ], 
             "input-messages" : [
             {
-                "data" : "22"
+                "data" : "18"
             }
             ], 
             "input-updates" : [
@@ -851,17 +851,17 @@
             ], 
             "input-octets" : [
             {
-                "data" : "466"
+                "data" : "390"
             }
             ], 
             "output-messages" : [
             {
-                "data" : "114"
+                "data" : "113"
             }
             ], 
             "output-updates" : [
             {
-                "data" : "95"
+                "data" : "97"
             }
             ], 
             "output-refreshes" : [
@@ -871,7 +871,7 @@
             ], 
             "output-octets" : [
             {
-                "data" : "6032"
+                "data" : "6107"
             }
             ], 
             "bgp-output-queue" : [

--- a/snapshots/junos_then_action_conflicts/show/dut/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/dut/show_interfaces_|_display_json.txt
@@ -179,18 +179,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "aa:c1:ab:92:82:46"
+                "data" : "aa:c1:ab:f1:5b:30"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "aa:c1:ab:92:82:46"
+                "data" : "aa:c1:ab:f1:5b:30"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:25 ago)", 
-                "attributes" : {"junos:seconds" : "505"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:01 ago)", 
+                "attributes" : {"junos:seconds" : "421"}
             }
             ], 
             "traffic-statistics" : [
@@ -208,7 +208,7 @@
                 ], 
                 "output-bps" : [
                 {
-                    "data" : "48"
+                    "data" : "56"
                 }
                 ], 
                 "output-pps" : [
@@ -314,12 +314,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "54"
+                        "data" : "52"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "54"
+                        "data" : "44"
                     }
                     ]
                 }
@@ -1367,18 +1367,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "aa:c1:ab:df:ed:a8"
+                "data" : "aa:c1:ab:0b:7c:6c"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "aa:c1:ab:df:ed:a8"
+                "data" : "aa:c1:ab:0b:7c:6c"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:26 ago)", 
-                "attributes" : {"junos:seconds" : "506"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:01 ago)", 
+                "attributes" : {"junos:seconds" : "421"}
             }
             ], 
             "traffic-statistics" : [
@@ -1396,7 +1396,7 @@
                 ], 
                 "output-bps" : [
                 {
-                    "data" : "136"
+                    "data" : "176"
                 }
                 ], 
                 "output-pps" : [
@@ -1507,7 +1507,7 @@
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "47"
+                        "data" : "58"
                     }
                     ]
                 }
@@ -1800,18 +1800,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:02"
+                "data" : "2c:6b:f5:79:0c:02"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:02"
+                "data" : "2c:6b:f5:79:0c:02"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:27 ago)", 
-                "attributes" : {"junos:seconds" : "507"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:02 ago)", 
+                "attributes" : {"junos:seconds" : "422"}
             }
             ], 
             "traffic-statistics" : [
@@ -2131,18 +2131,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:03"
+                "data" : "2c:6b:f5:79:0c:03"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:03"
+                "data" : "2c:6b:f5:79:0c:03"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:27 ago)", 
-                "attributes" : {"junos:seconds" : "507"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:02 ago)", 
+                "attributes" : {"junos:seconds" : "422"}
             }
             ], 
             "traffic-statistics" : [
@@ -2462,18 +2462,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:04"
+                "data" : "2c:6b:f5:79:0c:04"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:04"
+                "data" : "2c:6b:f5:79:0c:04"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:27 ago)", 
-                "attributes" : {"junos:seconds" : "507"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:02 ago)", 
+                "attributes" : {"junos:seconds" : "422"}
             }
             ], 
             "traffic-statistics" : [
@@ -2793,18 +2793,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:05"
+                "data" : "2c:6b:f5:79:0c:05"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:05"
+                "data" : "2c:6b:f5:79:0c:05"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:27 ago)", 
-                "attributes" : {"junos:seconds" : "507"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:02 ago)", 
+                "attributes" : {"junos:seconds" : "422"}
             }
             ], 
             "traffic-statistics" : [
@@ -3124,18 +3124,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:06"
+                "data" : "2c:6b:f5:79:0c:06"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:06"
+                "data" : "2c:6b:f5:79:0c:06"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:27 ago)", 
-                "attributes" : {"junos:seconds" : "507"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:02 ago)", 
+                "attributes" : {"junos:seconds" : "422"}
             }
             ], 
             "traffic-statistics" : [
@@ -3455,18 +3455,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:07"
+                "data" : "2c:6b:f5:79:0c:07"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:07"
+                "data" : "2c:6b:f5:79:0c:07"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:28 ago)", 
-                "attributes" : {"junos:seconds" : "508"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:02 ago)", 
+                "attributes" : {"junos:seconds" : "422"}
             }
             ], 
             "traffic-statistics" : [
@@ -3786,18 +3786,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:08"
+                "data" : "2c:6b:f5:79:0c:08"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:08"
+                "data" : "2c:6b:f5:79:0c:08"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:28 ago)", 
-                "attributes" : {"junos:seconds" : "508"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:03 ago)", 
+                "attributes" : {"junos:seconds" : "423"}
             }
             ], 
             "traffic-statistics" : [
@@ -4117,18 +4117,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:09"
+                "data" : "2c:6b:f5:79:0c:09"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:09"
+                "data" : "2c:6b:f5:79:0c:09"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:28 ago)", 
-                "attributes" : {"junos:seconds" : "508"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:03 ago)", 
+                "attributes" : {"junos:seconds" : "423"}
             }
             ], 
             "traffic-statistics" : [
@@ -4448,18 +4448,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:0a"
+                "data" : "2c:6b:f5:79:0c:0a"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:0a"
+                "data" : "2c:6b:f5:79:0c:0a"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:29 ago)", 
-                "attributes" : {"junos:seconds" : "509"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:03 ago)", 
+                "attributes" : {"junos:seconds" : "423"}
             }
             ], 
             "traffic-statistics" : [
@@ -4779,18 +4779,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:0b"
+                "data" : "2c:6b:f5:79:0c:0b"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:0b"
+                "data" : "2c:6b:f5:79:0c:0b"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:08:29 ago)", 
-                "attributes" : {"junos:seconds" : "509"}
+                "data" : "2026-05-20 22:09:51 UTC (00:07:04 ago)", 
+                "attributes" : {"junos:seconds" : "424"}
             }
             ], 
             "traffic-statistics" : [
@@ -5021,14 +5021,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:11", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ee:83:11"}
+                "data" : "2c:6b:f5:79:0c:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:79:0c:11"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:83:11", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ee:83:11"}
+                "data" : "2c:6b:f5:79:0c:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:79:0c:11"}
             }
             ], 
             "interface-flapped" : [
@@ -5475,8 +5475,8 @@
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:46:08 UTC (00:10:19 ago)", 
-                "attributes" : {"junos:seconds" : "619"}
+                "data" : "2026-05-20 22:08:05 UTC (00:08:50 ago)", 
+                "attributes" : {"junos:seconds" : "530"}
             }
             ], 
             "traffic-statistics" : [
@@ -5484,12 +5484,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "60988"
+                    "data" : "58403"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "104996"
+                    "data" : "102530"
                 }
                 ]
             }
@@ -5544,12 +5544,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "60024"
+                        "data" : "57515"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "104997"
+                        "data" : "102531"
                     }
                     ]
                 }
@@ -6998,20 +6998,20 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "0c:00:d7:6e:ff:00", 
-                "attributes" : {"junos:format" : "MAC 0c:00:d7:6e:ff:00"}
+                "data" : "0c:00:d7:0d:9a:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:d7:0d:9a:00"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "0c:00:d7:6e:ff:00", 
-                "attributes" : {"junos:format" : "MAC 0c:00:d7:6e:ff:00"}
+                "data" : "0c:00:d7:0d:9a:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:d7:0d:9a:00"}
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:46:08 UTC (00:10:20 ago)", 
-                "attributes" : {"junos:seconds" : "620"}
+                "data" : "2026-05-20 22:08:05 UTC (00:08:50 ago)", 
+                "attributes" : {"junos:seconds" : "530"}
             }
             ], 
             "traffic-statistics" : [
@@ -7019,12 +7019,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "8368"
+                    "data" : "6149"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "8263"
+                    "data" : "6021"
                 }
                 ]
             }
@@ -7079,12 +7079,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "8340"
+                        "data" : "6149"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "8304"
+                        "data" : "6022"
                     }
                     ]
                 }
@@ -7291,7 +7291,7 @@
                         ], 
                         "ifa-local" : [
                         {
-                            "data" : "fe80::e00:d7ff:fe6e:ff00"
+                            "data" : "fe80::e00:d7ff:fe0d:9a00"
                         }
                         ], 
                         "in6-addr-flags" : [
@@ -7595,14 +7595,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:8a:f0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ee:8a:f0"}
+                "data" : "2c:6b:f5:79:13:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:79:13:f0"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:8a:f0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ee:8a:f0"}
+                "data" : "2c:6b:f5:79:13:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:79:13:f0"}
             }
             ], 
             "interface-flapped" : [
@@ -8009,12 +8009,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "1251"
+                    "data" : "1137"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "1251"
+                    "data" : "1137"
                 }
                 ]
             }
@@ -8301,12 +8301,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "1251"
+                        "data" : "1137"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "1251"
+                        "data" : "1137"
                     }
                     ]
                 }
@@ -8946,14 +8946,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:8a:b0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ee:8a:b0"}
+                "data" : "2c:6b:f5:79:13:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:79:13:b0"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ee:8a:b0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ee:8a:b0"}
+                "data" : "2c:6b:f5:79:13:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:79:13:b0"}
             }
             ], 
             "interface-flapped" : [

--- a/snapshots/junos_then_action_conflicts/show/dut/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/dut/show_route_instance_|_display_json.txt
@@ -25,7 +25,7 @@
                 ], 
                 "irib-active-count" : [
                 {
-                    "data" : "102"
+                    "data" : "104"
                 }
                 ], 
                 "irib-holddown-count" : [
@@ -35,7 +35,7 @@
                 ], 
                 "irib-hidden-count" : [
                 {
-                    "data" : "11"
+                    "data" : "13"
                 }
                 ]
             }, 

--- a/snapshots/junos_then_action_conflicts/show/dut/show_route_protocol_bgp_detail_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/dut/show_route_protocol_bgp_detail_|_display_json.txt
@@ -12,17 +12,17 @@
             ], 
             "destination-count" : [
             {
-                "data" : "113"
+                "data" : "117"
             }
             ], 
             "total-route-count" : [
             {
-                "data" : "113"
+                "data" : "117"
             }
             ], 
             "active-route-count" : [
             {
-                "data" : "102"
+                "data" : "104"
             }
             ], 
             "holddown-route-count" : [
@@ -32,7 +32,7 @@
             ], 
             "hidden-route-count" : [
             {
-                "data" : "11"
+                "data" : "13"
             }
             ], 
             "rt" : [
@@ -105,17 +105,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -182,8 +182,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -330,17 +330,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -407,8 +407,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -555,17 +555,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -632,8 +632,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -780,17 +780,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -857,8 +857,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -1005,17 +1005,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1082,8 +1082,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -1230,17 +1230,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1307,8 +1307,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -1455,17 +1455,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1532,8 +1532,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -1685,17 +1685,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1762,8 +1762,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -1915,17 +1915,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -1992,8 +1992,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -2145,17 +2145,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -2222,8 +2222,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -2380,17 +2380,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -2457,8 +2457,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -2610,17 +2610,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -2687,8 +2687,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -2840,17 +2840,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -2917,8 +2917,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -3070,17 +3070,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3147,8 +3147,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -3295,17 +3295,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3372,8 +3372,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -3520,17 +3520,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3597,8 +3597,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -3745,17 +3745,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -3822,8 +3822,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -4012,8 +4012,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -4160,17 +4160,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -4237,8 +4237,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -4385,17 +4385,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -4462,8 +4462,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -4610,17 +4610,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -4687,8 +4687,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -4835,17 +4835,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -4912,8 +4912,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -5060,17 +5060,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5137,8 +5137,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -5285,17 +5285,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5362,8 +5362,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -5524,17 +5524,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5601,8 +5601,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -5763,17 +5763,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -5840,8 +5840,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -5988,17 +5988,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6065,8 +6065,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -6218,17 +6218,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6295,8 +6295,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -6448,17 +6448,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6525,8 +6525,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -6673,17 +6673,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6750,8 +6750,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -6898,17 +6898,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -6975,8 +6975,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -7123,17 +7123,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -7200,8 +7200,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -7348,17 +7348,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -7425,8 +7425,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -7573,17 +7573,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -7650,8 +7650,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -7798,17 +7798,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -7875,8 +7875,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -8023,17 +8023,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8100,8 +8100,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -8248,17 +8248,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8325,8 +8325,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -8473,17 +8473,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8550,8 +8550,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -8698,17 +8698,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -8775,8 +8775,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -8928,17 +8928,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9005,8 +9005,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -9158,17 +9158,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9235,8 +9235,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -9388,17 +9388,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9465,8 +9465,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -9618,17 +9618,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9695,8 +9695,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -9848,17 +9848,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -9925,8 +9925,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -10078,17 +10078,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10155,8 +10155,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -10308,17 +10308,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10385,8 +10385,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -10538,17 +10538,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10615,8 +10615,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -10768,17 +10768,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -10845,8 +10845,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -10998,17 +10998,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11075,8 +11075,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -11228,17 +11228,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11305,8 +11305,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -11458,17 +11458,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11535,8 +11535,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -11688,17 +11688,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11765,8 +11765,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -11918,17 +11918,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -11995,8 +11995,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [
@@ -12148,17 +12148,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12225,8 +12225,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -12378,17 +12378,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12455,8 +12455,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -12608,17 +12608,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12685,8 +12685,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -12838,17 +12838,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -12915,8 +12915,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -13068,17 +13068,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -13145,8 +13145,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -13298,17 +13298,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -13375,8 +13375,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -13528,17 +13528,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -13605,8 +13605,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -13758,17 +13758,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -13835,8 +13835,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -13988,17 +13988,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14065,8 +14065,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -14218,17 +14218,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14295,8 +14295,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric2" : [
@@ -14448,17 +14448,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14525,8 +14525,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -14673,17 +14673,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14750,8 +14750,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -14898,17 +14898,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -14975,8 +14975,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -15123,17 +15123,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -15200,8 +15200,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -15348,17 +15348,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -15425,8 +15425,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -15573,17 +15573,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -15650,8 +15650,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -15798,17 +15798,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -15875,8 +15875,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -16023,17 +16023,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -16100,8 +16100,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -16248,17 +16248,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -16325,8 +16325,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -16473,17 +16473,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -16550,8 +16550,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -16698,17 +16698,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -16775,8 +16775,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -16929,17 +16929,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17006,8 +17006,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -17157,17 +17157,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17234,8 +17234,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -17382,17 +17382,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17459,8 +17459,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -17610,17 +17610,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17687,8 +17687,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -17835,17 +17835,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -17912,8 +17912,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -18060,17 +18060,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -18137,8 +18137,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -18285,17 +18285,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -18362,8 +18362,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -18513,17 +18513,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -18590,8 +18590,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -18741,17 +18741,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -18818,8 +18818,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -18957,17 +18957,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19034,8 +19034,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -19182,17 +19182,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19259,8 +19259,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -19410,17 +19410,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19487,8 +19487,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -19635,17 +19635,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19712,8 +19712,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -19860,17 +19860,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -19937,8 +19937,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -20091,17 +20091,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -20168,8 +20168,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -20322,17 +20322,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -20399,8 +20399,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -20553,17 +20553,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -20630,8 +20630,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -20784,17 +20784,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -20861,8 +20861,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -21015,17 +21015,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21092,8 +21092,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -21144,6 +21144,468 @@
                         "community" : [
                         {
                             "data" : "65001:4010"
+                        }, 
+                        {
+                            "data" : "65001:9100"
+                        }, 
+                        {
+                            "data" : "65001:9101"
+                        }
+                        ]
+                    }
+                    ], 
+                    "bgp-rt-flag" : [
+                    {
+                        "data" : "Accepted"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "peer-id" : [
+                    {
+                        "data" : "1.1.1.1"
+                    }
+                    ], 
+                    "thread-name" : [
+                    {
+                        "data" : "junos-main"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.171.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "rt-entry-count" : [
+                {
+                    "data" : "1", 
+                    "attributes" : {"junos:format" : "1 entry"}
+                }
+                ], 
+                "rt-announced-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-state" : [
+                {
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "preference2" : [
+                    {
+                        "data" : "-101"
+                    }
+                    ], 
+                    "nhh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-type" : [
+                        {
+                            "data" : "Router"
+                        }
+                        ], 
+                        "nh-index" : [
+                        {
+                            "data" : "589"
+                        }
+                        ], 
+                        "nh-address" : [
+                        {
+                            "data" : "0x91be814"
+                        }
+                        ], 
+                        "nh-reference-count" : [
+                        {
+                            "data" : "202"
+                        }
+                        ], 
+                        "nh-session-id" : [
+                        {
+                            "data" : "320"
+                        }
+                        ], 
+                        "nh-kernel-id" : [
+                        {
+                            "data" : "0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "gateway" : [
+                    {
+                        "data" : "10.0.12.0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-string" : [
+                        {
+                            "data" : "Next hop"
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "session" : [
+                        {
+                            "data" : "320"
+                        }
+                        ]
+                    }
+                    ], 
+                    "rt-entry-state" : [
+                    {
+                        "data" : "Active Ext"
+                    }
+                    ], 
+                    "local-as" : [
+                    {
+                        "data" : "65002"
+                    }
+                    ], 
+                    "peer-as" : [
+                    {
+                        "data" : "65001"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "task-name" : [
+                    {
+                        "data" : "BGP_65001.10.0.12.0"
+                    }
+                    ], 
+                    "announce-bits" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "announce-tasks" : [
+                    {
+                        "data" : "0-KRT 1-BGP_RT_Background "
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "AS path: 65001 I"
+                    }
+                    ], 
+                    "bgp-path-attributes" : [
+                    {
+                        "attr-as-path-effective" : [
+                        {
+                            "aspath-effective-string" : [
+                            {
+                                "data" : "AS path: "
+                            }
+                            ], 
+                            "attr-value" : [
+                            {
+                                "data" : "65001 I"
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ], 
+                    "communities" : [
+                    {
+                        "community" : [
+                        {
+                            "data" : "65001:4012"
+                        }, 
+                        {
+                            "data" : "65001:9100"
+                        }, 
+                        {
+                            "data" : "65001:9101"
+                        }
+                        ]
+                    }
+                    ], 
+                    "bgp-rt-flag" : [
+                    {
+                        "data" : "Accepted"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "peer-id" : [
+                    {
+                        "data" : "1.1.1.1"
+                    }
+                    ], 
+                    "thread-name" : [
+                    {
+                        "data" : "junos-main"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.172.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "rt-entry-count" : [
+                {
+                    "data" : "1", 
+                    "attributes" : {"junos:format" : "1 entry"}
+                }
+                ], 
+                "rt-announced-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-state" : [
+                {
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "preference2" : [
+                    {
+                        "data" : "-101"
+                    }
+                    ], 
+                    "nhh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-type" : [
+                        {
+                            "data" : "Router"
+                        }
+                        ], 
+                        "nh-index" : [
+                        {
+                            "data" : "589"
+                        }
+                        ], 
+                        "nh-address" : [
+                        {
+                            "data" : "0x91be814"
+                        }
+                        ], 
+                        "nh-reference-count" : [
+                        {
+                            "data" : "202"
+                        }
+                        ], 
+                        "nh-session-id" : [
+                        {
+                            "data" : "320"
+                        }
+                        ], 
+                        "nh-kernel-id" : [
+                        {
+                            "data" : "0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "gateway" : [
+                    {
+                        "data" : "10.0.12.0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-string" : [
+                        {
+                            "data" : "Next hop"
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "session" : [
+                        {
+                            "data" : "320"
+                        }
+                        ]
+                    }
+                    ], 
+                    "rt-entry-state" : [
+                    {
+                        "data" : "Active Ext"
+                    }
+                    ], 
+                    "local-as" : [
+                    {
+                        "data" : "65002"
+                    }
+                    ], 
+                    "peer-as" : [
+                    {
+                        "data" : "65001"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "task-name" : [
+                    {
+                        "data" : "BGP_65001.10.0.12.0"
+                    }
+                    ], 
+                    "announce-bits" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "announce-tasks" : [
+                    {
+                        "data" : "0-KRT 1-BGP_RT_Background "
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "AS path: 65001 I"
+                    }
+                    ], 
+                    "bgp-path-attributes" : [
+                    {
+                        "attr-as-path-effective" : [
+                        {
+                            "aspath-effective-string" : [
+                            {
+                                "data" : "AS path: "
+                            }
+                            ], 
+                            "attr-value" : [
+                            {
+                                "data" : "65001 I"
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ], 
+                    "communities" : [
+                    {
+                        "community" : [
+                        {
+                            "data" : "65001:4013"
                         }, 
                         {
                             "data" : "65001:9100"
@@ -21246,17 +21708,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21323,8 +21785,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -21471,17 +21933,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21548,8 +22010,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:51", 
-                        "attributes" : {"junos:seconds" : "171"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -21696,17 +22158,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21773,8 +22235,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "validation-state" : [
@@ -21921,17 +22383,17 @@
                         ], 
                         "nh-index" : [
                         {
-                            "data" : "590"
+                            "data" : "589"
                         }
                         ], 
                         "nh-address" : [
                         {
-                            "data" : "0x91c0b14"
+                            "data" : "0x91be814"
                         }
                         ], 
                         "nh-reference-count" : [
                         {
-                            "data" : "196"
+                            "data" : "202"
                         }
                         ], 
                         "nh-session-id" : [
@@ -21998,8 +22460,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "2:50", 
-                        "attributes" : {"junos:seconds" : "170"}
+                        "data" : "3:15", 
+                        "attributes" : {"junos:seconds" : "195"}
                     }
                     ], 
                     "metric" : [

--- a/snapshots/junos_then_action_conflicts/show/dut/show_route_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/dut/show_route_|_display_json.txt
@@ -12,17 +12,17 @@
             ], 
             "destination-count" : [
             {
-                "data" : "113"
+                "data" : "117"
             }
             ], 
             "total-route-count" : [
             {
-                "data" : "113"
+                "data" : "117"
             }
             ], 
             "active-route-count" : [
             {
-                "data" : "102"
+                "data" : "104"
             }
             ], 
             "holddown-route-count" : [
@@ -32,7 +32,7 @@
             ], 
             "hidden-route-count" : [
             {
-                "data" : "11"
+                "data" : "13"
             }
             ], 
             "rt" : [
@@ -72,8 +72,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:53", 
-                        "attributes" : {"junos:seconds" : "593"}
+                        "data" : "00:08:18", 
+                        "attributes" : {"junos:seconds" : "498"}
                     }
                     ], 
                     "nh" : [
@@ -129,8 +129,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:08:32", 
-                        "attributes" : {"junos:seconds" : "512"}
+                        "data" : "00:07:07", 
+                        "attributes" : {"junos:seconds" : "427"}
                     }
                     ], 
                     "nh" : [
@@ -186,8 +186,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:08:32", 
-                        "attributes" : {"junos:seconds" : "512"}
+                        "data" : "00:07:07", 
+                        "attributes" : {"junos:seconds" : "427"}
                     }
                     ], 
                     "nh-type" : [
@@ -243,8 +243,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:08:32", 
-                        "attributes" : {"junos:seconds" : "512"}
+                        "data" : "00:07:07", 
+                        "attributes" : {"junos:seconds" : "427"}
                     }
                     ], 
                     "nh" : [
@@ -300,8 +300,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:08:32", 
-                        "attributes" : {"junos:seconds" : "512"}
+                        "data" : "00:07:07", 
+                        "attributes" : {"junos:seconds" : "427"}
                     }
                     ], 
                     "nh-type" : [
@@ -357,8 +357,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -434,8 +434,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -511,8 +511,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -588,8 +588,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -665,8 +665,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -742,8 +742,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -819,8 +819,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -896,8 +896,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -973,8 +973,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1050,8 +1050,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1127,8 +1127,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1204,8 +1204,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1281,8 +1281,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1358,8 +1358,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1435,8 +1435,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1512,8 +1512,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1589,8 +1589,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1666,8 +1666,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1734,8 +1734,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1811,8 +1811,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1888,8 +1888,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -1965,8 +1965,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2042,8 +2042,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2119,8 +2119,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2196,8 +2196,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2273,8 +2273,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2350,8 +2350,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -2432,8 +2432,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -2514,8 +2514,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2591,8 +2591,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2668,8 +2668,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2745,8 +2745,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2822,8 +2822,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2899,8 +2899,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -2976,8 +2976,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -3053,8 +3053,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -3130,8 +3130,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -3207,8 +3207,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -3284,8 +3284,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -3366,8 +3366,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -3448,8 +3448,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -3530,8 +3530,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -3612,8 +3612,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -3694,8 +3694,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -3776,8 +3776,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -3858,8 +3858,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -3940,8 +3940,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -4022,8 +4022,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -4104,8 +4104,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -4186,8 +4186,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -4268,8 +4268,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -4350,8 +4350,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -4432,8 +4432,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "med" : [
@@ -4514,8 +4514,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -4591,8 +4591,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -4668,8 +4668,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -4745,8 +4745,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -4822,8 +4822,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -4899,8 +4899,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -4976,8 +4976,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5053,8 +5053,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5130,8 +5130,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5207,8 +5207,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5284,8 +5284,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5361,8 +5361,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5438,8 +5438,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5515,8 +5515,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5592,8 +5592,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5669,8 +5669,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5746,8 +5746,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5823,8 +5823,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5900,8 +5900,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -5977,8 +5977,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6054,8 +6054,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6131,8 +6131,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6208,8 +6208,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6285,8 +6285,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6362,8 +6362,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6439,8 +6439,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6516,8 +6516,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6593,8 +6593,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6670,8 +6670,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6747,8 +6747,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6824,8 +6824,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6901,8 +6901,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -6978,8 +6978,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -7055,8 +7055,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:10", 
+                        "attributes" : {"junos:seconds" : "190"}
                     }
                     ], 
                     "local-preference" : [
@@ -7132,8 +7132,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7209,8 +7209,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7286,8 +7286,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7363,8 +7363,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7440,8 +7440,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7517,8 +7517,162 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.171.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.172.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7594,8 +7748,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7671,8 +7825,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:47", 
-                        "attributes" : {"junos:seconds" : "167"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7748,8 +7902,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:46", 
-                        "attributes" : {"junos:seconds" : "166"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "local-preference" : [
@@ -7825,8 +7979,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:02:46", 
-                        "attributes" : {"junos:seconds" : "166"}
+                        "data" : "00:03:11", 
+                        "attributes" : {"junos:seconds" : "191"}
                     }
                     ], 
                     "med" : [
@@ -7941,8 +8095,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:19", 
+                        "attributes" : {"junos:seconds" : "499"}
                     }
                     ], 
                     "nh" : [
@@ -8003,8 +8157,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:20", 
+                        "attributes" : {"junos:seconds" : "500"}
                     }
                     ], 
                     "nh" : [
@@ -8060,8 +8214,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:20", 
+                        "attributes" : {"junos:seconds" : "500"}
                     }
                     ], 
                     "nh-type" : [
@@ -8151,8 +8305,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:23", 
+                        "attributes" : {"junos:seconds" : "503"}
                     }
                     ], 
                     "metric" : [
@@ -8208,8 +8362,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:23", 
+                        "attributes" : {"junos:seconds" : "503"}
                     }
                     ], 
                     "metric" : [
@@ -8265,8 +8419,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:23", 
+                        "attributes" : {"junos:seconds" : "503"}
                     }
                     ], 
                     "metric" : [
@@ -8318,8 +8472,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:23", 
+                        "attributes" : {"junos:seconds" : "503"}
                     }
                     ], 
                     "metric" : [
@@ -8375,8 +8529,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:23", 
+                        "attributes" : {"junos:seconds" : "503"}
                     }
                     ], 
                     "metric" : [
@@ -8432,8 +8586,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:23", 
+                        "attributes" : {"junos:seconds" : "503"}
                     }
                     ], 
                     "metric" : [
@@ -8519,8 +8673,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:19", 
+                        "attributes" : {"junos:seconds" : "499"}
                     }
                     ], 
                     "nh" : [
@@ -8581,8 +8735,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:20", 
+                        "attributes" : {"junos:seconds" : "500"}
                     }
                     ], 
                     "nh" : [
@@ -8638,8 +8792,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:20", 
+                        "attributes" : {"junos:seconds" : "500"}
                     }
                     ], 
                     "nh-type" : [
@@ -8663,7 +8817,7 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "rt-destination" : [
                 {
-                    "data" : "fe80::e00:d7ff:fe6e:ff00/128", 
+                    "data" : "fe80::e00:d7ff:fe0d:9a00/128", 
                     "attributes" : {"junos:emit" : "emit"}
                 }
                 ], 
@@ -8696,8 +8850,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:54", 
-                        "attributes" : {"junos:seconds" : "594"}
+                        "data" : "00:08:20", 
+                        "attributes" : {"junos:seconds" : "500"}
                     }
                     ], 
                     "nh-type" : [

--- a/snapshots/junos_then_action_conflicts/show/sender/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/sender/show_bgp_neighbor_|_display_json.txt
@@ -7,7 +7,7 @@
             "attributes" : {"junos:style" : "detail"}, 
             "peer-address" : [
             {
-                "data" : "10.0.12.1+50390"
+                "data" : "10.0.12.1+179"
             }
             ], 
             "peer-as" : [
@@ -17,7 +17,7 @@
             ], 
             "local-address" : [
             {
-                "data" : "10.0.12.0+179"
+                "data" : "10.0.12.0+64680"
             }
             ], 
             "local-as" : [
@@ -71,7 +71,7 @@
             ], 
             "last-error" : [
             {
-                "data" : "Cease"
+                "data" : "None"
             }
             ], 
             "bgp-option-information" : [
@@ -127,32 +127,13 @@
             ], 
             "elapsed-time" : [
             {
-                "data" : "9:22", 
-                "attributes" : {"junos:seconds" : "562"}
+                "data" : "8:00", 
+                "attributes" : {"junos:seconds" : "480"}
             }
             ], 
             "recv-ebgp-origin-validation-state" : [
             {
                 "data" : "Reject"
-            }
-            ], 
-            "bgp-error" : [
-            {
-                "name" : [
-                {
-                    "data" : "Cease"
-                }
-                ], 
-                "send-count" : [
-                {
-                    "data" : "1"
-                }
-                ], 
-                "receive-count" : [
-                {
-                    "data" : "0"
-                }
-                ]
             }
             ], 
             "bgp-malformed-attributes" : [
@@ -326,7 +307,7 @@
                 ], 
                 "advertised-prefix-count" : [
                 {
-                    "data" : "108"
+                    "data" : "112"
                 }
                 ]
             }
@@ -385,29 +366,29 @@
                 ], 
                 "bgp-nlri-recv-time" : [
                 {
-                    "data" : "0"
+                    "data" : "1"
                 }
                 ]
             }
             ], 
             "last-received" : [
             {
-                "data" : "0"
+                "data" : "15"
             }
             ], 
             "last-sent" : [
             {
-                "data" : "15"
+                "data" : "12"
             }
             ], 
             "last-checked" : [
             {
-                "data" : "562"
+                "data" : "480"
             }
             ], 
             "input-messages" : [
             {
-                "data" : "24"
+                "data" : "20"
             }
             ], 
             "input-updates" : [
@@ -422,7 +403,7 @@
             ], 
             "input-octets" : [
             {
-                "data" : "504"
+                "data" : "428"
             }
             ], 
             "output-messages" : [
@@ -432,7 +413,7 @@
             ], 
             "output-updates" : [
             {
-                "data" : "108"
+                "data" : "112"
             }
             ], 
             "output-refreshes" : [
@@ -442,7 +423,7 @@
             ], 
             "output-octets" : [
             {
-                "data" : "6290"
+                "data" : "6430"
             }
             ], 
             "bgp-output-queue" : [

--- a/snapshots/junos_then_action_conflicts/show/sender/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/sender/show_interfaces_|_display_json.txt
@@ -179,18 +179,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "aa:c1:ab:b5:86:0c"
+                "data" : "aa:c1:ab:36:ab:cb"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "aa:c1:ab:b5:86:0c"
+                "data" : "aa:c1:ab:36:ab:cb"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:09:04 ago)", 
-                "attributes" : {"junos:seconds" : "544"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:53 ago)", 
+                "attributes" : {"junos:seconds" : "473"}
             }
             ], 
             "traffic-statistics" : [
@@ -208,7 +208,7 @@
                 ], 
                 "output-bps" : [
                 {
-                    "data" : "136"
+                    "data" : "160"
                 }
                 ], 
                 "output-pps" : [
@@ -314,12 +314,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "58"
+                        "data" : "47"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "56"
+                        "data" : "60"
                     }
                     ]
                 }
@@ -1372,18 +1372,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:01"
+                "data" : "2c:6b:f5:ae:97:01"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:01"
+                "data" : "2c:6b:f5:ae:97:01"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:57 UTC (00:09:07 ago)", 
-                "attributes" : {"junos:seconds" : "547"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:54 ago)", 
+                "attributes" : {"junos:seconds" : "474"}
             }
             ], 
             "traffic-statistics" : [
@@ -1703,18 +1703,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:02"
+                "data" : "2c:6b:f5:ae:97:02"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:02"
+                "data" : "2c:6b:f5:ae:97:02"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:57 UTC (00:09:07 ago)", 
-                "attributes" : {"junos:seconds" : "547"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:55 ago)", 
+                "attributes" : {"junos:seconds" : "475"}
             }
             ], 
             "traffic-statistics" : [
@@ -2034,18 +2034,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:03"
+                "data" : "2c:6b:f5:ae:97:03"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:03"
+                "data" : "2c:6b:f5:ae:97:03"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:57 UTC (00:09:07 ago)", 
-                "attributes" : {"junos:seconds" : "547"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:55 ago)", 
+                "attributes" : {"junos:seconds" : "475"}
             }
             ], 
             "traffic-statistics" : [
@@ -2365,18 +2365,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:04"
+                "data" : "2c:6b:f5:ae:97:04"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:04"
+                "data" : "2c:6b:f5:ae:97:04"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:57 UTC (00:09:07 ago)", 
-                "attributes" : {"junos:seconds" : "547"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:56 ago)", 
+                "attributes" : {"junos:seconds" : "476"}
             }
             ], 
             "traffic-statistics" : [
@@ -2696,18 +2696,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:05"
+                "data" : "2c:6b:f5:ae:97:05"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:05"
+                "data" : "2c:6b:f5:ae:97:05"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:57 UTC (00:09:08 ago)", 
-                "attributes" : {"junos:seconds" : "548"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:57 ago)", 
+                "attributes" : {"junos:seconds" : "477"}
             }
             ], 
             "traffic-statistics" : [
@@ -3027,18 +3027,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:06"
+                "data" : "2c:6b:f5:ae:97:06"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:06"
+                "data" : "2c:6b:f5:ae:97:06"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:57 UTC (00:09:08 ago)", 
-                "attributes" : {"junos:seconds" : "548"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:58 ago)", 
+                "attributes" : {"junos:seconds" : "478"}
             }
             ], 
             "traffic-statistics" : [
@@ -3121,12 +3121,12 @@
                 ], 
                 "local-index" : [
                 {
-                    "data" : "342"
+                    "data" : "340"
                 }
                 ], 
                 "snmp-index" : [
                 {
-                    "data" : "548"
+                    "data" : "546"
                 }
                 ], 
                 "if-config-flags" : [
@@ -3358,18 +3358,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:07"
+                "data" : "2c:6b:f5:ae:97:07"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:07"
+                "data" : "2c:6b:f5:ae:97:07"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:57 UTC (00:09:08 ago)", 
-                "attributes" : {"junos:seconds" : "548"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:58 ago)", 
+                "attributes" : {"junos:seconds" : "478"}
             }
             ], 
             "traffic-statistics" : [
@@ -3452,12 +3452,12 @@
                 ], 
                 "local-index" : [
                 {
-                    "data" : "340"
+                    "data" : "341"
                 }
                 ], 
                 "snmp-index" : [
                 {
-                    "data" : "546"
+                    "data" : "547"
                 }
                 ], 
                 "if-config-flags" : [
@@ -3689,18 +3689,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:08"
+                "data" : "2c:6b:f5:ae:97:08"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:08"
+                "data" : "2c:6b:f5:ae:97:08"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:57 UTC (00:09:08 ago)", 
-                "attributes" : {"junos:seconds" : "548"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:59 ago)", 
+                "attributes" : {"junos:seconds" : "479"}
             }
             ], 
             "traffic-statistics" : [
@@ -3783,12 +3783,12 @@
                 ], 
                 "local-index" : [
                 {
-                    "data" : "341"
+                    "data" : "342"
                 }
                 ], 
                 "snmp-index" : [
                 {
-                    "data" : "547"
+                    "data" : "548"
                 }
                 ], 
                 "if-config-flags" : [
@@ -4020,18 +4020,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:09"
+                "data" : "2c:6b:f5:ae:97:09"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:09"
+                "data" : "2c:6b:f5:ae:97:09"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:09:08 ago)", 
-                "attributes" : {"junos:seconds" : "548"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:59 ago)", 
+                "attributes" : {"junos:seconds" : "479"}
             }
             ], 
             "traffic-statistics" : [
@@ -4351,18 +4351,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:0a"
+                "data" : "2c:6b:f5:ae:97:0a"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:0a"
+                "data" : "2c:6b:f5:ae:97:0a"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:09:08 ago)", 
-                "attributes" : {"junos:seconds" : "548"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:59 ago)", 
+                "attributes" : {"junos:seconds" : "479"}
             }
             ], 
             "traffic-statistics" : [
@@ -4682,18 +4682,18 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:0b"
+                "data" : "2c:6b:f5:ae:97:0b"
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:0b"
+                "data" : "2c:6b:f5:ae:97:0b"
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:47:58 UTC (00:09:08 ago)", 
-                "attributes" : {"junos:seconds" : "548"}
+                "data" : "2026-05-20 22:09:37 UTC (00:07:59 ago)", 
+                "attributes" : {"junos:seconds" : "479"}
             }
             ], 
             "traffic-statistics" : [
@@ -4924,14 +4924,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:11", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ac:89:11"}
+                "data" : "2c:6b:f5:ae:97:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ae:97:11"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:89:11", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ac:89:11"}
+                "data" : "2c:6b:f5:ae:97:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ae:97:11"}
             }
             ], 
             "interface-flapped" : [
@@ -5378,8 +5378,8 @@
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:46:08 UTC (00:10:58 ago)", 
-                "attributes" : {"junos:seconds" : "658"}
+                "data" : "2026-05-20 22:07:55 UTC (00:09:41 ago)", 
+                "attributes" : {"junos:seconds" : "581"}
             }
             ], 
             "traffic-statistics" : [
@@ -5387,12 +5387,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "61836"
+                    "data" : "59237"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "106154"
+                    "data" : "103771"
                 }
                 ]
             }
@@ -5447,12 +5447,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "60833"
+                        "data" : "58315"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "106155"
+                        "data" : "103781"
                     }
                     ]
                 }
@@ -6901,20 +6901,20 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "0c:00:07:6c:3b:00", 
-                "attributes" : {"junos:format" : "MAC 0c:00:07:6c:3b:00"}
+                "data" : "0c:00:d7:d2:5a:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:d7:d2:5a:00"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "0c:00:07:6c:3b:00", 
-                "attributes" : {"junos:format" : "MAC 0c:00:07:6c:3b:00"}
+                "data" : "0c:00:d7:d2:5a:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:d7:d2:5a:00"}
             }
             ], 
             "interface-flapped" : [
             {
-                "data" : "2026-05-20 18:46:08 UTC (00:10:58 ago)", 
-                "attributes" : {"junos:seconds" : "658"}
+                "data" : "2026-05-20 22:07:55 UTC (00:09:41 ago)", 
+                "attributes" : {"junos:seconds" : "581"}
             }
             ], 
             "traffic-statistics" : [
@@ -6922,12 +6922,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "3312"
+                    "data" : "5502"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "3333"
+                    "data" : "5473"
                 }
                 ]
             }
@@ -6982,12 +6982,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "3286"
+                        "data" : "5502"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "3334"
+                        "data" : "5475"
                     }
                     ]
                 }
@@ -7194,7 +7194,7 @@
                         ], 
                         "ifa-local" : [
                         {
-                            "data" : "fe80::e00:7ff:fe6c:3b00"
+                            "data" : "fe80::e00:d7ff:fed2:5a00"
                         }
                         ], 
                         "in6-addr-flags" : [
@@ -7498,14 +7498,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:90:f0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ac:90:f0"}
+                "data" : "2c:6b:f5:ae:9e:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ae:9e:f0"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:90:f0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ac:90:f0"}
+                "data" : "2c:6b:f5:ae:9e:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ae:9e:f0"}
             }
             ], 
             "interface-flapped" : [
@@ -7912,12 +7912,12 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "input-packets" : [
                 {
-                    "data" : "1309"
+                    "data" : "1213"
                 }
                 ], 
                 "output-packets" : [
                 {
-                    "data" : "1309"
+                    "data" : "1213"
                 }
                 ]
             }
@@ -8204,12 +8204,12 @@
                     "attributes" : {"junos:style" : "brief"}, 
                     "input-packets" : [
                     {
-                        "data" : "1309"
+                        "data" : "1213"
                     }
                     ], 
                     "output-packets" : [
                     {
-                        "data" : "1309"
+                        "data" : "1213"
                     }
                     ]
                 }
@@ -8849,14 +8849,14 @@
             ], 
             "current-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:90:b0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ac:90:b0"}
+                "data" : "2c:6b:f5:ae:9e:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ae:9e:b0"}
             }
             ], 
             "hardware-physical-address" : [
             {
-                "data" : "2c:6b:f5:ac:90:b0", 
-                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ac:90:b0"}
+                "data" : "2c:6b:f5:ae:9e:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:ae:9e:b0"}
             }
             ], 
             "interface-flapped" : [

--- a/snapshots/junos_then_action_conflicts/show/sender/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/sender/show_route_instance_|_display_json.txt
@@ -25,7 +25,7 @@
                 ], 
                 "irib-active-count" : [
                 {
-                    "data" : "111"
+                    "data" : "115"
                 }
                 ], 
                 "irib-holddown-count" : [

--- a/snapshots/junos_then_action_conflicts/show/sender/show_route_protocol_bgp_detail_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/sender/show_route_protocol_bgp_detail_|_display_json.txt
@@ -12,17 +12,17 @@
             ], 
             "destination-count" : [
             {
-                "data" : "111"
+                "data" : "115"
             }
             ], 
             "total-route-count" : [
             {
-                "data" : "111"
+                "data" : "115"
             }
             ], 
             "active-route-count" : [
             {
-                "data" : "111"
+                "data" : "115"
             }
             ], 
             "holddown-route-count" : [

--- a/snapshots/junos_then_action_conflicts/show/sender/show_route_|_display_json.txt
+++ b/snapshots/junos_then_action_conflicts/show/sender/show_route_|_display_json.txt
@@ -12,17 +12,17 @@
             ], 
             "destination-count" : [
             {
-                "data" : "111"
+                "data" : "115"
             }
             ], 
             "total-route-count" : [
             {
-                "data" : "111"
+                "data" : "115"
             }
             ], 
             "active-route-count" : [
             {
-                "data" : "111"
+                "data" : "115"
             }
             ], 
             "holddown-route-count" : [
@@ -72,8 +72,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:10:32", 
-                        "attributes" : {"junos:seconds" : "632"}
+                        "data" : "00:09:10", 
+                        "attributes" : {"junos:seconds" : "550"}
                     }
                     ], 
                     "nh" : [
@@ -129,8 +129,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:12", 
-                        "attributes" : {"junos:seconds" : "552"}
+                        "data" : "00:08:03", 
+                        "attributes" : {"junos:seconds" : "483"}
                     }
                     ], 
                     "nh" : [
@@ -186,8 +186,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:09:12", 
-                        "attributes" : {"junos:seconds" : "552"}
+                        "data" : "00:08:03", 
+                        "attributes" : {"junos:seconds" : "483"}
                     }
                     ], 
                     "nh-type" : [
@@ -243,8 +243,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -291,8 +291,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -339,8 +339,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -387,8 +387,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -435,8 +435,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -483,8 +483,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -531,8 +531,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -579,8 +579,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -627,8 +627,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -675,8 +675,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -723,8 +723,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -771,8 +771,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -819,8 +819,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -867,8 +867,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -915,8 +915,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -963,8 +963,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1011,8 +1011,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1059,8 +1059,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1107,8 +1107,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1155,8 +1155,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1203,8 +1203,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1251,8 +1251,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1299,8 +1299,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1347,8 +1347,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1395,8 +1395,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1443,8 +1443,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1491,8 +1491,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1539,8 +1539,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1587,8 +1587,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1635,8 +1635,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1683,8 +1683,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1731,8 +1731,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1779,8 +1779,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1827,8 +1827,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1875,8 +1875,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1923,8 +1923,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -1971,8 +1971,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2019,8 +2019,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2067,8 +2067,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2115,8 +2115,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2163,8 +2163,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2211,8 +2211,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2259,8 +2259,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2307,8 +2307,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2355,8 +2355,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2403,8 +2403,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2451,8 +2451,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2499,8 +2499,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2547,8 +2547,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2595,8 +2595,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2643,8 +2643,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2691,8 +2691,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2739,8 +2739,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2787,8 +2787,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2835,8 +2835,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2883,8 +2883,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2931,8 +2931,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -2979,8 +2979,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3027,8 +3027,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3075,8 +3075,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3123,8 +3123,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3171,8 +3171,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3219,8 +3219,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3267,8 +3267,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3315,8 +3315,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3363,8 +3363,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3411,8 +3411,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3459,8 +3459,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3507,8 +3507,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3555,8 +3555,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3603,8 +3603,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3651,8 +3651,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3699,8 +3699,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3747,8 +3747,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3795,8 +3795,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3843,8 +3843,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3891,8 +3891,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3939,8 +3939,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -3987,8 +3987,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4035,8 +4035,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4083,8 +4083,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4131,8 +4131,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4179,8 +4179,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4227,8 +4227,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4275,8 +4275,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4323,8 +4323,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4371,8 +4371,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4419,8 +4419,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4467,8 +4467,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4515,8 +4515,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4563,8 +4563,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4611,8 +4611,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4659,8 +4659,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4707,8 +4707,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4755,8 +4755,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4803,8 +4803,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4851,8 +4851,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:52", 
+                        "attributes" : {"junos:seconds" : "232"}
                     }
                     ], 
                     "nh-type" : [
@@ -4899,8 +4899,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -4947,8 +4947,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -4995,8 +4995,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5043,8 +5043,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5091,8 +5091,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5139,8 +5139,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5187,8 +5187,200 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.170.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.171.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.172.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.50.173.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5235,8 +5427,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5283,8 +5475,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5331,8 +5523,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5379,8 +5571,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:03:25", 
-                        "attributes" : {"junos:seconds" : "205"}
+                        "data" : "00:03:53", 
+                        "attributes" : {"junos:seconds" : "233"}
                     }
                     ], 
                     "nh-type" : [
@@ -5461,8 +5653,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:10:31", 
-                        "attributes" : {"junos:seconds" : "631"}
+                        "data" : "00:09:07", 
+                        "attributes" : {"junos:seconds" : "547"}
                     }
                     ], 
                     "nh" : [
@@ -5523,8 +5715,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:10:32", 
-                        "attributes" : {"junos:seconds" : "632"}
+                        "data" : "00:09:11", 
+                        "attributes" : {"junos:seconds" : "551"}
                     }
                     ], 
                     "nh" : [
@@ -5580,8 +5772,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:10:32", 
-                        "attributes" : {"junos:seconds" : "632"}
+                        "data" : "00:09:11", 
+                        "attributes" : {"junos:seconds" : "551"}
                     }
                     ], 
                     "nh-type" : [
@@ -5671,8 +5863,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:10:31", 
-                        "attributes" : {"junos:seconds" : "631"}
+                        "data" : "00:09:07", 
+                        "attributes" : {"junos:seconds" : "547"}
                     }
                     ], 
                     "nh" : [
@@ -5733,8 +5925,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:10:32", 
-                        "attributes" : {"junos:seconds" : "632"}
+                        "data" : "00:09:11", 
+                        "attributes" : {"junos:seconds" : "551"}
                     }
                     ], 
                     "nh" : [
@@ -5790,8 +5982,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:10:32", 
-                        "attributes" : {"junos:seconds" : "632"}
+                        "data" : "00:09:11", 
+                        "attributes" : {"junos:seconds" : "551"}
                     }
                     ], 
                     "nh-type" : [
@@ -5815,7 +6007,7 @@
                 "attributes" : {"junos:style" : "brief"}, 
                 "rt-destination" : [
                 {
-                    "data" : "fe80::e00:7ff:fe6c:3b00/128", 
+                    "data" : "fe80::e00:d7ff:fed2:5a00/128", 
                     "attributes" : {"junos:emit" : "emit"}
                 }
                 ], 
@@ -5848,8 +6040,8 @@
                     ], 
                     "age" : [
                     {
-                        "data" : "00:10:32", 
-                        "attributes" : {"junos:seconds" : "632"}
+                        "data" : "00:09:11", 
+                        "attributes" : {"junos:seconds" : "551"}
                     }
                     ], 
                     "nh-type" : [

--- a/snapshots/junos_then_action_conflicts/source/build/README.md
+++ b/snapshots/junos_then_action_conflicts/source/build/README.md
@@ -1,6 +1,6 @@
 # Build inputs for junos_then_action_conflicts
 
-The 108-term IMPORT policy on dut and the matching tag-and-export
+The 112-term IMPORT policy on dut and the matching tag-and-export
 policy on sender are too large to deploy as a single startup config
 (commit fails at boot, leaving SSH unreachable). The build process is:
 
@@ -9,28 +9,32 @@ policy on sender are too large to deploy as a single startup config
    config is small enough to ship as the final form).
 
 2. **Probe**: `python3 push-terms.py probe-dut`
-   - Bulk-pushes all 108 dut terms via `load set terminal`.
+   - Bulk-pushes all 112 dut terms via `load set terminal`.
    - Runs `commit check`. If it fails, binary-searches the term set
      to isolate each rejection.
    - Writes `commit-results.yaml` with per-term outcome.
 
 3. **Apply**: `python3 push-terms.py apply-dut` and
    `python3 push-terms.py apply-sender`
-   - Pushes the surviving terms (101 on dut, 108 on sender).
-   - Commits.
+   - Pushes the surviving terms (currently all 112 on this
+     vJunos-router build) and commits.
 
 4. **Standard**: `lab_builder validate` + `collect` + `build-snapshot`.
 
 After all steps, `../configs/dut.cfg` and `../configs/sender.cfg`
-are the post-commit retained config (FULL form, with `/* COMMIT-REJECTED */`
-blocks for the 7 rejected terms).
+are the post-commit retained config (FULL form). Any commit-rejected
+terms are wrapped in `/* COMMIT-REJECTED */` blocks. On the current
+vJunos-router build no terms are rejected at commit time — the
+BGP-OUTPUT-QUEUE-PRIORITY actions are silently dropped at load time
+(see README §1 rows 24, 25), so the term itself commits cleanly with
+only its `accept` retained.
 
 ## Files
 
 | File                  | Purpose                                                                                                                                                                                                                       |
 | --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `manifest-N-*.yaml`   | Per-section term definitions (see lab plan §1–§7)                                                                                                                                                                             |
-| `term-metadata.yaml`  | Flat aggregation of all 108 terms (generated)                                                                                                                                                                                 |
+| `term-metadata.yaml`  | Flat aggregation of all 112 terms (generated)                                                                                                                                                                                 |
 | `assemble.py`         | Reads manifests, writes `term-metadata.yaml` and full configs                                                                                                                                                                 |
 | `push-terms.py`       | Drives the probe/apply phases against a running lab                                                                                                                                                                           |
 | `commit-results.yaml` | Per-term commit-check outcome (output of `probe-dut`)                                                                                                                                                                         |

--- a/snapshots/junos_then_action_conflicts/source/build/dut.intended.cfg
+++ b/snapshots/junos_then_action_conflicts/source/build/dut.intended.cfg
@@ -1129,7 +1129,7 @@ policy-options {
             }
         }
         /* ============================================================
-         * §5  (10 terms)
+         * §5  (14 terms)
          * ============================================================ */
         /* term 4001: accept; reject; with mark interleaving */
         term FC-ACCEPT-THEN-REJECT {
@@ -1247,6 +1247,54 @@ policy-options {
                 community add MARK-A;
                 community add MARK-B;
                 accept;
+            }
+        }
+        /* term 4011: next term; next term; with mark interleaving (same-family dedup baseline) */
+        term FC-NEXT-TERM-DEDUP {
+            from {
+                route-filter 10.50.170.0/24 exact;
+            }
+            then {
+                community add MARK-A;
+                next term;
+                community add MARK-B;
+                next term;
+            }
+        }
+        /* term 4012: next policy; next policy; with mark interleaving (same-family dedup baseline) */
+        term FC-NEXT-POLICY-DEDUP {
+            from {
+                route-filter 10.50.171.0/24 exact;
+            }
+            then {
+                community add MARK-A;
+                next policy;
+                community add MARK-B;
+                next policy;
+            }
+        }
+        /* term 4013: next term; next policy; with mark interleaving - which terminator wins? */
+        term FC-NEXT-TERM-THEN-NEXT-POLICY {
+            from {
+                route-filter 10.50.172.0/24 exact;
+            }
+            then {
+                community add MARK-A;
+                next term;
+                community add MARK-B;
+                next policy;
+            }
+        }
+        /* term 4014: next policy; next term; with mark interleaving - which terminator wins? */
+        term FC-NEXT-POLICY-THEN-NEXT-TERM {
+            from {
+                route-filter 10.50.173.0/24 exact;
+            }
+            then {
+                community add MARK-A;
+                next policy;
+                community add MARK-B;
+                next term;
             }
         }
         /* ============================================================

--- a/snapshots/junos_then_action_conflicts/source/build/manifest-5-flowcontrol.yaml
+++ b/snapshots/junos_then_action_conflicts/source/build/manifest-5-flowcontrol.yaml
@@ -114,6 +114,50 @@ terms:
       - "community add MARK-B"
       - "accept"
 
+  - term_id: 4011
+    prefix: "10.50.170.0/24"
+    name: "FC-NEXT-TERM-DEDUP"
+    description: "next term; next term; with mark interleaving (same-family dedup baseline)"
+    section: "5"
+    actions:
+      - "community add MARK-A"
+      - "next term"
+      - "community add MARK-B"
+      - "next term"
+
+  - term_id: 4012
+    prefix: "10.50.171.0/24"
+    name: "FC-NEXT-POLICY-DEDUP"
+    description: "next policy; next policy; with mark interleaving (same-family dedup baseline)"
+    section: "5"
+    actions:
+      - "community add MARK-A"
+      - "next policy"
+      - "community add MARK-B"
+      - "next policy"
+
+  - term_id: 4013
+    prefix: "10.50.172.0/24"
+    name: "FC-NEXT-TERM-THEN-NEXT-POLICY"
+    description: "next term; next policy; with mark interleaving - which terminator wins?"
+    section: "5"
+    actions:
+      - "community add MARK-A"
+      - "next term"
+      - "community add MARK-B"
+      - "next policy"
+
+  - term_id: 4014
+    prefix: "10.50.173.0/24"
+    name: "FC-NEXT-POLICY-THEN-NEXT-TERM"
+    description: "next policy; next term; with mark interleaving - which terminator wins?"
+    section: "5"
+    actions:
+      - "community add MARK-A"
+      - "next policy"
+      - "community add MARK-B"
+      - "next term"
+
   # §6 Forwarding-only (3 terms)
   - term_id: 5001
     prefix: "10.50.180.0/24"

--- a/snapshots/junos_then_action_conflicts/source/build/push-terms.py
+++ b/snapshots/junos_then_action_conflicts/source/build/push-terms.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Per-term commit-check iterator for junos-then-action-conflicts.
 
-Runs on the EC2 host. For each of the 108 dut terms (and 108 sender
+Runs on the EC2 host. For each of the 112 dut terms (and 112 sender
 TAG-N terms, plus per-prefix static routes), pushes the term's set-
 form lines, runs `commit check`, and records:
 
@@ -21,7 +21,7 @@ The expected workflow on EC2 is:
   3. Run:  python3 push-terms.py apply-dut
        -> pushes only the accepts to dut and commits.
   4. Run:  python3 push-terms.py apply-sender
-       -> pushes the 108 sender terms (all should accept since they
+       -> pushes the 112 sender terms (all should accept since they
           only reference the marker community, which is benign).
   5. Validate, collect, build snapshot.
 """
@@ -210,7 +210,7 @@ def _bulk_commit_check(
     Junos commit-check error messages identify the offending hierarchy
     line. If the failed lines reference a `term <NAME>` we can map back
     to term_index by name. Bulk-push is fast (~30s for ~600 lines)
-    versus per-term (~10s × 108 = 18 min).
+    versus per-term (~10s × 112 = 18 min).
     """
     for line in all_lines:
         line = line.strip()
@@ -257,8 +257,8 @@ def probe_dut() -> None:
     """Bulk-push every term to dut. Binary-search any rejection.
 
     Strategy:
-      1. Push all 108 terms' set lines in one shot.
-      2. Run `commit check`. If it succeeds, all 108 accept.
+      1. Push all 112 terms' set lines in one shot.
+      2. Run `commit check`. If it succeeds, all 112 accept.
       3. If it fails, binary-search: split candidate set in half, push
          each half from a clean state, repeat until each rejected term
          is isolated. Bulk-success on the surviving subset becomes the

--- a/snapshots/junos_then_action_conflicts/source/build/term-metadata.yaml
+++ b/snapshots/junos_then_action_conflicts/source/build/term-metadata.yaml
@@ -972,6 +972,50 @@ terms:
       - accept
     input_communities: []
     description: Two side-effects + terminator (sanity baseline) - both should survive
+  - term_id: 4011
+    section: "5"
+    prefix: 10.50.170.0/24
+    name: FC-NEXT-TERM-DEDUP
+    actions:
+      - community add MARK-A
+      - next term
+      - community add MARK-B
+      - next term
+    input_communities: []
+    description: next term; next term; with mark interleaving (same-family dedup baseline)
+  - term_id: 4012
+    section: "5"
+    prefix: 10.50.171.0/24
+    name: FC-NEXT-POLICY-DEDUP
+    actions:
+      - community add MARK-A
+      - next policy
+      - community add MARK-B
+      - next policy
+    input_communities: []
+    description: next policy; next policy; with mark interleaving (same-family dedup baseline)
+  - term_id: 4013
+    section: "5"
+    prefix: 10.50.172.0/24
+    name: FC-NEXT-TERM-THEN-NEXT-POLICY
+    actions:
+      - community add MARK-A
+      - next term
+      - community add MARK-B
+      - next policy
+    input_communities: []
+    description: next term; next policy; with mark interleaving - which terminator wins?
+  - term_id: 4014
+    section: "5"
+    prefix: 10.50.173.0/24
+    name: FC-NEXT-POLICY-THEN-NEXT-TERM
+    actions:
+      - community add MARK-A
+      - next policy
+      - community add MARK-B
+      - next term
+    input_communities: []
+    description: next policy; next term; with mark interleaving - which terminator wins?
   - term_id: 5001
     section: "6"
     prefix: 10.50.180.0/24

--- a/snapshots/junos_then_action_conflicts/source/configs/dut.cfg
+++ b/snapshots/junos_then_action_conflicts/source/configs/dut.cfg
@@ -1129,7 +1129,7 @@ policy-options {
             }
         }
         /* ============================================================
-         * §5  (10 terms)
+         * §5  (14 terms)
          * ============================================================ */
         /* term 4001: accept; reject; with mark interleaving */
         term FC-ACCEPT-THEN-REJECT {
@@ -1247,6 +1247,54 @@ policy-options {
                 community add MARK-A;
                 community add MARK-B;
                 accept;
+            }
+        }
+        /* term 4011: next term; next term; with mark interleaving (same-family dedup baseline) */
+        term FC-NEXT-TERM-DEDUP {
+            from {
+                route-filter 10.50.170.0/24 exact;
+            }
+            then {
+                community add MARK-A;
+                next term;
+                community add MARK-B;
+                next term;
+            }
+        }
+        /* term 4012: next policy; next policy; with mark interleaving (same-family dedup baseline) */
+        term FC-NEXT-POLICY-DEDUP {
+            from {
+                route-filter 10.50.171.0/24 exact;
+            }
+            then {
+                community add MARK-A;
+                next policy;
+                community add MARK-B;
+                next policy;
+            }
+        }
+        /* term 4013: next term; next policy; with mark interleaving - which terminator wins? */
+        term FC-NEXT-TERM-THEN-NEXT-POLICY {
+            from {
+                route-filter 10.50.172.0/24 exact;
+            }
+            then {
+                community add MARK-A;
+                next term;
+                community add MARK-B;
+                next policy;
+            }
+        }
+        /* term 4014: next policy; next term; with mark interleaving - which terminator wins? */
+        term FC-NEXT-POLICY-THEN-NEXT-TERM {
+            from {
+                route-filter 10.50.173.0/24 exact;
+            }
+            then {
+                community add MARK-A;
+                next policy;
+                community add MARK-B;
+                next term;
             }
         }
         /* ============================================================

--- a/snapshots/junos_then_action_conflicts/source/configs/sender.cfg
+++ b/snapshots/junos_then_action_conflicts/source/configs/sender.cfg
@@ -126,6 +126,10 @@ routing-options {
         route 10.50.167.0/24 discard;  /* term 4008 FC-REJECT-THEN-DEFAULT-ACTION-ACCEPT */
         route 10.50.168.0/24 discard;  /* term 4009 FC-ACCEPT-THEN-SIDE-EFFECT */
         route 10.50.169.0/24 discard;  /* term 4010 FC-TWO-SIDE-EFFECTS-THEN-ACCEPT */
+        route 10.50.170.0/24 discard;  /* term 4011 FC-NEXT-TERM-DEDUP */
+        route 10.50.171.0/24 discard;  /* term 4012 FC-NEXT-POLICY-DEDUP */
+        route 10.50.172.0/24 discard;  /* term 4013 FC-NEXT-TERM-THEN-NEXT-POLICY */
+        route 10.50.173.0/24 discard;  /* term 4014 FC-NEXT-POLICY-THEN-NEXT-TERM */
         route 10.50.180.0/24 discard;  /* term 5001 FWD-LOAD-BALANCE-DUPLICATE-DIFF */
         route 10.50.181.0/24 discard;  /* term 5002 FWD-MULTIPATH-RESOLVE-DUPLICATE */
         route 10.50.182.0/24 discard;  /* term 5003 FWD-INSTALL-NEXTHOP-DIFF */
@@ -242,6 +246,10 @@ policy-options {
     community MARK-4008 { members 65001:4008; }
     community MARK-4009 { members 65001:4009; }
     community MARK-4010 { members 65001:4010; }
+    community MARK-4011 { members 65001:4011; }
+    community MARK-4012 { members 65001:4012; }
+    community MARK-4013 { members 65001:4013; }
+    community MARK-4014 { members 65001:4014; }
     community MARK-5001 { members 65001:5001; }
     community MARK-5002 { members 65001:5002; }
     community MARK-5003 { members 65001:5003; }
@@ -1293,6 +1301,46 @@ policy-options {
             }
             then {
                 community add MARK-4010;
+                accept;
+            }
+        }
+        term TAG-4011 {
+            from {
+                protocol static;
+                route-filter 10.50.170.0/24 exact;
+            }
+            then {
+                community add MARK-4011;
+                accept;
+            }
+        }
+        term TAG-4012 {
+            from {
+                protocol static;
+                route-filter 10.50.171.0/24 exact;
+            }
+            then {
+                community add MARK-4012;
+                accept;
+            }
+        }
+        term TAG-4013 {
+            from {
+                protocol static;
+                route-filter 10.50.172.0/24 exact;
+            }
+            then {
+                community add MARK-4013;
+                accept;
+            }
+        }
+        term TAG-4014 {
+            from {
+                protocol static;
+                route-filter 10.50.173.0/24 exact;
+            }
+            then {
+                community add MARK-4014;
                 accept;
             }
         }

--- a/snapshots/junos_then_action_conflicts/source/topology.clab.yml
+++ b/snapshots/junos_then_action_conflicts/source/topology.clab.yml
@@ -12,11 +12,11 @@
 #     lo0 1.1.1.1/32                            lo0 2.2.2.2/32                              lo0 3.3.3.3/32
 #     link 10.0.12.0/31                         link 10.0.12.1/31  10.0.23.0/31              link 10.0.23.1/31
 #
-# - sender: originates ~108 /24 test prefixes via static, exports to dut
+# - sender: originates ~112 /24 test prefixes via static, exports to dut
 #   tagged with per-term marker community 65001:<term-id> (and §4
 #   conflict-shape input payloads where required).
 # - dut: imports from sender via a single policy-statement IMPORT whose
-#   ~108 terms each test one same-attribute conflict shape, then exports
+#   ~112 terms each test one same-attribute conflict shape, then exports
 #   pass-through to collector.
 # - collector: applies a transparent IMPORT-ALL policy so every marker
 #   community propagates intact, used as the observation point for §5


### PR DESCRIPTION
Adds 4 §5 flow-control terms (4011-4014) to characterize how Junos
collapses `next term` and `next policy` when both appear in the same
`then` block, and recollects the lab on vJunos-router 25.4R1.12.

Finding: `next term` and `next policy` are the same attribute family.
A `then` block holds at most one of them — dedup collapses identical
pairs, and last-wins applies to mixed pairs:

- 4011 NT;NT  -> NT       (dedup; route falls through, no propagation)
- 4012 NP;NP  -> NP       (dedup; route returns to BGP, propagates)
- 4013 NT;NP  -> NP       (last-wins; route propagates)
- 4014 NP;NT  -> NT       (last-wins; route falls through)

In all four cases both side-effect `community add` lines survive the
collapse and execute around the surviving terminator; the collector
RIB confirms the runtime winner via which marker communities arrive.
This generalizes the §1/§2/§3 last-wins rule to the named-disposition
family and tightens the README synthesis prose accordingly.

Prompt:
```
Let's iterate on the lab we just added in HEAD. Let's add a setup to
resolve next-term vs next-policy (order sensitive or not, and which
one wins?)
```

---
**Stack**:
- #190 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*