### PR TITLE
sros: discover VPRN names for collection instead of hardcoding "red"

### DIFF
--- a/src/lab_builder/collector.py
+++ b/src/lab_builder/collector.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
-from lab_builder.config import command_to_filename
+from lab_builder.config import DynamicCommandGroup, command_to_filename
 from lab_builder.device import run_command
 from lab_builder.models import CollectedData, NodeInfo
 
@@ -13,6 +14,9 @@ def collect_node(node: NodeInfo, output_dir: Path) -> CollectedData:
     """Collect all show commands from a single node.
 
     Saves each command output to a file matching the lab-validation naming convention.
+    First runs the profile's static ``show_commands``, then expands any
+    ``dynamic_command_groups`` (device-driven per-instance state, e.g. SR OS
+    VPRNs) into concrete commands and collects those too.
     """
     node_dir = output_dir / node.name
     node_dir.mkdir(parents=True, exist_ok=True)
@@ -20,20 +24,73 @@ def collect_node(node: NodeInfo, output_dir: Path) -> CollectedData:
     result = CollectedData(node=node.name, output_dir=node_dir)
 
     for command in node.profile.show_commands:
-        filename = command_to_filename(command)
-        filepath = node_dir / filename
+        _collect_command(node, node_dir, command, result)
 
-        try:
-            output = run_command(node, command, timeout=60)
-            filepath.write_text(output)
-            result.files.append(filename)
-            print(f"  {node.name}: collected {filename}")
-        except Exception as e:
-            error_msg = f"{command}: {e}"
-            result.errors.append(error_msg)
-            print(f"  {node.name}: FAILED {filename} - {e}")
+    for group in node.profile.dynamic_command_groups:
+        for command in _expand_dynamic_group(node, group, result):
+            _collect_command(node, node_dir, command, result)
 
     return result
+
+
+def _collect_command(
+    node: NodeInfo, node_dir: Path, command: str, result: CollectedData
+) -> str | None:
+    """Run one command, write its output, and record it. Returns the output."""
+    filename = command_to_filename(command)
+    filepath = node_dir / filename
+    try:
+        output = run_command(node, command, timeout=60)
+        filepath.write_text(output)
+        result.files.append(filename)
+        print(f"  {node.name}: collected {filename}")
+        return output
+    except Exception as e:
+        error_msg = f"{command}: {e}"
+        result.errors.append(error_msg)
+        print(f"  {node.name}: FAILED {filename} - {e}")
+        return None
+
+
+def _expand_dynamic_group(
+    node: NodeInfo, group: DynamicCommandGroup, result: CollectedData
+) -> list[str]:
+    """Run a group's discovery command and expand its templates per instance.
+
+    The discovery command's output is saved like any other (so the raw
+    enumeration is part of the snapshot), then parsed for instance names. Each
+    name is substituted into every command template. A discovery failure or an
+    empty/unparseable result yields no expanded commands -- a node with no such
+    instances simply collects nothing extra.
+    """
+    node_dir = result.output_dir
+    output = _collect_command(node, node_dir, group.discovery_command, result)
+    if output is None:
+        return []
+
+    names = _parse_instance_names(output, group)
+    if names:
+        print(f"  {node.name}: discovered {group.discovery_json_key} {names}")
+
+    commands: list[str] = []
+    for name in names:
+        for template in group.command_templates:
+            commands.append(template.format(name=name))
+    return commands
+
+
+def _parse_instance_names(output: str, group: DynamicCommandGroup) -> list[str]:
+    """Extract instance names from a discovery command's JSON output."""
+    try:
+        obj = json.loads(output)
+    except json.JSONDecodeError:
+        return []
+    entries = obj.get(group.discovery_json_key, []) if isinstance(obj, dict) else []
+    names: list[str] = []
+    for entry in entries:
+        if isinstance(entry, dict) and group.name_field in entry:
+            names.append(entry[group.name_field])
+    return names
 
 
 def collect_all(nodes: list[NodeInfo], output_dir: Path) -> list[CollectedData]:

--- a/src/lab_builder/config.py
+++ b/src/lab_builder/config.py
@@ -7,6 +7,36 @@ from dataclasses import dataclass, field
 
 
 @dataclass(frozen=True)
