### PR TITLE
sros: drop internal phase/rung markers from lab docs and comments

### DIFF
--- a/snapshots/sros_bgp_policy/source/topology.clab.yml
+++ b/snapshots/sros_bgp_policy/source/topology.clab.yml
@@ -1,7 +1,7 @@
-# L5 — BGP policy depth: Nokia SR-SIM (SR OS) + Arista cEOS.
+# BGP policy depth: Nokia SR-SIM (SR OS) + Arista cEOS.
 #
-# Climbs the SR-OS ladder rung L5 (P8-LADDER.md): reuses the two-router eBGP
-# topology and gives r1 a richer eBGP export policy that sets community, MED
+# Reuses the two-router eBGP topology and gives r1 a richer eBGP export policy
+# that sets community, MED
 # (metric), and an as-path-prepend, plus a `through`-type prefix-list match.
 # The cEOS oracle (r2) validates the attributes that cross the eBGP session
 # (community / MED / as-path) on the routes it learns from r1, and exercises

--- a/snapshots/sros_ibgp/source/topology.clab.yml
+++ b/snapshots/sros_ibgp/source/topology.clab.yml
@@ -1,7 +1,7 @@
-# L3 — iBGP: Nokia SR-SIM + Arista cEOS + second Nokia SR-SIM.
+# iBGP: Nokia SR-SIM + Arista cEOS + second Nokia SR-SIM.
 #
-# Climbs the SR-OS ladder rung L3 (P8-LADDER.md): adds an iBGP session between
-# two SR-OS routers in AS 65001 (r1 and r3) on top of the r1<->r2 eBGP session.
+# Adds an iBGP session between two SR-OS routers in AS 65001 (r1 and r3) on top
+# of the r1<->r2 eBGP session.
 # Exercises the SR-OS iBGP default-accept path (no import policy on the iBGP
 # group) and type-internal peering, distinct from eBGP default-reject.
 #

--- a/snapshots/sros_isis/source/topology.clab.yml
+++ b/snapshots/sros_isis/source/topology.clab.yml
@@ -1,6 +1,6 @@
 # ISIS single-area (L2): two Nokia SR-SIM (SR OS) routers.
 #
-# New ladder rung: IS-IS, the one IGP captured in state but not yet modeled in
+# IS-IS, the one IGP captured in state but not yet modeled in
 # Batfish (the FromProtocol enum aside). Mirrors the sros_ospf lab's two-SR-SIM
 # design (avoids cross-vendor IGP config quirks; reuses the `info json /state
 # router "Base" isis *` capture). r1 and r3 form an L2 adjacency over a

--- a/snapshots/sros_misconfig/source/topology.clab.yml
+++ b/snapshots/sros_misconfig/source/topology.clab.yml
@@ -1,13 +1,13 @@
-# L8 — Deliberate misconfigurations: Nokia SR-SIM (SR OS) + Arista cEOS.
+# Deliberate misconfigurations: Nokia SR-SIM (SR OS) + Arista cEOS.
 #
-# Climbs the SR-OS ladder rung L8 (P8-LADDER.md): the eBGP topology, but r1 is
+# The eBGP topology, but r1 is
 # deliberately misconfigured with an AS mismatch — r1's ebgp group sets
 # peer-as 65099, but r2 is AS 65002 — so the eBGP session never establishes
 # (the device sits in Connect/Active). r1's import/export reference valid
 # policies, so the only thing keeping the routes from flowing is the dead
 # session.
 #
-# NOTE: the rung was originally specced to also carry an undefined-policy
+# NOTE: this lab was originally specced to also carry an undefined-policy
 # reference, but SR-OS enforces the policy leafref at commit and REJECTS a
 # reference to a non-existent policy-statement (MGMT_CORE #224), aborting the
 # whole startup config. So a committed config cannot contain an undefined

