### PR TITLE
infra: reach lab instances over SSM, drop the SSH security group

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -20,7 +20,12 @@ The workflow is designed to be driven by Claude Code or run manually.
 ## Prerequisites
 
 - **AWS CLI v2.34+** with configured credentials (`aws configure` or
-  `AWS_PROFILE` environment variable)
+  `AWS_PROFILE` environment variable). The `NestedVirtualization` CPU option
+  the launch script uses requires **2.34 or newer** — older CLIs fail with
+  `Unknown parameter in CpuOptions`.
+- **[session-manager-plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html)**
+  installed locally. Instances are reached over SSM Session Manager (no inbound
+  SSH), and SSH/scp tunnel through it via a `ProxyCommand`.
 - **Juniper vJunos-router qcow2 image** — free download from
   [Juniper vJunos Labs](https://www.juniper.net/us/en/dm/vjunos-labs.html)
   (non-production use, no time limit)
@@ -66,7 +71,7 @@ launch.
 ```bash
 AWS_PROFILE=<profile> ./ec2-launch.sh
 # Wait for setup to complete (~5-10 min)
-ssh -i <key> ubuntu@<ip> 'cat /var/log/ec2-setup-complete'
+ssh lab 'cat /var/log/ec2-setup-complete'   # see "Connecting" below for the `lab` alias
 ```
 
 ### Subsequent Launches
@@ -115,27 +120,44 @@ and broken out in the startup config; see `examples/srsim-ceos-ebgp/`.
 ```bash
 # Launch instance
 AWS_PROFILE=<profile> ./ec2-launch.sh
+```
 
-# Upload topology and configs
-IP=<from launch output>
-KEY=<from launch output>
-ssh -i $KEY ubuntu@$IP 'mkdir -p ~/lab/mylab/configs ~/lab/src'
-scp -i $KEY -r src/lab_builder ubuntu@$IP:~/lab/src/
-scp -i $KEY topology.clab.yml ubuntu@$IP:~/lab/mylab/
-scp -i $KEY configs/*.cfg ubuntu@$IP:~/lab/mylab/configs/
+**Connecting (SSM, no inbound SSH):** the launch script prints a ready-to-use
+`~/.ssh/config` block — paste it in once per launch (the instance-id changes
+each time). It sets up a `lab` host that tunnels SSH through SSM:
+
+```
+Host lab
+    HostName i-0123456789abcdef0      # instance-id from launch output
+    User ubuntu
+    IdentityFile ~/.lab-validation/<key>.pem
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+    ProxyCommand sh -c "aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p --region <region>"
+```
+
+With that in place, `ssh lab` and `scp ... lab:` work like any host (the
+SSM agent registers ~30-60s after the instance starts). Upload the builder
+and inputs:
+
+```bash
+ssh lab 'mkdir -p ~/lab/mylab/configs ~/lab/src'
+scp -r src/lab_builder lab:~/lab/src/
+scp topology.clab.yml lab:~/lab/mylab/
+scp configs/*.cfg lab:~/lab/mylab/configs/
 ```
 
 ### Step 3: Deploy Topology
 
 ```bash
-ssh -i $KEY ubuntu@$IP \
+ssh lab \
     'cd ~/lab/mylab && sudo containerlab deploy -t topology.clab.yml'
 ```
 
 vJunos-router takes 5-10 minutes to boot. Monitor with:
 
 ```bash
-ssh -i $KEY ubuntu@$IP 'sudo containerlab inspect -t ~/lab/mylab/topology.clab.yml'
+ssh lab 'sudo containerlab inspect -t ~/lab/mylab/topology.clab.yml'
 ```
 
 Wait until all nodes show `(healthy)`.
@@ -145,7 +167,7 @@ Wait until all nodes show `(healthy)`.
 Verify SSH access and routing protocol convergence:
 
 ```bash
-ssh -i $KEY ubuntu@$IP \
+ssh lab \
     'cd ~/lab && PYTHONPATH=src python3 -m lab_builder health-check mylab/topology.clab.yml'
 ```
 
@@ -163,7 +185,7 @@ If the topology has a `checks.yaml` file, run validation checks to verify
 the lab is in the expected state before collecting data:
 
 ```bash
-ssh -i $KEY ubuntu@$IP \
+ssh lab \
     'cd ~/lab && PYTHONPATH=src python3 -m lab_builder validate mylab/topology.clab.yml --checks mylab/checks.yaml'
 ```
 
@@ -198,7 +220,7 @@ pitfalls:
 ### Step 5: Collect Show Commands
 
 ```bash
-ssh -i $KEY ubuntu@$IP \
+ssh lab \
     'cd ~/lab && PYTHONPATH=src python3 -m lab_builder collect mylab/topology.clab.yml --output-dir /tmp/collected'
 ```
 
@@ -208,14 +230,14 @@ Files are named to match the lab-validation parser conventions.
 ### Step 6: Build Snapshot
 
 ```bash
-ssh -i $KEY ubuntu@$IP \
+ssh lab \
     'cd ~/lab && PYTHONPATH=src python3 -m lab_builder build-snapshot mylab/topology.clab.yml --name junos_my_feature --collected-dir /tmp/collected --snapshots-dir /tmp/snapshots'
 ```
 
 ### Step 7: Download Snapshot
 
 ```bash
-scp -i $KEY -r ubuntu@$IP:/tmp/snapshots/junos_my_feature snapshots/
+scp -r lab:/tmp/snapshots/junos_my_feature snapshots/
 ```
 
 ### Step 8: Tear Down
@@ -277,11 +299,11 @@ To modify configs without full redeploy (saves 5-10 min boot time):
 
 ```bash
 # Push new config to a node
-ssh -i $KEY ubuntu@$IP \
+ssh lab \
     'cd ~/lab && PYTHONPATH=src python3 -m lab_builder push-config mylab/topology.clab.yml r1 /path/to/new-config.txt'
 
 # Re-collect just that node
-ssh -i $KEY ubuntu@$IP \
+ssh lab \
     'cd ~/lab && PYTHONPATH=src python3 -m lab_builder recollect mylab/topology.clab.yml r1 --output-dir /tmp/collected'
 ```
 
@@ -328,7 +350,7 @@ add or iterate on one:
    `snapshots/junos_evpn_type5/source/checks.yaml` for the schema).
 2. Upload to the EC2 box alongside the topology and run:
    ```bash
-   ssh -i $KEY ubuntu@$IP \
+   ssh lab \
        'cd ~/lab && PYTHONPATH=src python3 -m lab_builder validate mylab/topology.clab.yml --checks mylab/checks.yaml'
    ```
 3. Adjust checks until everything passes against the deployed lab,
@@ -596,6 +618,22 @@ rather than being validated against Batfish. See
 **SSH connection refused after deploy**: vJunos-router takes 5-10 minutes to
 boot. Wait for `(healthy)` in `containerlab inspect` output before attempting
 SSH.
+
+**`ssh lab` hangs or "TargetNotConnected"**: the SSM agent registers ~30-60s
+after the instance enters `running`. Confirm registration with
+`aws ssm describe-instance-information`. If it never registers, the instance
+has no outbound path to the SSM endpoints (it needs the auto-assigned public
+IP + internet gateway, or VPC endpoints) — check it was launched in a subnet
+with internet egress. `Bad SSM document` / `command not found` means the
+local **session-manager-plugin** is missing (see Prerequisites).
+
+**`ec2-launch.sh` says "no AWS region configured"**: set the region via
+`AWS_REGION`/`AWS_DEFAULT_REGION` (the script now honors both) or
+`aws configure set region <region>`. Use the region where the image S3 bucket
+lives.
+
+**`Unknown parameter in CpuOptions: "NestedVirtualization"`**: the AWS CLI is
+older than 2.34 (see Prerequisites); upgrade it.
 
 **Startup config not applied**: Configs must be in curly-brace format, not
 set format. vrnetlab concatenates the config with its init.conf and mounts

--- a/infra/ec2-launch.sh
+++ b/infra/ec2-launch.sh
@@ -5,6 +5,7 @@
 #
 # Prerequisites:
 #   - AWS CLI v2.34+ configured with valid credentials
+#   - session-manager-plugin installed locally (to SSH over SSM)
 #   - VM images uploaded to S3 via upload-image.sh
 #   - A region that supports M8i instances (most US/EU regions)
 #
@@ -13,7 +14,8 @@
 #
 # The script creates:
 #   - An IAM instance profile with S3 read access (for downloading VM images)
-#   - A security group allowing SSH from your current IP
+#     and the SSM managed policy (so the instance is reachable over Session
+#     Manager — outbound 443 only, no inbound SSH and no security group)
 #   - A key pair (if --key-name not provided)
 #   - An EC2 instance with ec2-setup.sh as user-data
 #   - Auto-termination via scheduled shutdown (InstanceInitiatedShutdownBehavior=terminate)
@@ -32,7 +34,6 @@ KEY_NAME=""
 TIMEOUT_HOURS=4
 USE_SPOT=false
 IMAGE_FILTER="all"
-SECURITY_GROUP_NAME="lab-validation-containerlab"
 
 usage() {
     cat <<EOF
@@ -86,11 +87,16 @@ if [[ -f "${STATE_FILE}" ]]; then
     fi
 fi
 
-REGION=$(aws configure get region 2>/dev/null || echo "")
+# Resolve region from the environment first (the AWS CLI honors these but
+# `aws configure get region` does not), then fall back to the configured
+# profile default.
+REGION="${AWS_REGION:-${AWS_DEFAULT_REGION:-$(aws configure get region 2>/dev/null || echo "")}}"
 if [[ -z "${REGION}" ]]; then
     echo "Error: no AWS region configured. Set AWS_DEFAULT_REGION or run 'aws configure'." >&2
     exit 1
 fi
+# Pin every subsequent `aws` call (and the SSM ProxyCommand we print) to it.
+export AWS_DEFAULT_REGION="${REGION}"
 echo "Region: ${REGION}"
 
 # Derive S3 bucket name from account ID
@@ -138,6 +144,14 @@ if ! aws iam get-role --role-name "${ROLE_NAME}" &>/dev/null; then
         }"
 fi
 
+# Attach the SSM managed policy so the instance registers with Session Manager
+# and is reachable over 443 (no inbound SSH). Idempotent — attaching an
+# already-attached policy is a no-op. Done outside the create-role block so it
+# is also applied to roles created before SSM became the default.
+aws iam attach-role-policy \
+    --role-name "${ROLE_NAME}" \
+    --policy-arn "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore" >/dev/null
+
 if ! aws iam get-instance-profile --instance-profile-name "${PROFILE_NAME}" &>/dev/null; then
     echo "Creating instance profile: ${PROFILE_NAME}"
     aws iam create-instance-profile --instance-profile-name "${PROFILE_NAME}" > /dev/null
@@ -165,33 +179,9 @@ if [[ -z "${AMI_ID}" || "${AMI_ID}" == "None" ]]; then
 fi
 echo "AMI: ${AMI_ID}"
 
-# Create or reuse security group
-SG_ID=$(aws ec2 describe-security-groups \
-    --filters "Name=group-name,Values=${SECURITY_GROUP_NAME}" \
-    --query 'SecurityGroups[0].GroupId' \
-    --output text 2>/dev/null || echo "None")
-
-if [[ "${SG_ID}" == "None" || -z "${SG_ID}" ]]; then
-    echo "Creating security group..."
-    SG_ID=$(aws ec2 create-security-group \
-        --group-name "${SECURITY_GROUP_NAME}" \
-        --description "SSH access for lab-validation containerlab instances" \
-        --query 'GroupId' \
-        --output text)
-fi
-
-# Update SSH ingress rule with current IP
-MY_IP=$(curl -s https://checkip.amazonaws.com)
-echo "Your IP: ${MY_IP}"
-
-# Revoke existing SSH rules and add current IP
-aws ec2 revoke-security-group-ingress \
-    --group-id "${SG_ID}" \
-    --protocol tcp --port 22 --cidr 0.0.0.0/0 2>/dev/null || true
-aws ec2 authorize-security-group-ingress \
-    --group-id "${SG_ID}" \
-    --protocol tcp --port 22 --cidr "${MY_IP}/32" 2>/dev/null || true
-echo "Security group: ${SG_ID} (SSH from ${MY_IP}/32)"
+# No security group is created: the instance is reached over AWS Systems
+# Manager (Session Manager), which the SSM agent dials out to over 443. There
+# is no inbound SSH, so the instance keeps the VPC default security group.
 
 # Create key pair if needed
 KEY_FILE=""
@@ -237,7 +227,6 @@ RUN_ARGS=(
     --image-id "${AMI_ID}"
     --instance-type "${INSTANCE_TYPE}"
     --key-name "${KEY_NAME}"
-    --security-group-ids "${SG_ID}"
     --user-data "file://${USER_DATA_FILE}"
     --iam-instance-profile "Name=${PROFILE_NAME}"
     --cpu-options "NestedVirtualization=enabled"
@@ -289,7 +278,6 @@ state = {
     'instance_type': '${INSTANCE_TYPE}',
     'key_name': '${KEY_NAME}',
     'key_file': '${KEY_FILE}',
-    'security_group_id': '${SG_ID}',
     'auto_terminate_after': '${EXPIRY}',
     'spot': True if '${USE_SPOT}' == 'true' else False,
 }
@@ -297,7 +285,11 @@ with open('${STATE_FILE}', 'w') as f:
     json.dump(state, f, indent=2)
 "
 
-SSH_CMD="ssh -i ${KEY_FILE} -o StrictHostKeyChecking=no ubuntu@${PUBLIC_IP}"
+# The instance is reached over SSM Session Manager (no inbound SSH). SSH
+# tunnels through an SSM ProxyCommand keyed on the instance-id; scp and the
+# netmiko-based lab_builder steps then work unchanged. Add a one-off host to
+# ~/.ssh/config so plain `ssh lab` / `scp ... lab:` work:
+SSM_PROXY="sh -c \"aws ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p --region ${REGION}\""
 
 echo ""
 echo "============================================"
@@ -309,14 +301,22 @@ echo "Instance type: ${INSTANCE_TYPE}"
 echo "Images:       ${IMAGE_FILTER}"
 echo "Auto-terminate: ${EXPIRY}"
 echo ""
-echo "SSH command:"
-echo "  ${SSH_CMD}"
+echo "Connect via SSM Session Manager (requires the session-manager-plugin)."
+echo "Add this block to ~/.ssh/config, then use 'ssh lab' / 'scp ... lab:':"
 echo ""
-echo "The instance is bootstrapping (installing Docker, containerlab, KVM tools)."
-echo "This takes ~3-5 minutes. Check progress with:"
-echo "  ${SSH_CMD} 'tail -f /var/log/cloud-init-output.log'"
+echo "  Host lab"
+echo "      HostName ${INSTANCE_ID}"
+echo "      User ubuntu"
+echo "      IdentityFile ${KEY_FILE}"
+echo "      StrictHostKeyChecking no"
+echo "      UserKnownHostsFile /dev/null"
+echo "      ProxyCommand ${SSM_PROXY}"
+echo ""
+echo "The SSM agent registers ~30-60s after the instance is running; the"
+echo "instance then bootstraps (~3-5 min). Check progress with:"
+echo "  ssh lab 'tail -f /var/log/cloud-init-output.log'"
 echo ""
 echo "Verify setup is complete:"
-echo "  ${SSH_CMD} 'cat /var/log/ec2-setup-complete'"
+echo "  ssh lab 'cat /var/log/ec2-setup-complete'"
 echo ""
 echo "State saved to: ${STATE_FILE}"


### PR DESCRIPTION
Connect to lab-validation EC2 instances via AWS Systems Manager (Session
Manager) instead of inbound SSH. ec2-launch.sh attaches
AmazonSSMManagedInstanceCore to the instance role (idempotent, alongside
the existing S3 policy) and no longer creates a security group, the
per-launch MY_IP ingress rule, or passes --security-group-ids — the
instance keeps the VPC default SG with no inbound. SSH/scp and the
netmiko-based lab_builder steps work unchanged by tunnelling through an
SSM ProxyCommand keyed on the instance-id; the script prints a
ready-to-paste ~/.ssh/config `lab` host.

This removes the source-IP fragility that broke connecting from networks
whose egress NAT rotates or blocks outbound port 22: SSM only needs the
agent's outbound 443, so there is nothing to allow-list. Attaching the
policy before launch means the agent registers on first boot (~20s
observed) with no reboot.

Also: ec2-launch.sh now honors AWS_REGION/AWS_DEFAULT_REGION (the AWS CLI
reads them but `aws configure get region` does not), and the README gets
the session-manager-plugin prerequisite, the SSM connection flow, the
AWS CLI >=2.34 note, and matching troubleshooting; the ssh -i $KEY
ubuntu@$IP examples become `ssh lab` / `scp ... lab:`.

Verified end-to-end with a launch: first-boot SSM registration, ssh lab,
and an scp roundtrip, with the instance on only the default SG.

----

Prompt:
```
now let's do the second work
```

The "second work" is the follow-up agreed during the nxos_isis lab
build (batfish/lab-validation PR for batfish/batfish#10003): make SSM the
default connection path for infra/ and stop referencing security groups,
since corporate egress blocks outbound SSH to arbitrary EC2 IPs. Later
clarifications confirmed SSM needs no Elastic IP (the free auto-assigned
public IP suffices for the agent's outbound 443).
