### PR TITLE
nxos: skip management VRF in route validation; un-sickbay IS-IS routes

### DIFF
--- a/snapshots/nxos_isis/source/README.md
+++ b/snapshots/nxos_isis/source/README.md
@@ -38,20 +38,24 @@ adjacency forms as the default level-1-2 and routes install as `L1` instead of
 
 ## Batfish coverage
 
-Until batfish gains NX-OS IS-IS support, the IS-IS lines produce
-`This syntax is unrecognized` parse warnings and IS-IS is not modeled, so
-Batfish never installs the IS-IS-learned loopback routes. The route-comparison
-test (`test_main_rib_routes`) is therefore sickbay'd to batfish/batfish#10003 in
-`../validation/sickbay.yaml`; the snapshot, parser, and checks are correct now
-so validation flips green once batfish lands the fix.
+Batfish models NX-OS IS-IS as of batfish/batfish#10003: `router isis`,
+`net`, `is-type`, `ip router isis`, `isis circuit-type`, and `isis network
+point-to-point` are parsed and converted, the level-2 adjacency forms over
+the point-to-point link, and each router installs the other's loopback as an
+`isisL2` route (1.1.1.1/32, 2.2.2.2/32) with the NX-OS wide metric (40 per
+transit link, 1 on the originating loopback).
 
 The lab-validation NX-OS route parser was extended in this change to recognize
 `isis-<tag>, L1|L2` next-hop lines (previously the parser raised on any IS-IS
 route).
 
+`test_main_rib_routes` validates clean. The NX-OS validator skips the
+management VRF (vrnetlab injects a management default route and brings mgmt0
+up out of band, neither of which is in the startup config Batfish parses), so
+only the routed IS-IS state is compared.
+
 ## Validation target
 
 `pytest lab_tests/test_labs.py --labname=nxos_isis` parses the collected
-device data and compares the main RIB against Batfish. Interface and config
-checks validate clean; IS-IS route comparison is sickbay'd pending
-batfish/batfish#10003.
+device data and compares the main RIB against Batfish. The IS-IS loopback
+routes, interface, and config checks all validate clean.

--- a/snapshots/nxos_isis/validation/sickbay.yaml
+++ b/snapshots/nxos_isis/validation/sickbay.yaml
@@ -1,12 +1,4 @@
 entries:
-  - hostname: ".*"
-    test_name: test_main_rib_routes
-    skip:
-      reason: >-
-        Batfish does not yet model IS-IS on NX-OS, so the isisL2 routes the
-        devices learn for each other's loopback (1.1.1.1/32, 2.2.2.2/32) are
-        absent from the Batfish RIB. This lab exists to validate that fix.
-        https://github.com/batfish/batfish/issues/10003
   - hostname: r1
     test_name: test_interface_properties
     skip:

--- a/snapshots/nxos_n9kv_ebgp/validation/sickbay.yaml
+++ b/snapshots/nxos_n9kv_ebgp/validation/sickbay.yaml
@@ -1,10 +1,4 @@
 entries:
-  - hostname: ".*"
-    test_name: test_main_rib_routes
-    skip:
-      reason: >-
-        Management VRF default route (0.0.0.0/0) injected by vrnetlab at boot
-        is not in startup config, so Batfish does not model it.
   - hostname: r2
     test_name: test_interface_properties
     skip:

--- a/src/lab_validation/validators/NxosValidator.py
+++ b/src/lab_validation/validators/NxosValidator.py
@@ -93,13 +93,17 @@ class NxosValidator(VendorValidator):
     ) -> dict[Any, Any]:
         # Drop mgmt routes and hsrp routes (https://github.com/batfish/lab-validation/issues/59)
         # Drop hmm routes: https://github.com/batfish/lab-validation/issues/61
+        # Drop the management VRF: vrnetlab injects routes (e.g. a default route) and brings mgmt0
+        # up out of band, neither of which is in the startup config Batfish parses.
         validate_routes = [
             r
             for r in nxos_routes
             if r.protocol != "hsrp"
             and r.protocol != "hmm"
+            and r.vrf != "management"
             and (r.next_hop_int is None or not r.next_hop_int.startswith("mgmt"))
         ]
+        batfish_routes = [r for r in batfish_routes if r.vrf != "management"]
 
         matched_routes = match_pairs(
             batfish_routes,

--- a/tests/lab_validation/validators/test_nxosValidator.py
+++ b/tests/lab_validation/validators/test_nxosValidator.py
@@ -267,6 +267,54 @@ def test_diff_routes_cost() -> None:
     ) == [("vrf", math.inf)]
 
 
+def test_validate_main_rib_routes_skips_management_vrf() -> None:
+    # A management-VRF route present on only one side must not produce a failure: vrnetlab injects
+    # management routes that are absent from the startup config Batfish parses.
+    nxos_mgmt_route = NxosMainRibRoute(
+        vrf="management",
+        network="0.0.0.0/0",
+        protocol="static",
+        next_vrf=None,
+        next_hop_ip="10.0.0.2",
+        next_hop_int=None,
+        admin=1,
+        metric=0,
+        tag=None,
+        evpn=False,
+        segid=None,
+        tunnelid=None,
+    )
+    batfish_mgmt_route = MainRibRoute(
+        vrf="management",
+        network="10.0.0.0/24",
+        next_hop=NextHopInterface(interface="mgmt0"),
+        protocol="connected",
+        metric=0,
+        admin=0,
+        tag=0,
+    )
+    # Management routes on either side are dropped, so there are no failures.
+    assert (
+        NxosValidator._validate_main_rib_routes([batfish_mgmt_route], [nxos_mgmt_route])
+        == {}
+    )
+
+    # A non-management route still gets validated (and a missing match reported).
+    default_route = MainRibRoute(
+        vrf="default",
+        network="1.1.1.1/32",
+        next_hop=NextHopIp(ip="10.0.0.1"),
+        protocol="isisL2",
+        metric=41,
+        admin=115,
+        tag=None,
+    )
+    assert (
+        NxosValidator._validate_main_rib_routes([default_route], [nxos_mgmt_route])
+        != {}
+    )
+
+
 def test_bgp_equal() -> None:
     bf = BgpRibRoute(
         weight=0,


### PR DESCRIPTION
The NX-OS validator already intends to drop management routes, but its
filter only catches routes whose next-hop interface is mgmt*. The management
VRF default route (0.0.0.0/0) that vrnetlab injects at boot has a next-hop IP
and no next-hop interface, so it slipped through and forced
test_main_rib_routes to be sickbay'd wholesale (which also hid real routed
state from validation).

Drop the entire management VRF from the comparison, on both the device and
Batfish sides, matching what IosValidator already does. vrnetlab injects
management routes and brings mgmt0 up out of band, neither of which is in the
startup config Batfish parses.

With that, both nxos_isis and nxos_n9kv_ebgp validate their main RIBs
cleanly, so their test_main_rib_routes sickbay entries are removed:
- nxos_isis: now actually validates the isisL2 loopback routes
  (1.1.1.1/32, 2.2.2.2/32) that batfish/batfish#10003 added.
- nxos_n9kv_ebgp: its sickbay was solely the management default route.