--- a/snapshots/sros_ospf/source/topology.clab.yml
+++ b/snapshots/sros_ospf/source/topology.clab.yml
@@ -1,8 +1,8 @@
-# L2 — OSPF single area: two Nokia SR-SIM routers.
+# OSPF single area: two Nokia SR-SIM routers.
 #
-# Climbs the SR-OS ladder rung L2 (P8-LADDER.md): r1 and r3 (both SR-OS) run
+# r1 and r3 (both SR-OS) run
 # OSPF in area 0 over a point-to-point link, each advertising its system
-# loopback. First greenfield IGP rung — exercises OspfProcess/area/interface
+# loopback. Exercises OspfProcess/area/interface
 # conversion and OSPF route validation in the main RIB.
 #
 # Topology:

--- a/snapshots/sros_redist/source/topology.clab.yml
+++ b/snapshots/sros_redist/source/topology.clab.yml
@@ -1,6 +1,6 @@
-# L6 — Redistribution: Nokia SR-SIM (SR OS) + Arista cEOS.
+# Redistribution: Nokia SR-SIM (SR OS) + Arista cEOS.
 #
-# Climbs the SR-OS ladder rung L6 (P8-LADDER.md): r1 has a static route and an
+# r1 has a static route and an
 # eBGP export policy that redistributes static routes into BGP (from protocol
 # name [static]). The cEOS oracle (r2) validates that the redistributed static
 # prefix appears in r2's BGP table with the right origin/as-path.

--- a/snapshots/sros_rr/source/topology.clab.yml
+++ b/snapshots/sros_rr/source/topology.clab.yml
@@ -1,6 +1,6 @@
-# L4 — BGP route reflection: three Nokia SR-SIM routers in AS 65001.
+# BGP route reflection: three Nokia SR-SIM routers in AS 65001.
 #
-# Climbs the SR-OS ladder rung L4 (P8-LADDER.md): r1 is a route reflector with
+# r1 is a route reflector with
 # two iBGP clients (r2, r3) in one cluster. The clients peer only with r1; they
 # learn each other's system loopback via reflection through r1, even though they
 # have no direct iBGP session.

--- a/snapshots/sros_services/source/README.md
+++ b/snapshots/sros_services/source/README.md
@@ -36,8 +36,7 @@ All SR-SIM configs are the upstream Nokia startup configs verbatim, with one
 addition: a materialized `system security` block (AAA profiles + SSH cipher
 list). SR-SIM auto-generates SSH defaults whose ciphers modern paramiko
 rejects; configuring any `system security` subtree replaces those defaults, so
-the block is required for SSH collection (and carries the admin user). See
-[WORKLOG] for the cipher-negotiation failure this fixes.
+the block is required for SSH collection (and carries the admin user).
 
 ## Batfish coverage: modeled underlay vs. unmodeled service overlay
 

--- a/snapshots/sros_static/source/topology.clab.yml
+++ b/snapshots/sros_static/source/topology.clab.yml
@@ -1,6 +1,6 @@
-# L1 — Interfaces + static routes: Nokia SR-SIM (SR OS) + Arista cEOS.
+# Interfaces + static routes: Nokia SR-SIM (SR OS) + Arista cEOS.
 #
-# Climbs the SR-OS ladder rung L1 (P8-LADDER.md): reuses the two-router eBGP
+# Reuses the two-router eBGP
 # topology and adds, on r1, a loopback interface (lo1) and two static routes
 # (one resolved via next-hop, one blackhole/discard). Validates the SR-OS
 # main-RIB static-route path end to end against device ground truth.

--- a/snapshots/sros_vprn/source/topology.clab.yml
+++ b/snapshots/sros_vprn/source/topology.clab.yml
@@ -1,6 +1,6 @@
-# L7 — Multi-VRF (VPRN): single Nokia SR-SIM.
+# Multi-VRF (VPRN): single Nokia SR-SIM.
 #