+class DynamicCommandGroup:
+    """A two-phase, device-driven command expansion for the collector.
+
+    Some operational state lives under a per-instance subtree whose instance
+    names are not known until the device is queried (e.g. SR OS service VPRNs:
+    each VPRN's route-table/interface state is at ``/state service vprn
+    "<name>" ...``, and the set of ``<name>`` depends on the running config).
+    Hardcoding the names means a lab whose VPRN is not literally the expected
+    name is silently never collected.
+
+    A DynamicCommandGroup runs ``discovery_command`` once, reads the list of
+    instance names out of its JSON, then expands each of ``command_templates``
+    (a ``{name}`` placeholder per discovered name) into a concrete command the
+    collector runs like any other. This mirrors the dynamic per-VRF handling
+    other vendors get for free from their ``... vrf all`` commands; SR OS has
+    no ``vrf all`` form for these state paths, so the collector discovers the
+    names itself.
+    """
+
+    # Command whose JSON output enumerates the instances (run once).
+    discovery_command: str
+    # Top-level JSON key holding the list of instance objects.
+    discovery_json_key: str
+    # Field in each instance object that holds the instance name.
+    name_field: str
+    # Per-instance command templates; "{name}" is replaced with each name.
+    command_templates: list[str]
+
+
+@dataclass(frozen=True)
 class VendorProfile:
     """Configuration for a specific network OS in containerlab."""
 
@@ -20,6 +50,10 @@ class VendorProfile:
     interface_prefix: str
     interface_offset: int  # eth1 maps to <prefix>0/0/<offset>
     show_commands: list[str] = field(default_factory=list)
+    # Device-driven command expansion run after show_commands (see
+    # DynamicCommandGroup). Empty for vendors whose per-instance state is
+    # reachable with a single wildcard/"vrf all" command.
+    dynamic_command_groups: list[DynamicCommandGroup] = field(default_factory=list)
     config_command: str = ""
     boot_timeout_seconds: int = 600
 
