### PR TITLE
ci: inline pre-commit steps to drop deprecated actions/cache@v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,8 +53,17 @@ jobs:
           cache: "pip"
           cache-dependency-path: ".pre-commit-config.yaml"
 
+      - name: Install pre-commit
+        run: python -m pip install pre-commit
+
+      - name: Cache pre-commit hooks
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/pre-commit
+          key: pre-commit-3|${{ env.pythonLocation }}|${{ hashFiles('.pre-commit-config.yaml') }}
+
       - name: Run pre-commit hooks
-        uses: pre-commit/action@v3.0.1
+        run: pre-commit run --show-diff-on-failure --color=always --all-files
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The lint job used pre-commit/action@v3.0.1, a composite action whose
action.yml hardcodes actions/cache@v4. That triggers GitHub's Node 20
deprecation warning (the v4 action is force-run on Node 24). Dependabot
cannot fix this: the cache reference is transitive, and v3.0.1 is the
latest release of pre-commit/action.

Inline the equivalent steps (install, cache, run) using actions/cache@v5
so the lint job no longer depends on the stale action. The cache key is
preserved verbatim so existing entries still hit. The composite action's
diagnostic "pip freeze --local" step is dropped as it had no effect on
the run.

----

Prompt:
```
Seems like dependabot hasn't bumped actions/cache in a while, and I'm
getting warnings that v4 is outdated. Do you know why that might be?

[follow-up] The specific error I got was for lint: "Node.js 20 is
deprecated. The following actions target Node.js 20 but are being forced
to run on Node.js 24: actions/cache@v4."

[follow-up] ok do it / send a pr
```

---
**Stack**:
- #212 ⬅
---
⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*