### PR TITLE
sros: mirror VRF-qualified VPRN interface names; un-sickbay pe1/pe3

### DIFF
--- a/snapshots/sros_services/source/README.md
+++ b/snapshots/sros_services/source/README.md
@@ -48,16 +48,16 @@ warnings** and `fileParseStatus` PASSED.
 
 ### Modeled and validated (the underlay)
 
-| Feature                                                                               | Status                                           |
-| ------------------------------------------------------------------------------------- | ------------------------------------------------ |
-| Interfaces (port / router-interface split, system loopback)                           | modeled                                          |
-| OSPF (areas, interfaces, metric, preference)                                          | modeled                                          |
-| IS-IS (L2, area-address, interface metric, **system-id auto-derived from system IP**) | modeled (system-id derivation added by this lab) |
-| BGP iBGP sessions (group→neighbor inheritance, system-sourced)                        | modeled                                          |
-| Static routes (next-hop, blackhole)                                                   | modeled                                          |
-| `service vprn` → VRF (RED/BLUE)                                                       | modeled                                          |
-| per-VPRN interfaces with a name reused across VRFs                                    | only one VRF's copy modeled (lab-validation#203) |
-| policy-options (policy-statement, community, prefix-list)                             | modeled                                          |
+| Feature                                                                               | Status                                                 |
+| ------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Interfaces (port / router-interface split, system loopback)                           | modeled                                                |
+| OSPF (areas, interfaces, metric, preference)                                          | modeled                                                |
+| IS-IS (L2, area-address, interface metric, **system-id auto-derived from system IP**) | modeled (system-id derivation added by this lab)       |
+| BGP iBGP sessions (group→neighbor inheritance, system-sourced)                        | modeled                                                |
+| Static routes (next-hop, blackhole)                                                   | modeled                                                |
+| `service vprn` → VRF (RED/BLUE)                                                       | modeled                                                |
+| per-VPRN interfaces with a name reused across VRFs                                    | modeled (qualified `<vrf>.<name>`, lab-validation#203) |
+| policy-options (policy-statement, community, prefix-list)                             | modeled                                                |
 
 ### Parses but not converted — sickbay'd (the service overlay)
 
@@ -84,8 +84,10 @@ ground truth (the `info json /state` captures): interfaces, iBGP session state,
 and config-format on all six nodes, plus the main-RIB route comparison where it
 is not sickbay'd.
 
-- **BGP sessions and config-format validate clean on all six nodes; interfaces
-  validate clean on the four underlay-only nodes.**
+- **BGP sessions, config-format, and interfaces validate clean on all six
+  nodes** — including pe1/pe3's VPRN interface name reused across the RED and
+  BLUE VRFs (`to-cea` / `to-cez`), which Batfish models under its VRF-qualified
+  name `<vrf>.<name>` so both copies survive (batfish/lab-validation#203).
 - **Main-RIB route comparison is sickbay'd on all six nodes**
   (`../validation/sickbay.yaml`), for two distinct documented reasons:
   - **IGP ECMP** (p1/p2/pe2/pe4): SR OS installs a single best path per prefix
@@ -98,6 +100,3 @@ is not sickbay'd.
     their RIBs carry bgp-vpn (MPLS L3VPN) routes (batfish/batfish#9991) and IES
     interface + SR-ISIS-tunnel static routes (batfish/batfish#9996) that the VI
     model does not reproduce.
-- **Interface comparison is sickbay'd on pe1/pe3** (batfish/lab-validation#203):
-  each reuses a VPRN interface name across the RED and BLUE VRFs (`to-cea` /
-  `to-cez`), and Batfish keeps only the first-configured VRF's copy.

--- a/snapshots/sros_services/validation/sickbay.yaml
+++ b/snapshots/sros_services/validation/sickbay.yaml
@@ -17,18 +17,13 @@
 #    (https://github.com/batfish/batfish/issues/9996). pe1/pe3 also exhibit the
 #    ECMP gap, but #9991/#9996 already cover their whole-test sickbay.
 #
-# 3. VPRN interface name reused across VRFs (pe1/pe3). pe1 configures interface
-#    "to-cea" in both the RED and BLUE VPRNs (pe3: "to-cez"); the device has it
-#    in both VRFs with distinct addresses, but Batfish keys interfaces by name
-#    per node and keeps only the first-configured one (BLUE), dropping the RED
-#    instance. So test_interface_properties for pe1/pe3 sees a device interface
-#    Batfish does not model. Tracked:
-#    https://github.com/batfish/lab-validation/issues/203
-#
 # The underlay control plane (interfaces, OSPF/IS-IS adjacencies, the iBGP mesh,
-# config-format) validates on all six nodes. On pe1/pe3 the main-RIB route
-# comparison (#9991/#9996) and the interface comparison (#203) are sickbay'd;
-# elsewhere only the main-RIB ECMP gap (#200) is.
+# config-format) validates on all six nodes, including pe1/pe3's reused VPRN
+# interface name ("to-cea"/"to-cez" in both RED and BLUE): Batfish now models a
+# non-Base interface under its VRF-qualified name (<vrf>.<name>), so both copies
+# survive (lab-validation#203, fixed). On pe1/pe3 only the main-RIB route
+# comparison (#9991/#9996) is sickbay'd; elsewhere only the main-RIB ECMP gap
+# (#200) is.
 entries:
   - hostname: p1
     test_name: test_main_rib_routes
@@ -54,11 +49,3 @@ entries:
     test_name: test_main_rib_routes
     skip:
       reason: https://github.com/batfish/batfish/issues/9991
-  - hostname: pe1
-    test_name: test_interface_properties
-    skip:
-      reason: https://github.com/batfish/lab-validation/issues/203
-  - hostname: pe3
-    test_name: test_interface_properties
-    skip:
-      reason: https://github.com/batfish/lab-validation/issues/203

--- a/src/lab_validation/validators/SrosValidator.py
+++ b/src/lab_validation/validators/SrosValidator.py
@@ -18,6 +18,7 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import AbstractSet, Any
 
+import attr
 from pybatfish.datamodel import (
     NextHop,
     NextHopDiscard,
@@ -332,13 +333,31 @@ class SrosValidator(VendorValidator):
         # VPRN (multi-VRF) interfaces, if collected: a file named
         # info_json_state_service_vprn_<name>_interface.txt holds the VPRN's L3
         # interfaces (same schema as Base). Batfish models them as interfaces in
-        # the VPRN's VRF; interface comparison is by name, so include them so the
-        # VPRN interfaces are validated, not flagged as extra Batfish interfaces.
+        # the VPRN's VRF; include them so the VPRN interfaces are validated, not
+        # flagged as extra Batfish interfaces.
         for vprn_path in sorted(
             self.device_path.glob("info_json_state_service_vprn_*_interface.txt")
         ):
-            interfaces.extend(parse_interface_state_json(vprn_path.read_text()))
+            interfaces.extend(self._parse_vprn_interfaces(vprn_path))
         return interfaces
+
+    @staticmethod
+    def _parse_vprn_interfaces(vprn_path: Path) -> Sequence[SrosInterface]:
+        """Parse a VPRN interface state file, qualifying each name with its VRF.
+
+        SR OS scopes interface names per router instance, so the same name (e.g.
+        ``to-cea``) can appear in two VPRNs. Batfish keys interfaces by name per
+        node, so it models a non-Base (VPRN) interface under the qualified name
+        ``<vrf>.<name>`` (see SrosConversions.viInterfaceName). Mirror that here so
+        the comparison pairs by the same name and reused names are not collapsed.
+        """
+        vrf = SrosValidator._vprn_name_from_filename(
+            vprn_path.name, suffix="_interface.txt"
+        )
+        return [
+            attr.evolve(iface, name=f"{vrf}.{iface.name}")
+            for iface in parse_interface_state_json(vprn_path.read_text())
+        ]
 
     def _parse_routes(self) -> Sequence[SrosIpRoute]:
         path = self.device_path / self.ROUTE_TABLE_FILENAME
@@ -367,8 +386,11 @@ class SrosValidator(VendorValidator):
             if_path = (
                 self.device_path / f"info_json_state_service_vprn_{vrf}_interface.txt"
             )
+            # Resolve VPRN route egress interfaces to their qualified VI names
+            # (<vrf>.<name>), matching Batfish's NextHopInterface (see
+            # _parse_vprn_interfaces).
             ifmap = (
-                self._if_index_map(parse_interface_state_json(if_path.read_text()))
+                self._if_index_map(self._parse_vprn_interfaces(if_path))
                 if if_path.is_file()
                 else {}
             )
@@ -380,10 +402,14 @@ class SrosValidator(VendorValidator):
         return {i.if_index: i.name for i in interfaces if i.if_index is not None}
 
     @staticmethod
-    def _vprn_name_from_filename(filename: str) -> str:
-        """Extract the VPRN service-name from its route-table state filename."""
+    def _vprn_name_from_filename(
+        filename: str, suffix: str = "_route-table.txt"
+    ) -> str:
+        """Extract the VPRN service-name from its per-VPRN state filename."""
         prefix = "info_json_state_service_vprn_"
-        suffix = "_route-table.txt"
+        assert filename.startswith(prefix) and filename.endswith(suffix), (
+            f"unexpected VPRN state filename: {filename}"
+        )
         return filename[len(prefix) : -len(suffix)]
 
     def _parse_bgp_routes(self) -> Sequence[SrosBgpRoute]:

--- a/tests/lab_validation/validators/test_SrosValidator.py
+++ b/tests/lab_validation/validators/test_SrosValidator.py
@@ -573,6 +573,34 @@ def test_get_runtime_data(tmp_path) -> None:
     assert rt.interfaces["system"].bandwidth is None
 
 
+def _interface_state_json(name: str, address: str) -> str:
+    # Minimal `info json /state ... interface` payload with one L3 interface.
+    return (
+        '{"nokia-state:interface": [{'
+        f'"interface-name": "{name}", "oper-state": "up", "if-index": 5, '
+        f'"ipv4": {{"oper-state": "up", "primary": {{"oper-address": "{address}"}}}}'
+        "}]}"
+    )
+
+
+def test_parse_interfaces_qualifies_reused_vprn_names(tmp_path) -> None:
+    # The same interface name in two VPRNs must yield two distinct, VRF-qualified
+    # interfaces (matching Batfish's <vrf>.<name>), not collapse to one. (#203)
+    (tmp_path / SrosValidator.INTERFACE_FILENAME).write_text(
+        _interface_state_json("system", "10.10.10.1")
+    )
+    (tmp_path / "info_json_state_service_vprn_RED_interface.txt").write_text(
+        _interface_state_json("to-cea", "192.168.30.254")
+    )
+    (tmp_path / "info_json_state_service_vprn_BLUE_interface.txt").write_text(
+        _interface_state_json("to-cea", "192.168.40.254")
+    )
+    by_name = {i.name: i for i in SrosValidator(tmp_path)._parse_interfaces()}
+    assert set(by_name) == {"system", "RED.to-cea", "BLUE.to-cea"}
+    assert by_name["RED.to-cea"].primary_address == "192.168.30.254"
+    assert by_name["BLUE.to-cea"].primary_address == "192.168.40.254"
+
+
 def test_parse_helpers_assert_on_missing_file(tmp_path) -> None:
     # The parse helpers crash (not silently degrade) when a state file is absent.
     v = SrosValidator(tmp_path)


### PR DESCRIPTION
Batfish now models a non-Base (VPRN) interface under its VRF-qualified
name <vrf>.<name>, since SR-OS scopes interface names per router
instance and a name reused across two VPRNs would otherwise collide
(batfish/batfish, this branch). Mirror that in SrosValidator: parse each
VPRN interface state file with its name qualified by the service-name,
including the if-index->name map used to resolve VPRN route egress
interfaces.

With both sides naming the reused interface consistently, the
sros_services interface comparison passes on pe1/pe3 (each reuses to-cea
/ to-cez across RED and BLUE). Drop the two test_interface_properties
sickbay entries and update the lab README's per-VPRN-interface row.

Fixes batfish/lab-validation#203.

----

Prompt:
```
Let's fix the interface duplicating naming across VPRN bug you just
filed, and make that part of the lab pass. (See recent PR to
lab-validation). I think the idiomatic fix is to name both interfaces
<vrf>.<iface> when collisions happen
```

Refined in conversation: name all non-Base VPRN interfaces <vrf>.<iface>
unconditionally (not only on collision), matching the Batfish-side fix.