@@ -158,12 +192,9 @@ NOKIA_SRSIM = VendorProfile(
         'info json /state router "Base" bgp rib',
         'info json /state router "Base" ospf *',
         'info json /state router "Base" isis *',
-        # VPRN (multi-VRF) state: a non-Base router instance is a `service vprn`, whose
-        # state lives under `/state service vprn "<name>" ...` (same nokia-state schema as
-        # the Base route-table/interface trees). Captures the "red" VPRN used by the L7 lab;
-        # returns empty when no such VPRN is configured.
-        'info json /state service vprn "red" route-table',
-        'info json /state service vprn "red" interface *',
+        # VPRN (multi-VRF) state is collected dynamically -- see
+        # dynamic_command_groups below -- because the VPRN names are not known
+        # until the device is queried.
         # Plain-text (human-readable, cross-check):
         "show version",
         "show router interface",
@@ -172,6 +203,32 @@ NOKIA_SRSIM = VendorProfile(
         "show router bgp routes",
         "show router ospf neighbor",
         "show router isis adjacency",
+    ],
+    # VPRN (multi-VRF) state. A non-Base router instance is a `service vprn`
+    # whose state lives under `/state service vprn "<name>" ...` (same
+    # nokia-state schema as the Base route-table/interface trees). Unlike the
+    # `vrf all` form other vendors expose, SR OS has no single command that
+    # dumps every VPRN's route-table unwrapped, so the collector first
+    # enumerates the VPRN names (the `oper-service-id` wildcard returns just
+    # name + id per VPRN -- a small payload) and then collects each VPRN's
+    # route-table and interface state under the same per-VPRN filename the
+    # SrosValidator already discovers by glob. A device with no VPRN yields no
+    # names and therefore no files (vs. the old hardcoded `"red"` probe that
+    # wrote an empty `{}` on every node). CONFIRMED LIVE on SR-SIM 26.3.R1
+    # (2026-06-11): the discovery wildcard returns
+    # {"nokia-state:vprn": [{"service-name": "RED", "oper-service-id": 100}, ...]}
+    # and the per-VPRN paths return the unwrapped nokia-state:unicast /
+    # nokia-state:interface shapes the parsers expect.
+    dynamic_command_groups=[
+        DynamicCommandGroup(
+            discovery_command="info json /state service vprn * oper-service-id",
+            discovery_json_key="nokia-state:vprn",
+            name_field="service-name",
+            command_templates=[
+                'info json /state service vprn "{name}" route-table',
+                'info json /state service vprn "{name}" interface *',
+            ],
+        ),
     ],
     config_command="admin show configuration",
     boot_timeout_seconds=600,

--- a/src/lab_validation/parsers/sros/commands/interfaces.py
+++ b/src/lab_validation/parsers/sros/commands/interfaces.py
@@ -11,8 +11,8 @@ def parse_interface_state_json(text: str) -> Sequence[SrosInterface]:
     """Parse ``info json /state router "Base" interface`` into SrosInterfaces.
 
     An empty object (``{}``) is the valid response for an instance with no
-    interfaces — e.g. the ``vprn "red"`` state path probed on every SR OS
-    collection when no such VPRN is configured — and yields no interfaces.
+    interfaces (e.g. a VPRN whose interface state path returns nothing) and
+    yields no interfaces.
     """
     obj = json.loads(text)
     if not obj:

--- a/src/lab_validation/parsers/sros/commands/routes.py
+++ b/src/lab_validation/parsers/sros/commands/routes.py
@@ -27,8 +27,8 @@ def parse_route_table_json(
     """
     obj = json.loads(text)
     # An empty object ({}) is the valid response for an instance with no route
-    # table — e.g. the vprn "red" state path probed on every SR OS collection
-    # when no such VPRN is configured — and yields no routes.
+    # table (e.g. a VPRN whose route-table state path returns nothing) and
+    # yields no routes.
     if not obj:
         return []
     assert _UNICAST in obj, f"missing '{_UNICAST}' in route-table state"

--- a/tests/lab_builder/test_collector.py
+++ b/tests/lab_builder/test_collector.py
@@ -1,0 +1,163 @@
+"""Tests for lab_builder.collector, focused on dynamic command expansion."""
+
+from __future__ import annotations
+
+import lab_builder.collector as collector
+from lab_builder.collector import collect_node
+from lab_builder.config import (
+    NOKIA_SRSIM,
+    VendorProfile,
+    command_to_filename,
+)
+from lab_builder.models import NodeInfo
+
+# A discovery command output naming two VPRNs (the live SR-SIM 26.3.R1 shape).
+_VPRN_DISCOVERY_JSON = """{
+    "nokia-state:vprn": [
+        {"service-name": "RED", "oper-service-id": 100},
+        {"service-name": "BLUE", "oper-service-id": 200}
+    ]
+}"""
+
+
+def _sros_node() -> NodeInfo:
+    return NodeInfo(
+        name="r1",
+        kind="nokia_srsim",
+        profile=NOKIA_SRSIM,
+        management_ip="172.20.20.2",
+    )
+
+
+def _fake_run_command(responses: dict[str, str]):
+    """Build a run_command stub that returns canned text keyed by command.
+
+    Unlisted commands return "{}" (the SR OS empty-state shape), so a test only
+    needs to spell out the commands it cares about.
+    """
+
+    def _run(node: NodeInfo, command: str, timeout: int = 60) -> str:
+        return responses.get(command, "{}")
+
+    return _run
+
+
+def test_collect_node_discovers_and_expands_vprns(tmp_path, monkeypatch) -> None:
+    # The SR OS profile enumerates VPRNs from the device, then collects each
+    # VPRN's route-table and interface state under the per-VPRN filename the
+    # SrosValidator discovers by glob.
+    responses = {
+        "info json /state service vprn * oper-service-id": _VPRN_DISCOVERY_JSON,
+        'info json /state service vprn "RED" route-table': '{"red-rt": true}',
+        'info json /state service vprn "RED" interface *': '{"red-if": true}',
+        'info json /state service vprn "BLUE" route-table': '{"blue-rt": true}',
+        'info json /state service vprn "BLUE" interface *': '{"blue-if": true}',
+    }
+    monkeypatch.setattr(collector, "run_command", _fake_run_command(responses))
+
+    result = collect_node(_sros_node(), tmp_path)
+
+    node_dir = tmp_path / "r1"
+    # Discovery output is saved as part of the snapshot.
+    assert (node_dir / "info_json_state_service_vprn_oper-service-id.txt").is_file()
+    # Per-VPRN files exist for both discovered names, with the expected content.
+    for name, tag in [("RED", "red"), ("BLUE", "blue")]:
+        rt = node_dir / f"info_json_state_service_vprn_{name}_route-table.txt"
+        intf = node_dir / f"info_json_state_service_vprn_{name}_interface.txt"
+        assert rt.read_text() == f'{{"{tag}-rt": true}}'
+        assert intf.read_text() == f'{{"{tag}-if": true}}'
+        assert rt.name in result.files
+        assert intf.name in result.files
+    assert not result.errors
+
+
+def test_collect_node_no_vprns_collects_no_vprn_files(tmp_path, monkeypatch) -> None:
+    # A device with no VPRN yields an empty discovery list and therefore no
+    # per-VPRN files -- an improvement over the old hardcoded "red" probe, which
+    # wrote an empty {} file on every node regardless.
+    responses = {
+        "info json /state service vprn * oper-service-id": '{"nokia-state:vprn": []}',
+    }
+    monkeypatch.setattr(collector, "run_command", _fake_run_command(responses))
+
+    result = collect_node(_sros_node(), tmp_path)
+
+    node_dir = tmp_path / "r1"
+    vprn_files = list(node_dir.glob("info_json_state_service_vprn_*_route-table.txt"))
+    assert vprn_files == []
+    # The discovery command itself still ran and was saved.
+    assert (node_dir / "info_json_state_service_vprn_oper-service-id.txt").is_file()
+    assert not result.errors
+
+
+def test_collect_node_discovery_failure_is_recorded_not_fatal(
+    tmp_path, monkeypatch
+) -> None:
+    # If the discovery command errors, the group expands to nothing and the
+    # error is recorded; static commands are unaffected.
+    def _run(node: NodeInfo, command: str, timeout: int = 60) -> str:
+        if "service vprn" in command:
+            raise RuntimeError("boom")
+        return "{}"
+
+    monkeypatch.setattr(collector, "run_command", _run)
+
+    result = collect_node(_sros_node(), tmp_path)
+
+    node_dir = tmp_path / "r1"
+    assert list(node_dir.glob("info_json_state_service_vprn_*")) == []
+    assert any("oper-service-id" in e for e in result.errors)
+    # A static command still produced a file.
+    assert (node_dir / "info_json_state_system.txt").is_file()
+
+
+def test_collect_node_unparseable_discovery_yields_no_expansion(
+    tmp_path, monkeypatch
+) -> None:
+    responses = {
+        "info json /state service vprn * oper-service-id": "not json at all",
+    }
+    monkeypatch.setattr(collector, "run_command", _fake_run_command(responses))
+
+    result = collect_node(_sros_node(), tmp_path)
+
+    node_dir = tmp_path / "r1"
+    assert list(node_dir.glob("info_json_state_service_vprn_*_route-table.txt")) == []
+    # The (unparseable) discovery output was still saved; no error -- an empty
+    # or malformed enumeration just means "no instances".
+    assert (node_dir / "info_json_state_service_vprn_oper-service-id.txt").is_file()
+    assert not result.errors
+
+
+def test_collect_node_no_dynamic_groups(tmp_path, monkeypatch) -> None:
+    # A profile without dynamic groups behaves exactly like the static path.
+    profile = VendorProfile(
+        name="x",
+        containerlab_kind="x",
+        default_username="u",
+        default_password="p",
+        netmiko_device_type="t",
+        interface_prefix="",
+        interface_offset=0,
+        show_commands=["show version"],
+    )
+    node = NodeInfo(name="n", kind="x", profile=profile, management_ip="1.2.3.4")
+    monkeypatch.setattr(
+        collector, "run_command", _fake_run_command({"show version": "v1"})
+    )
+
+    result = collect_node(node, tmp_path)
+
+    assert (tmp_path / "n" / "show_version.txt").read_text() == "v1"
+    assert result.files == ["show_version.txt"]
+
+
+def test_expanded_filenames_match_validator_glob() -> None:
+    # The per-VPRN filenames the collector writes must match the pattern the
+    # SrosValidator globs (info_json_state_service_vprn_<name>_route-table.txt
+    # and _interface.txt) so discovery flows straight through to validation.
+    group = NOKIA_SRSIM.dynamic_command_groups[0]
+    for template in group.command_templates:
+        filename = command_to_filename(template.format(name="RED"))
+        assert filename.startswith("info_json_state_service_vprn_RED_")
+        assert filename.endswith(("_route-table.txt", "_interface.txt"))

--- a/tests/lab_builder/test_config.py
+++ b/tests/lab_builder/test_config.py
@@ -44,6 +44,32 @@ class TestCommandToFilename:
 
 
 class TestNokiaSrsimProfile:
+    def test_no_hardcoded_vprn_name_in_show_commands(self) -> None:
+        # VPRN state is collected dynamically (the names are discovered from the
+        # device), so no specific VPRN name -- formerly the literal "red" -- may
+        # be baked into the static command list.
+        for cmd in NOKIA_SRSIM.show_commands:
+            assert "service vprn" not in cmd, cmd
+
+    def test_vprn_discovery_group_is_wired(self) -> None:
+        groups = NOKIA_SRSIM.dynamic_command_groups
+        assert len(groups) == 1
+        group = groups[0]
+        # Discovery enumerates names from the state tree's vprn list.
+        assert group.discovery_command.startswith("info json /state service vprn *")
+        assert group.discovery_json_key == "nokia-state:vprn"
+        assert group.name_field == "service-name"
+        # Each template has a single {name} slot and targets the per-VPRN state
+        # paths the SrosValidator consumes.
+        templates = group.command_templates
+        assert any("route-table" in t for t in templates)
+        assert any("interface *" in t for t in templates)
+        for t in templates:
+            assert t.count("{name}") == 1, t
+            assert t.format(name="RED").startswith(
+                'info json /state service vprn "RED" '
+            )
+
     def test_state_commands_use_info_json_with_modifier_before_path(self) -> None:
         # SR OS JSON output is `info json /state ...` -- the `json` modifier comes
         # BEFORE the path. Putting it AFTER (`info /state ... json`) makes SR OS parse


### PR DESCRIPTION
The nokia_srsim collector hardcoded `info json /state service vprn
"red" route-table` / `interface *` in its show_commands, so a lab whose
VPRN was not literally named "red" was silently never collected. Other
vendors avoid this because their `... vrf all` commands return every VRF
in one blob; SR OS has no such unwrapped form for the per-VPRN state
paths, so the collector has to enumerate the names itself.

Add a DynamicCommandGroup to VendorProfile: a discovery command whose
JSON output names the instances, plus per-instance command templates the
collector expands once the names are known. Wire it for SR-OS VPRNs --
discover via `info json /state service vprn * oper-service-id` (a small
name+id payload), then collect each VPRN's route-table and interface
state under the same per-VPRN filename SrosValidator already discovers by
glob. A node with no VPRN yields no names and therefore no files, instead
of the old hardcoded probe that wrote an empty `{}` on every node.

The SrosValidator and parsers are unchanged: the generated filenames
(info_json_state_service_vprn_<name>_route-table.txt etc.) already match
the validator's glob. The discovery wildcard and per-VPRN shapes were
confirmed live on SR-SIM 26.3.R1: the wildcard returns
{"nokia-state:vprn": [{"service-name": "RED", ...}, ...]} and the
per-VPRN paths return the unwrapped nokia-state:unicast /
nokia-state:interface the parsers expect.

----

Prompt:
```
It seems like in SR-OS validation, we are *hardcoding* the set of
VRPN/VRFs to collect data from. In other vendors, like I think NX-OS,
this is dynamic -- the list of VRFs is fetched and processed, then we
iteratively collect and validate each. Can we fix that for SR-OS as
well?
```

Confirmed the discovery command and per-VPRN state shapes on a live
single-node SR-SIM lab, then validated the full path end to end by
recollecting the sros_services lab: pe1/pe3 auto-discovered RED/BLUE and
captured real per-VPRN state; pe2/pe4/p1/p2 (no VPRN) wrote no per-VPRN
files. The DynamicCommandGroup abstraction is reusable for the next
vendor with a discover-then-iterate state tree.