-# Climbs the SR-OS ladder rung L7 (P8-LADDER.md): r1 has the Base router plus a
+# r1 has the Base router plus a
 # VPRN service "red" with its own loopback interface in a separate VRF. Validates
 # VRF separation — the VPRN's 172.16.0.1/32 is in the "red" VRF, not in Base, and
 # Base's routes are not in red.

--- a/snapshots/sros_vprn_bgp/source/topology.clab.yml
+++ b/snapshots/sros_vprn_bgp/source/topology.clab.yml
@@ -1,8 +1,8 @@
 # VPRN L3VPN with full RD/RT (MP-BGP vpn-ipv4): two Nokia SR-SIM PEs.
 #
-# Heaviest ladder rung: a real MPLS L3VPN between two SR-OS PEs, validating
+# A real MPLS L3VPN between two SR-OS PEs, validating
 # route-distinguisher + route-target (vrf-target) import/export end to end —
-# the part of multi-VRF that the L7 loopback-only VPRN lab did not exercise.
+# the part of multi-VRF that the loopback-only sros_vprn lab did not exercise.
 #
 # Underlay (router "Base"): OSPF area 0 for PE-PE loopback reachability, LDP
 # for MPLS transport, and an iBGP session between system loopbacks carrying the

--- a/src/lab_validation/validators/SrosValidator.py
+++ b/src/lab_validation/validators/SrosValidator.py
@@ -7,10 +7,9 @@ keyed by the ``nokia-state`` YANG modules, which is the SR OS analog of Junos
 ``show | display json`` — so, like the Arista validator, this is JSON-driven
 rather than CLI-text parsing.
 
-This is the first SR OS validation slice (P5-V): it covers what Batfish models
-after parse/extract/convert — interfaces, the main RIB, and the BGP RIB. SR OS
-``router "Base"`` is the main routing instance, which maps to Batfish's default
-VRF.
+It covers what Batfish models after parse/extract/convert — interfaces, the
+main RIB, and the BGP RIB. SR OS ``router "Base"`` is the main routing
+instance, which maps to Batfish's default VRF.
 """
 
 import math

--- a/tests/lab_validation/parsers/sros/test_sros_parsers.py
+++ b/tests/lab_validation/parsers/sros/test_sros_parsers.py
@@ -239,7 +239,7 @@ def test_parse_bgp_rib_out_carries_advertised_attributes() -> None:
     """The advertised (rib-out-post) routes carry the export-policy-set attributes
     — community, MED, prepended AS-path — joined from their attr-sets.
 
-    Uses the L5 policy lab where r1 sets community 65001:100 / MED 50 / prepend on
+    Uses the BGP-policy lab where r1 sets community 65001:100 / MED 50 / prepend on
     its system prefix and MED 200 on its loopback. This confirms communities and
     advanced BGP attributes ARE present in the SR OS bgp-rib state (on the rib-out
     view), not just observable via the cEOS peer.


### PR DESCRIPTION
Remove the internal planning-doc references (P8-LADDER.md, "ladder rung
L#", "first/second/third pass", a dangling [WORKLOG] link, and the P5-V
phase marker) from the SR-OS lab topology headers, the SrosValidator
docstring, and the parser tests. These leaked from uncommitted planning
files and mean nothing to an external reader; the technical descriptions
they wrapped are preserved.

Comment/doc-only changes; no behavior changes. Companion to the batfish
SR-OS doc cleanup.

----

Prompt:
```
I'm getting ready to put down the SR-OS work. A few checks:

1/ Do we list SR-OS in our supported vendors list in our docs?
2/ Are any of the vendor-specific docs outdated or inaccurate? (the
committed ones).
3/ Do we reference thinks like P4 or L8 that are in our
orchestration/roadmap files but not committed? If so, we should probably
clean up / get rid of those / make them self-contained.
4/ Do all the SR-OS docs read well top-to-bottom as cumulative standlone
docs, not work status or timeline oriented?
```

Followed by: extend the same cleanup into code/test comments and test
configs across both repos.
