### PR TITLE
junos: add extended-community literal lab; parse and canonicalize ext communities

### DIFF
--- a/snapshots/junos_ext_community_literal/batfish/layer1_topology.json
+++ b/snapshots/junos_ext_community_literal/batfish/layer1_topology.json
@@ -1,0 +1,14 @@
+{
+    "edges": [
+        {
+            "node1": {
+                "hostname": "sender",
+                "interfaceName": "ge-0/0/0"
+            },
+            "node2": {
+                "hostname": "receiver",
+                "interfaceName": "ge-0/0/0"
+            }
+        }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/configs/receiver/show_configuration_|_display_set.txt
+++ b/snapshots/junos_ext_community_literal/configs/receiver/show_configuration_|_display_set.txt
@@ -1,0 +1,22 @@
+set version 25.4R1.12
+set system host-name receiver
+set system root-authentication encrypted-password "$6$X3Zd02lP$hDUk4FZeX19DtmKqYojTO2g.i/sH1yvNNDoLwO35lwC32BjEtweFesoS.vn.DjBTbRmiLKQGWZf7fKd3PmU.J0"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$aMJerCyR$quYGWu7c98uamBHN74.k7ct9AwRtwbQQonM4FBkDnsG0ktI0z4MKfu.hyQTRRgA6.tYiCnd6PWwRE9lkFjYrS/"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to sender"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.1/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 2.2.2.2/32
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 2.2.2.2
+set routing-options autonomous-system 65002
+set protocols bgp group FROM-SENDER type external
+set protocols bgp group FROM-SENDER peer-as 65001
+set protocols bgp group FROM-SENDER neighbor 10.0.12.0

--- a/snapshots/junos_ext_community_literal/configs/sender/show_configuration_|_display_set.txt
+++ b/snapshots/junos_ext_community_literal/configs/sender/show_configuration_|_display_set.txt
@@ -1,0 +1,41 @@
+set version 25.4R1.12
+set system host-name sender
+set system root-authentication encrypted-password "$6$WrftO1Ig$5ZYsUFYsXHHPOapgOJwkuWLZQaVahzN2kid7wQOOEgP54iUiTJT6VA/qqFCgdTjm/A2exuRX8mNWW2XYQpArr0"
+set system login user admin uid 2000
+set system login user admin class super-user
+set system login user admin authentication encrypted-password "$6$jLzQ/O0F$UdInk2piU869EPSyCPgfblsqtzmWI7UB/T4IwkmsHh/wdjgxWMtEXoZ8nU12oHeLcG72pM6C.KHjSV7sf0wZR/"
+set system services netconf ssh
+set system services ssh root-login allow
+set system management-instance
+set chassis fpc 0 pic 0 number-of-ports 12
+set interfaces ge-0/0/0 description "link to receiver"
+set interfaces ge-0/0/0 unit 0 family inet address 10.0.12.0/31
+set interfaces fxp0 unit 0 family inet address 10.0.0.15/24
+set interfaces fxp0 unit 0 family inet6 address 2001:db8::2/64
+set interfaces lo0 unit 0 family inet address 1.1.1.1/32
+set policy-options policy-statement ADVERTISE term mystery from route-filter 10.10.1.0/24 exact
+set policy-options policy-statement ADVERTISE term mystery then community add MYSTERY
+set policy-options policy-statement ADVERTISE term mystery then accept
+set policy-options policy-statement ADVERTISE term rt4 from route-filter 10.10.2.0/24 exact
+set policy-options policy-statement ADVERTISE term rt4 then community add RT-4BYTE
+set policy-options policy-statement ADVERTISE term rt4 then accept
+set policy-options policy-statement ADVERTISE term rt2 from route-filter 10.10.3.0/24 exact
+set policy-options policy-statement ADVERTISE term rt2 then community add RT-2BYTE
+set policy-options policy-statement ADVERTISE term rt2 then accept
+set policy-options policy-statement ADVERTISE term control from route-filter 10.10.0.0/24 exact
+set policy-options policy-statement ADVERTISE term control then accept
+set policy-options policy-statement ADVERTISE term default then reject
+set policy-options community MYSTERY members 65000:672277L:36867
+set policy-options community RT-2BYTE members target:65000:36867
+set policy-options community RT-4BYTE members target:672277L:36867
+set routing-instances mgmt_junos routing-options rib mgmt_junos.inet6.0 static route ::/0 next-hop 2001:db8::1
+set routing-instances mgmt_junos routing-options static route 0.0.0.0/0 next-hop 10.0.0.2
+set routing-options router-id 1.1.1.1
+set routing-options autonomous-system 65001
+set routing-options static route 10.10.0.0/24 discard
+set routing-options static route 10.10.1.0/24 discard
+set routing-options static route 10.10.2.0/24 discard
+set routing-options static route 10.10.3.0/24 discard
+set protocols bgp group TO-RECEIVER type external
+set protocols bgp group TO-RECEIVER peer-as 65002
+set protocols bgp group TO-RECEIVER neighbor 10.0.12.1 export ADVERTISE

--- a/snapshots/junos_ext_community_literal/show/host_nos.txt
+++ b/snapshots/junos_ext_community_literal/show/host_nos.txt
@@ -1,0 +1,1 @@
+{"receiver": "junos", "sender": "junos"}

--- a/snapshots/junos_ext_community_literal/show/receiver/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/receiver/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,452 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.1+57839"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "FROM-SENDER"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "None"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "10:59", 
+                "attributes" : {"junos:seconds" : "659"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "20"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "20"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "659"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "31"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "771"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "479"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/receiver/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/receiver/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to sender"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:9a:1d:0e"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:9a:1d:0e"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:54 ago)", 
+                "attributes" : {"junos:seconds" : "654"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "538"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "68"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "42"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.1"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:54 ago)", 
+                "attributes" : {"junos:seconds" : "654"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:55 ago)", 
+                "attributes" : {"junos:seconds" : "655"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:55 ago)", 
+                "attributes" : {"junos:seconds" : "655"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:55 ago)", 
+                "attributes" : {"junos:seconds" : "655"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:55 ago)", 
+                "attributes" : {"junos:seconds" : "655"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:55 ago)", 
+                "attributes" : {"junos:seconds" : "655"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:56 ago)", 
+                "attributes" : {"junos:seconds" : "656"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:56 ago)", 
+                "attributes" : {"junos:seconds" : "656"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:56 ago)", 
+                "attributes" : {"junos:seconds" : "656"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:56 ago)", 
+                "attributes" : {"junos:seconds" : "656"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:49:10 UTC (00:10:56 ago)", 
+                "attributes" : {"junos:seconds" : "656"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:1b:60:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:60:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:1b:60:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:47:37 UTC (00:12:29 ago)", 
+                "attributes" : {"junos:seconds" : "749"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "67747"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "112273"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "66699"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "112274"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:ae:c8:8e:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:ae:c8:8e:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:ae:c8:8e:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:ae:c8:8e:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:47:37 UTC (00:12:29 ago)", 
+                "attributes" : {"junos:seconds" : "749"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "5891"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "6066"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "5891"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "6194"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:aeff:fec8:8e00"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:67:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:1b:67:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:67:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:1b:67:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "1500"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "1500"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2.2.2.2"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:67:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:1b:67:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:1b:67:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:1b:67:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/receiver/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/receiver/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/receiver/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/receiver/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/receiver/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/receiver/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "7"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/receiver/show_route_protocol_bgp_detail_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/receiver/show_route_protocol_bgp_detail_|_display_json.txt
@@ -1,0 +1,990 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.0.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "rt-entry-count" : [
+                {
+                    "data" : "1", 
+                    "attributes" : {"junos:format" : "1 entry"}
+                }
+                ], 
+                "rt-announced-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-state" : [
+                {
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "preference2" : [
+                    {
+                        "data" : "-101"
+                    }
+                    ], 
+                    "nhh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-type" : [
+                        {
+                            "data" : "Router"
+                        }
+                        ], 
+                        "nh-index" : [
+                        {
+                            "data" : "587"
+                        }
+                        ], 
+                        "nh-address" : [
+                        {
+                            "data" : "0x91bd894"
+                        }
+                        ], 
+                        "nh-reference-count" : [
+                        {
+                            "data" : "8"
+                        }
+                        ], 
+                        "nh-session-id" : [
+                        {
+                            "data" : "320"
+                        }
+                        ], 
+                        "nh-kernel-id" : [
+                        {
+                            "data" : "0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "gateway" : [
+                    {
+                        "data" : "10.0.12.0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-string" : [
+                        {
+                            "data" : "Next hop"
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "session" : [
+                        {
+                            "data" : "320"
+                        }
+                        ]
+                    }
+                    ], 
+                    "rt-entry-state" : [
+                    {
+                        "data" : "Active Ext"
+                    }
+                    ], 
+                    "local-as" : [
+                    {
+                        "data" : "65002"
+                    }
+                    ], 
+                    "peer-as" : [
+                    {
+                        "data" : "65001"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "10:56", 
+                        "attributes" : {"junos:seconds" : "656"}
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "task-name" : [
+                    {
+                        "data" : "BGP_65001.10.0.12.0"
+                    }
+                    ], 
+                    "announce-bits" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "announce-tasks" : [
+                    {
+                        "data" : "0-KRT "
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "AS path: 65001 I"
+                    }
+                    ], 
+                    "bgp-path-attributes" : [
+                    {
+                        "attr-as-path-effective" : [
+                        {
+                            "aspath-effective-string" : [
+                            {
+                                "data" : "AS path: "
+                            }
+                            ], 
+                            "attr-value" : [
+                            {
+                                "data" : "65001 I"
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ], 
+                    "bgp-rt-flag" : [
+                    {
+                        "data" : "Accepted"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "peer-id" : [
+                    {
+                        "data" : "1.1.1.1"
+                    }
+                    ], 
+                    "thread-name" : [
+                    {
+                        "data" : "junos-main"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.1.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "rt-entry-count" : [
+                {
+                    "data" : "1", 
+                    "attributes" : {"junos:format" : "1 entry"}
+                }
+                ], 
+                "rt-announced-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-state" : [
+                {
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "preference2" : [
+                    {
+                        "data" : "-101"
+                    }
+                    ], 
+                    "nhh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-type" : [
+                        {
+                            "data" : "Router"
+                        }
+                        ], 
+                        "nh-index" : [
+                        {
+                            "data" : "587"
+                        }
+                        ], 
+                        "nh-address" : [
+                        {
+                            "data" : "0x91bd894"
+                        }
+                        ], 
+                        "nh-reference-count" : [
+                        {
+                            "data" : "8"
+                        }
+                        ], 
+                        "nh-session-id" : [
+                        {
+                            "data" : "320"
+                        }
+                        ], 
+                        "nh-kernel-id" : [
+                        {
+                            "data" : "0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "gateway" : [
+                    {
+                        "data" : "10.0.12.0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-string" : [
+                        {
+                            "data" : "Next hop"
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "session" : [
+                        {
+                            "data" : "320"
+                        }
+                        ]
+                    }
+                    ], 
+                    "rt-entry-state" : [
+                    {
+                        "data" : "Active Ext"
+                    }
+                    ], 
+                    "local-as" : [
+                    {
+                        "data" : "65002"
+                    }
+                    ], 
+                    "peer-as" : [
+                    {
+                        "data" : "65001"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "10:56", 
+                        "attributes" : {"junos:seconds" : "656"}
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "task-name" : [
+                    {
+                        "data" : "BGP_65001.10.0.12.0"
+                    }
+                    ], 
+                    "announce-bits" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "announce-tasks" : [
+                    {
+                        "data" : "0-KRT "
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "AS path: 65001 I"
+                    }
+                    ], 
+                    "bgp-path-attributes" : [
+                    {
+                        "attr-as-path-effective" : [
+                        {
+                            "aspath-effective-string" : [
+                            {
+                                "data" : "AS path: "
+                            }
+                            ], 
+                            "attr-value" : [
+                            {
+                                "data" : "65001 I"
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ], 
+                    "bgp-rt-flag" : [
+                    {
+                        "data" : "Accepted"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "peer-id" : [
+                    {
+                        "data" : "1.1.1.1"
+                    }
+                    ], 
+                    "thread-name" : [
+                    {
+                        "data" : "junos-main"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.2.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "rt-entry-count" : [
+                {
+                    "data" : "1", 
+                    "attributes" : {"junos:format" : "1 entry"}
+                }
+                ], 
+                "rt-announced-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-state" : [
+                {
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "preference2" : [
+                    {
+                        "data" : "-101"
+                    }
+                    ], 
+                    "nhh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-type" : [
+                        {
+                            "data" : "Router"
+                        }
+                        ], 
+                        "nh-index" : [
+                        {
+                            "data" : "587"
+                        }
+                        ], 
+                        "nh-address" : [
+                        {
+                            "data" : "0x91bd894"
+                        }
+                        ], 
+                        "nh-reference-count" : [
+                        {
+                            "data" : "8"
+                        }
+                        ], 
+                        "nh-session-id" : [
+                        {
+                            "data" : "320"
+                        }
+                        ], 
+                        "nh-kernel-id" : [
+                        {
+                            "data" : "0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "gateway" : [
+                    {
+                        "data" : "10.0.12.0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-string" : [
+                        {
+                            "data" : "Next hop"
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "session" : [
+                        {
+                            "data" : "320"
+                        }
+                        ]
+                    }
+                    ], 
+                    "rt-entry-state" : [
+                    {
+                        "data" : "Active Ext"
+                    }
+                    ], 
+                    "local-as" : [
+                    {
+                        "data" : "65002"
+                    }
+                    ], 
+                    "peer-as" : [
+                    {
+                        "data" : "65001"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "10:56", 
+                        "attributes" : {"junos:seconds" : "656"}
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "task-name" : [
+                    {
+                        "data" : "BGP_65001.10.0.12.0"
+                    }
+                    ], 
+                    "announce-bits" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "announce-tasks" : [
+                    {
+                        "data" : "0-KRT "
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "AS path: 65001 I"
+                    }
+                    ], 
+                    "bgp-path-attributes" : [
+                    {
+                        "attr-as-path-effective" : [
+                        {
+                            "aspath-effective-string" : [
+                            {
+                                "data" : "AS path: "
+                            }
+                            ], 
+                            "attr-value" : [
+                            {
+                                "data" : "65001 I"
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ], 
+                    "communities" : [
+                    {
+                        "extended-community" : [
+                        {
+                            "data" : "target:672277L:36867"
+                        }
+                        ]
+                    }
+                    ], 
+                    "bgp-rt-flag" : [
+                    {
+                        "data" : "Accepted"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "peer-id" : [
+                    {
+                        "data" : "1.1.1.1"
+                    }
+                    ], 
+                    "thread-name" : [
+                    {
+                        "data" : "junos-main"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.3.0"
+                }
+                ], 
+                "rt-prefix-length" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "rt-entry-count" : [
+                {
+                    "data" : "1", 
+                    "attributes" : {"junos:format" : "1 entry"}
+                }
+                ], 
+                "rt-announced-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "rt-state" : [
+                {
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "preference2" : [
+                    {
+                        "data" : "-101"
+                    }
+                    ], 
+                    "nhh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-type" : [
+                        {
+                            "data" : "Router"
+                        }
+                        ], 
+                        "nh-index" : [
+                        {
+                            "data" : "587"
+                        }
+                        ], 
+                        "nh-address" : [
+                        {
+                            "data" : "0x91bd894"
+                        }
+                        ], 
+                        "nh-reference-count" : [
+                        {
+                            "data" : "8"
+                        }
+                        ], 
+                        "nh-session-id" : [
+                        {
+                            "data" : "320"
+                        }
+                        ], 
+                        "nh-kernel-id" : [
+                        {
+                            "data" : "0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "gateway" : [
+                    {
+                        "data" : "10.0.12.0"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "attributes" : {"junos:indent" : "16"}, 
+                        "nh-string" : [
+                        {
+                            "data" : "Next hop"
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ], 
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "session" : [
+                        {
+                            "data" : "320"
+                        }
+                        ]
+                    }
+                    ], 
+                    "rt-entry-state" : [
+                    {
+                        "data" : "Active Ext"
+                    }
+                    ], 
+                    "local-as" : [
+                    {
+                        "data" : "65002"
+                    }
+                    ], 
+                    "peer-as" : [
+                    {
+                        "data" : "65001"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "10:56", 
+                        "attributes" : {"junos:seconds" : "656"}
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "task-name" : [
+                    {
+                        "data" : "BGP_65001.10.0.12.0"
+                    }
+                    ], 
+                    "announce-bits" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "announce-tasks" : [
+                    {
+                        "data" : "0-KRT "
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "AS path: 65001 I"
+                    }
+                    ], 
+                    "bgp-path-attributes" : [
+                    {
+                        "attr-as-path-effective" : [
+                        {
+                            "aspath-effective-string" : [
+                            {
+                                "data" : "AS path: "
+                            }
+                            ], 
+                            "attr-value" : [
+                            {
+                                "data" : "65001 I"
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ], 
+                    "communities" : [
+                    {
+                        "extended-community" : [
+                        {
+                            "data" : "target:65000:36867"
+                        }
+                        ]
+                    }
+                    ], 
+                    "bgp-rt-flag" : [
+                    {
+                        "data" : "Accepted"
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "peer-id" : [
+                    {
+                        "data" : "1.1.1.1"
+                    }
+                    ], 
+                    "thread-name" : [
+                    {
+                        "data" : "junos-main"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/receiver/show_route_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/receiver/show_route_|_display_json.txt
@@ -1,0 +1,1001 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2.2.2.2/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:54", 
+                        "attributes" : {"junos:seconds" : "714"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:57", 
+                        "attributes" : {"junos:seconds" : "657"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:57", 
+                        "attributes" : {"junos:seconds" : "657"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:55", 
+                        "attributes" : {"junos:seconds" : "655"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:55", 
+                        "attributes" : {"junos:seconds" : "655"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:55", 
+                        "attributes" : {"junos:seconds" : "655"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "BGP"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "170"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:10:55", 
+                        "attributes" : {"junos:seconds" : "655"}
+                    }
+                    ], 
+                    "local-preference" : [
+                    {
+                        "data" : "100"
+                    }
+                    ], 
+                    "as-path" : [
+                    {
+                        "data" : "65001 I"
+                    }
+                    ], 
+                    "validation-state" : [
+                    {
+                        "data" : "unverified"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:52", 
+                        "attributes" : {"junos:seconds" : "712"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:54", 
+                        "attributes" : {"junos:seconds" : "714"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:54", 
+                        "attributes" : {"junos:seconds" : "714"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:52", 
+                        "attributes" : {"junos:seconds" : "712"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:54", 
+                        "attributes" : {"junos:seconds" : "714"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:54", 
+                        "attributes" : {"junos:seconds" : "714"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:aeff:fec8:8e00/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:54", 
+                        "attributes" : {"junos:seconds" : "714"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/receiver/show_version_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/receiver/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "receiver"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/sender/show_bgp_neighbor_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/sender/show_bgp_neighbor_|_display_json.txt
@@ -1,0 +1,476 @@
+{
+    "bgp-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "bgp-peer" : [
+        {
+            "attributes" : {"junos:style" : "detail"}, 
+            "peer-address" : [
+            {
+                "data" : "10.0.12.1+57839"
+            }
+            ], 
+            "peer-as" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "local-address" : [
+            {
+                "data" : "10.0.12.0+179"
+            }
+            ], 
+            "local-as" : [
+            {
+                "data" : "65001"
+            }
+            ], 
+            "peer-group" : [
+            {
+                "data" : "TO-RECEIVER"
+            }
+            ], 
+            "peer-cfg-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-fwd-rti" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "peer-type" : [
+            {
+                "data" : "External"
+            }
+            ], 
+            "peer-state" : [
+            {
+                "data" : "Established"
+            }
+            ], 
+            "peer-flags" : [
+            {
+                "data" : "Sync"
+            }
+            ], 
+            "rsync-flags" : [
+            {
+            }
+            ], 
+            "last-state" : [
+            {
+                "data" : "OpenConfirm"
+            }
+            ], 
+            "last-event" : [
+            {
+                "data" : "RecvKeepAlive"
+            }
+            ], 
+            "last-error" : [
+            {
+                "data" : "Cease"
+            }
+            ], 
+            "bgp-option-information" : [
+            {
+                "export-policy" : [
+                {
+                    "data" : "ADVERTISE"
+                }
+                ], 
+                "send-community-type" : [
+                {
+                }
+                ], 
+                "bgp-options" : [
+                {
+                    "data" : "PeerAS Refresh"
+                }
+                ], 
+                "bgp-options2" : [
+                {
+                }
+                ], 
+                "bgp-options-extended" : [
+                {
+                    "data" : "GracefulShutdownRcv"
+                }
+                ], 
+                "bgp-options-extended2" : [
+                {
+                }
+                ], 
+                "holdtime" : [
+                {
+                    "data" : "90"
+                }
+                ], 
+                "preference" : [
+                {
+                    "data" : "170"
+                }
+                ], 
+                "gshut-recv-local-preference" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "flap-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "elapsed-time" : [
+            {
+                "data" : "11:09", 
+                "attributes" : {"junos:seconds" : "669"}
+            }
+            ], 
+            "recv-ebgp-origin-validation-state" : [
+            {
+                "data" : "Reject"
+            }
+            ], 
+            "bgp-error" : [
+            {
+                "name" : [
+                {
+                    "data" : "Cease"
+                }
+                ], 
+                "send-count" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "receive-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "bgp-malformed-attributes" : [
+            {
+                "malformed-information" : [
+                {
+                    "log-interval" : [
+                    {
+                        "data" : "300"
+                    }
+                    ], 
+                    "route-limit" : [
+                    {
+                        "data" : "1000"
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "peer-id" : [
+            {
+                "data" : "2.2.2.2"
+            }
+            ], 
+            "local-id" : [
+            {
+                "data" : "1.1.1.1"
+            }
+            ], 
+            "active-holdtime" : [
+            {
+                "data" : "90"
+            }
+            ], 
+            "keepalive-interval" : [
+            {
+                "data" : "30"
+            }
+            ], 
+            "group-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "peer-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "bgp-peer-iosession" : [
+            {
+                "iosession-thread-name" : [
+                {
+                    "data" : "bgpio-0"
+                }
+                ], 
+                "iosession-state" : [
+                {
+                    "data" : "Enabled"
+                }
+                ]
+            }
+            ], 
+            "bgp-bfd" : [
+            {
+                "bfd-configuration-state" : [
+                {
+                    "data" : "disabled"
+                }
+                ], 
+                "bfd-operational-state" : [
+                {
+                    "data" : "down"
+                }
+                ]
+            }
+            ], 
+            "local-interface-name" : [
+            {
+                "data" : "ge-0/0/0.0"
+            }
+            ], 
+            "local-interface-index" : [
+            {
+                "data" : "540"
+            }
+            ], 
+            "peer-restart-nlri-configured" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-peer" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "nlri-type-session" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "loop-check-display" : [
+            {
+                "data" : "AS loop check: Domain Scoped"
+            }
+            ], 
+            "peer-refresh-capability" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "peer-4byte-as-capability-advertised" : [
+            {
+                "data" : "65002"
+            }
+            ], 
+            "peer-addpath-not-supported" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-rib" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-bit" : [
+                {
+                    "data" : "20000"
+                }
+                ], 
+                "bgp-rib-state" : [
+                {
+                    "data" : "BGP restart is complete"
+                }
+                ], 
+                "send-state" : [
+                {
+                    "data" : "in sync"
+                }
+                ], 
+                "active-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "received-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "accepted-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "suppressed-prefix-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "advertised-prefix-count" : [
+                {
+                    "data" : "4"
+                }
+                ]
+            }
+            ], 
+            "peer-stale-route-time-configured" : [
+            {
+                "data" : "300"
+            }
+            ], 
+            "peer-no-restart" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "peer-restart-flags-received" : [
+            {
+                "data" : "Notification"
+            }
+            ], 
+            "peer-restart-nlri-negotiated" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-received" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-sent" : [
+            {
+                "data" : "inet-unicast"
+            }
+            ], 
+            "peer-end-of-rib-scheduled" : [
+            {
+            }
+            ], 
+            "peer-no-llgr-restarter" : [
+            {
+                "data" : [null]
+            }
+            ], 
+            "bgp-family-stat" : [
+            {
+                "attributes" : {"junos:style" : "detail"}, 
+                "nlri-type" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ], 
+                "bgp-nlri-send-time" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "bgp-nlri-recv-time" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "last-received" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "last-sent" : [
+            {
+                "data" : "2"
+            }
+            ], 
+            "last-checked" : [
+            {
+                "data" : "669"
+            }
+            ], 
+            "input-messages" : [
+            {
+                "data" : "28"
+            }
+            ], 
+            "input-updates" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "input-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "input-octets" : [
+            {
+                "data" : "580"
+            }
+            ], 
+            "output-messages" : [
+            {
+                "data" : "31"
+            }
+            ], 
+            "output-updates" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "output-refreshes" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "output-octets" : [
+            {
+                "data" : "727"
+            }
+            ], 
+            "bgp-output-queue" : [
+            {
+                "number" : [
+                {
+                    "data" : "1"
+                }
+                ], 
+                "count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "table-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "rib-adv-nlri" : [
+                {
+                    "data" : "inet-unicast"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/sender/show_interfaces_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/sender/show_interfaces_|_display_json.txt
@@ -1,0 +1,9311 @@
+{
+    "interface-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-interface", 
+                        "junos:style" : "normal"
+                       }, 
+        "physical-interface" : [
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "150"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "528"
+            }
+            ], 
+            "description" : [
+            {
+                "data" : "link to receiver"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "aa:c1:ab:d8:03:58"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "aa:c1:ab:d8:03:58"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:17 ago)", 
+                "attributes" : {"junos:seconds" : "677"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "48"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "alarm-not-present" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "334"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "540"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "43"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "72"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.12.0/31"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.12.0"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "multiservice"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lc-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "147"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "521"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lc-0/0/0.32769"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "330"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "522"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "vpls"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x4000000"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfe-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "149"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "524"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfe-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "333"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "527"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pfh-0/0/0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "148"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "523"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "800mbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16383"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "331"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "525"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "pfh-0/0/0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "332"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "526"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-mtu-user-conf" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "151"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "529"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:01"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:01"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/1.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "335"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "541"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "152"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "530"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:02"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:02"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/2.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "336"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "542"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "153"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "531"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:03"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:03"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/3.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "337"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "543"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "154"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "532"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:04"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:04"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/4.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "338"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "544"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "155"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "533"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:05"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:05"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/5.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "339"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "545"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "156"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "534"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:06"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:06"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/6.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "340"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "546"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "157"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "535"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:07"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:07"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/7.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "341"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "547"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/8"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "158"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "536"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:08"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:08"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/8.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "342"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "548"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/9"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "159"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "537"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:09"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:09"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/9.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "343"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "549"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/10"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "160"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "538"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:0a"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:0a"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/10.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "344"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "550"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ge-0/0/11"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "down"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "161"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "539"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "sonet-mode" : [
+            {
+                "data" : "LAN-PHY"
+            }
+            ], 
+            "mru" : [
+            {
+                "data" : "1522"
+            }
+            ], 
+            "source-filtering" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "1000mbps"
+            }
+            ], 
+            "eth-switch-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "remote-bounce" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "bpdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "ld-pdu-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "l2pt-error" : [
+            {
+                "data" : "none"
+            }
+            ], 
+            "loopback" : [
+            {
+                "data" : "disabled"
+            }
+            ], 
+            "if-flow-control" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-auto-negotiation" : [
+            {
+                "data" : "enabled"
+            }
+            ], 
+            "if-remote-fault" : [
+            {
+                "data" : "online"
+            }
+            ], 
+            "pad-to-minimum-frame-size" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-down" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-hardware-down" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "internal-flags" : [
+                {
+                    "data" : "0x4000"
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "physical-interface-cos-information" : [
+            {
+                "physical-interface-cos-hw-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ], 
+                "physical-interface-cos-use-max-queues" : [
+                {
+                    "data" : "8"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:0b"
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:0b"
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:48:58 UTC (00:11:18 ago)", 
+                "attributes" : {"junos:seconds" : "678"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "input-pps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-bps" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-pps" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "active-alarms" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "active-defects" : [
+            {
+                "interface-alarms" : [
+                {
+                    "ethernet-alarm-link-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ]
+            }
+            ], 
+            "ethernet-pcs-statistics" : [
+            {
+                "attributes" : {"junos:style" : "verbose"}, 
+                "bit-error-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "errored-blocks-seconds" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "interface-transmit-statistics" : [
+            {
+                "data" : "Disabled"
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "ge-0/0/11.16386"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "345"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "551"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-device-down" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "cbp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "131"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "501"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:3b:7d:11"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:7d:11", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:3b:7d:11"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "129"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "502"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "demux1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "130"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "503"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Not-Applicable"
+            }
+            ], 
+            "clocking" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsc"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "5"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "em1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "65"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "23"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "52:54:00:12:bd:fe", 
+                "attributes" : {"junos:format" : "MAC 52:54:00:12:bd:fe"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:47:32 UTC (00:12:44 ago)", 
+                "attributes" : {"junos:seconds" : "764"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "68066"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "112868"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "em1.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "24"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "67012"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "112869"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10/8"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-kernel" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.1"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.4"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::5254:ff:fe12:bdfe"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fec0::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fec0::a:0:0:4"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "tnp"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "0x4"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "esi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "136"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "504"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "138"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "505"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti1"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "139"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "506"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti2"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "140"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "507"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti3"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "141"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "508"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti4"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "142"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "509"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti5"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "143"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "510"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti6"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "144"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "511"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fti7"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "145"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "512"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "FTI"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Flexible-tunnel-Interface"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "fxp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "64"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "1"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "10Gbps"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x100200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x4"
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "0c:00:7f:c7:01:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:7f:c7:01:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "0c:00:7f:c7:01:00", 
+                "attributes" : {"junos:format" : "MAC 0c:00:7f:c7:01:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "2026-06-26 19:47:32 UTC (00:12:45 ago)", 
+                "attributes" : {"junos:seconds" : "765"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "4349"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "4490"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "fxp0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "13"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x4000000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "ENET2"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "4349"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "4647"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "10.0.0/24"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "10.0.0.15"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "10.0.0.255"
+                        }
+                        ]
+                    }
+                    ]
+                }, 
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet6"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1500"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "2"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "1"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "2001:db8::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "2001:db8::2"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }, 
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "internal-flags" : [
+                            {
+                                "data" : "0x800"
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "fe80::/64"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "fe80::e00:7fff:fec7:100"
+                        }
+                        ], 
+                        "in6-addr-flags" : [
+                        {
+                            "ifaf-none" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "gre"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "8"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ipip"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "9"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "IPIP"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "IP-over-IP"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "irb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "134"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "513"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:84:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:3b:84:f0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:84:f0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:3b:84:f0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsrv"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "128"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "514"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1514"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "00:00:00:00:00:00", 
+                "attributes" : {"junos:format" : "MAC 00:00:00:00:00:00"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "jsrv.1"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "324"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "515"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-up" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "internal-flags" : [
+                    {
+                        "data" : "0x24004000"
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "unknown"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "logical-interface-bandwidth" : [
+                {
+                    "data" : "1Gbps"
+                }
+                ], 
+                "irb-domain" : [
+                {
+                    "irb-routing-instance" : [
+                    {
+                        "data" : "None"
+                    }
+                    ], 
+                    "irb-bridge" : [
+                    {
+                        "data" : "None"
+                    }
+                    ]
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "1514"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "75000"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-is-primary" : [
+                        {
+                            "data" : [null]
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-preferred" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-destination" : [
+                        {
+                            "data" : "128/2"
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "128.0.0.127"
+                        }
+                        ], 
+                        "ifa-broadcast" : [
+                        {
+                            "data" : "191.255.255.255"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lo0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "6"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Loopback"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-loopback" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "1523"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "1523"
+                }
+                ]
+            }
+            ], 
+            "logical-interface" : [
+            {
+                "name" : [
+                {
+                    "data" : "lo0.0"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "320"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "16"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "ifff-sendbcast-pkt-to-re" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "ifa-flags" : [
+                        {
+                            "ifaf-current-default" : [
+                            {
+                                "data" : [null]
+                            }
+                            ], 
+                            "ifaf-current-primary" : [
+                            {
+                                "data" : [null]
+                            }
+                            ]
+                        }
+                        ], 
+                        "ifa-local" : [
+                        {
+                            "data" : "1.1.1.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16384"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "322"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "21"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "0"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ], 
+                    "interface-address" : [
+                    {
+                        "attributes" : {"heading" : "Addresses"}, 
+                        "ifa-local" : [
+                        {
+                            "data" : "127.0.0.1"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "name" : [
+                {
+                    "data" : "lo0.16385"
+                }
+                ], 
+                "local-index" : [
+                {
+                    "data" : "321"
+                }
+                ], 
+                "snmp-index" : [
+                {
+                    "data" : "22"
+                }
+                ], 
+                "if-config-flags" : [
+                {
+                    "iff-snmp-traps" : [
+                    {
+                        "data" : [null]
+                    }
+                    ]
+                }
+                ], 
+                "encapsulation" : [
+                {
+                    "data" : "Unspecified"
+                }
+                ], 
+                "policer-overhead" : [
+                {
+                }
+                ], 
+                "traffic-statistics" : [
+                {
+                    "attributes" : {"junos:style" : "brief"}, 
+                    "input-packets" : [
+                    {
+                        "data" : "1523"
+                    }
+                    ], 
+                    "output-packets" : [
+                    {
+                        "data" : "1523"
+                    }
+                    ]
+                }
+                ], 
+                "filter-information" : [
+                {
+                }
+                ], 
+                "address-family" : [
+                {
+                    "address-family-name" : [
+                    {
+                        "data" : "inet"
+                    }
+                    ], 
+                    "mtu" : [
+                    {
+                        "data" : "Unlimited"
+                    }
+                    ], 
+                    "max-local-cache" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "new-hold-limit" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-curr-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-unresolved-cnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "intf-dropcnt" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "address-family-flags" : [
+                    {
+                        "internal-flags" : [
+                        {
+                            "data" : "0x0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "lsi"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "LSI"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mif"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "146"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "516"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1440"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "mtun"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "66"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Multicast-GRE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "GRE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pimd"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "26"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "11"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIMD"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Decapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pime"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "25"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "10"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PIME"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PIM-Encapsulator"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pip0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "132"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "517"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Ethernet"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "9192"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "current-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:84:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:3b:84:b0"}
+            }
+            ], 
+            "hardware-physical-address" : [
+            {
+                "data" : "2c:6b:f5:3b:84:b0", 
+                "attributes" : {"junos:format" : "MAC 2c:6b:f5:3b:84:b0"}
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "pp0"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "133"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "518"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "PPPoE"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "1532"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-point-to-point" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "rbeb"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "137"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "519"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Remote-BEB"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "tap"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "12"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "Interface-Specific"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+                "iff-snmp-traps" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vtep"
+            }
+            ], 
+            "admin-status" : [
+            {
+                "data" : "up", 
+                "attributes" : {"junos:format" : "Enabled"}
+            }
+            ], 
+            "oper-status" : [
+            {
+                "data" : "up"
+            }
+            ], 
+            "local-index" : [
+            {
+                "data" : "135"
+            }
+            ], 
+            "snmp-index" : [
+            {
+                "data" : "520"
+            }
+            ], 
+            "if-type" : [
+            {
+                "data" : "Software-Pseudo"
+            }
+            ], 
+            "link-level-type" : [
+            {
+                "data" : "VxLAN-Tunnel-Endpoint"
+            }
+            ], 
+            "mtu" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "speed" : [
+            {
+                "data" : "Unlimited"
+            }
+            ], 
+            "if-device-flags" : [
+            {
+                "ifdf-present" : [
+                {
+                    "data" : [null]
+                }
+                ], 
+                "ifdf-running" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "ifd-specific-config-flags" : [
+            {
+                "internal-flags" : [
+                {
+                    "data" : "0x200"
+                }
+                ]
+            }
+            ], 
+            "if-config-flags" : [
+            {
+            }
+            ], 
+            "link-type" : [
+            {
+                "data" : "Full-Duplex"
+            }
+            ], 
+            "if-media-flags" : [
+            {
+                "ifmf-none" : [
+                {
+                    "data" : [null]
+                }
+                ]
+            }
+            ], 
+            "interface-flapped" : [
+            {
+                "data" : "Never", 
+                "attributes" : {"junos:seconds" : "0"}
+            }
+            ], 
+            "traffic-statistics" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "input-packets" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "output-packets" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/sender/show_isis_adjacency_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/sender/show_isis_adjacency_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "IS-IS instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/sender/show_ospf_neighbor_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/sender/show_ospf_neighbor_|_display_json.txt
@@ -1,0 +1,7 @@
+{
+    "output" : [
+    {
+        "data" : "OSPF instance is not running"
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/sender/show_route_instance_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/sender/show_route_instance_|_display_json.txt
@@ -1,0 +1,223 @@
+{
+    "instance-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing", 
+                        "junos:style" : "terse"
+                       }, 
+        "instance-core" : [
+        {
+            "instance-name" : [
+            {
+                "data" : "master"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "7"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private1__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "5"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private1__.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private2__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "__juniper_private2__.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "1"
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__juniper_private4__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "__master.anon__"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ]
+        }, 
+        {
+            "instance-name" : [
+            {
+                "data" : "mgmt_junos"
+            }
+            ], 
+            "instance-type" : [
+            {
+                "data" : "forwarding"
+            }
+            ], 
+            "instance-rib" : [
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "3"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }, 
+            {
+                "irib-name" : [
+                {
+                    "data" : "mgmt_junos.inet6.0"
+                }
+                ], 
+                "irib-active-count" : [
+                {
+                    "data" : "4"
+                }
+                ], 
+                "irib-holddown-count" : [
+                {
+                    "data" : "0"
+                }
+                ], 
+                "irib-hidden-count" : [
+                {
+                    "data" : "0"
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/sender/show_route_protocol_bgp_detail_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/sender/show_route_protocol_bgp_detail_|_display_json.txt
@@ -1,0 +1,106 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/sender/show_route_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/sender/show_route_|_display_json.txt
@@ -1,0 +1,885 @@
+{
+    "route-information" : [
+    {
+        "attributes" : {"xmlns" : "http://xml.juniper.net/junos/25.4R0/junos-routing"}, 
+        "route-table" : [
+        {
+            "comment" : "keepalive", 
+            "table-name" : [
+            {
+                "data" : "inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "7"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "1.1.1.1/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:16", 
+                        "attributes" : {"junos:seconds" : "736"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "lo0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/31"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:20", 
+                        "attributes" : {"junos:seconds" : "680"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.12.0/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:11:20", 
+                        "attributes" : {"junos:seconds" : "680"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "ge-0/0/0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:15", 
+                        "attributes" : {"junos:seconds" : "735"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.1.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:15", 
+                        "attributes" : {"junos:seconds" : "735"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.2.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:15", 
+                        "attributes" : {"junos:seconds" : "735"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.10.3.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:15", 
+                        "attributes" : {"junos:seconds" : "735"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Discard"
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "3"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "0.0.0.0/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:15", 
+                        "attributes" : {"junos:seconds" : "735"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "10.0.0.2"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.0/24"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:16", 
+                        "attributes" : {"junos:seconds" : "736"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "10.0.0.15/32"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:16", 
+                        "attributes" : {"junos:seconds" : "736"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }, 
+        {
+            "table-name" : [
+            {
+                "data" : "mgmt_junos.inet6.0"
+            }
+            ], 
+            "destination-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "total-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "active-route-count" : [
+            {
+                "data" : "4"
+            }
+            ], 
+            "holddown-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "hidden-route-count" : [
+            {
+                "data" : "0"
+            }
+            ], 
+            "rt" : [
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "::/0"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Static"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "5"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:15", 
+                        "attributes" : {"junos:seconds" : "735"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "to" : [
+                        {
+                            "data" : "2001:db8::1"
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::/64"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Direct"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:16", 
+                        "attributes" : {"junos:seconds" : "736"}
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "selected-next-hop" : [
+                        {
+                            "data" : [null]
+                        }
+                        ], 
+                        "via" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "2001:db8::2/128"
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:16", 
+                        "attributes" : {"junos:seconds" : "736"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }, 
+            {
+                "attributes" : {"junos:style" : "brief"}, 
+                "rt-destination" : [
+                {
+                    "data" : "fe80::e00:7fff:fec7:100/128", 
+                    "attributes" : {"junos:emit" : "emit"}
+                }
+                ], 
+                "rt-entry" : [
+                {
+                    "active-tag" : [
+                    {
+                        "data" : "*"
+                    }
+                    ], 
+                    "current-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "last-active" : [
+                    {
+                        "data" : [null]
+                    }
+                    ], 
+                    "protocol-name" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "preference" : [
+                    {
+                        "data" : "0"
+                    }
+                    ], 
+                    "age" : [
+                    {
+                        "data" : "00:12:16", 
+                        "attributes" : {"junos:seconds" : "736"}
+                    }
+                    ], 
+                    "nh-type" : [
+                    {
+                        "data" : "Local"
+                    }
+                    ], 
+                    "nh" : [
+                    {
+                        "nh-local-interface" : [
+                        {
+                            "data" : "fxp0.0"
+                        }
+                        ]
+                    }
+                    ]
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/show/sender/show_version_|_display_json.txt
+++ b/snapshots/junos_ext_community_literal/show/sender/show_version_|_display_json.txt
@@ -1,0 +1,1138 @@
+{
+    "software-information" : [
+    {
+        "host-name" : [
+        {
+            "data" : "sender"
+        }
+        ], 
+        "product-model" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "product-name" : [
+        {
+            "data" : "vmx"
+        }
+        ], 
+        "os-name" : [
+        {
+            "data" : "junos"
+        }
+        ], 
+        "junos-version" : [
+        {
+            "data" : "25.4R1.12"
+        }
+        ], 
+        "package-information" : [
+        {
+            "name" : [
+            {
+                "data" : "os-kernel"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-kernel-prd-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS Kernel 64-bit  [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-compat32-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs compat32 [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-vmguest-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS vmguest [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-libs-15-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS libs [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-runtime-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-compat32-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS 32-bit compatibility [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-junos"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-junos-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-boot-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-boot-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI boot files [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jail-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jail-runtime-x86-32-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS jail runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "zoneinfo"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-zoneinfo-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS time zone information [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-extensions"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-extensions-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py extensions [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "py-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "py-base-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS py base [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-package"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-package-20251105.210515_builder_main"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS package [20251105.210515_builder_main]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-efi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-efi-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS EFI runtime [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-crypto"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-crypto-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS crypto [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "netstack"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS network stack and utilities [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-nfx-3-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest (NFX-3) [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-net-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-net-mtx-prd-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx network modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-vmguest-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmguest  [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-daemons"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-daemons-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS daemons [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "os-modules-net"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "os-modules-net-x86-64-20251024.861cae5_builder_bsd15_254"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS OS network modules [20251024.861cae5_builder_bsd15_254]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-libs-compat32-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-libs-compat32-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx libs compat32 [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-modules-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-modules-mx-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx modules [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS vmx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-runtime-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-runtime-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mx runtime [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jinsight"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jinsight-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS J-Insight [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jdocs"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jdocs-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Online Documentation [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "dsa"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "dsa-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS dsa [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "vmguest"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Packet Forwarding Engine Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "ssh-tunneld"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "ssh-tunneld-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SSH Tunnel Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "sflow-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "sflow-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS sflow mx [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "na-telemetry"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "na-telemetry-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS na telemetry [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-sysmond"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-sysmond-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS System Monitoring [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-support"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-support-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS support scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-schedtrace"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-schedtrace-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "Junos scheduler tracing [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-rpd-telemetry-application"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-rpd-telemetry-application-x86-64-25.4R1.12-bsd15"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS RPD Telemetry Application [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-scripts"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-scripts-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS python routing scripts for consistency check in RIB/FIB/PFE [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-basic-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-basic [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-mpls-oam-advanced-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing mpls-oam-advanced [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-lsys"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-lsys-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing lsys [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-internal-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-internal [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-controller-external"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-controller-external-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing controller-external [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-compat32"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-compat32-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing 32-bit Compatible Version [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-routing-aggregated"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-routing-aggregated-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Routing aggregated [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-probe"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-probe-x86-64-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS probe utility [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-platform-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS common platform support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-openconfig"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-openconfig-x86-32-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Openconfig [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-l2-rsi"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-l2-rsi-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS L2 RSI Scripts [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-km"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-km-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Key Manager [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-jsqlsync"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-jsqlsync-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS SQL Sync Daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-dp-crypto-support-platform"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-dp-crypto-support-mtx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS mtx Data Plane Crypto Support [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-bbe-up"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-bbe-up-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Broadband Edge User Plane Apps [25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "junos-appidd"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "junos-appidd-mx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS appidd-mx application-identification daemon [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-wrlinux"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-wrlinux-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Linux Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-vmx"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-vmx-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsim-pfe-internal"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsim-pfe-internal-x86-32-20251216.154259_builder_junos_254_r1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Simulation Package [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jsd-jet-1"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jsd-x86-32-20251216.154259_builder_junos_254_r1-jet-1"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Extension Toolkit [20251216.154259_builder_junos_254_r1]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-base"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-base-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) [1.0.0+25.4R1.12]"
+            }
+            ]
+        }, 
+        {
+            "name" : [
+            {
+                "data" : "jmrt-test"
+            }
+            ], 
+            "package-name" : [
+            {
+                "data" : "jmrt-test-x86-64-25.4R1.12"
+            }
+            ], 
+            "comment" : [
+            {
+                "data" : "JUNOS Juniper Malware Removal Tool (JMRT) Test [1.0.0+25.4R1.12]"
+            }
+            ]
+        }
+        ]
+    }
+    ]
+}

--- a/snapshots/junos_ext_community_literal/source/README.md
+++ b/snapshots/junos_ext_community_literal/source/README.md
@@ -1,0 +1,110 @@
+# Junos Extended-Community Literal Lab
+
+Confirms how Junos interprets the generic extended-community literal
+`members 65000:672277L:36867`, a syntax seen in real configs whose
+high-order `65000` "type" is non-obvious.
+
+## The syntax
+
+Junos accepts extended communities in a generic `type:admin:admin`
+form in addition to the named forms (`target:…`, `origin:…`). For the
+mystery value:
+
+| Field     | Value       | Bytes | Meaning                               |
+| --------- | ----------- | ----- | ------------------------------------- |
+| `65000`   | 0xFDE8      | 2     | type octet 0xFD, subtype octet 0xE8   |
+| `672277L` | 0x000A_4215 | 4     | global administrator (L = 4-byte GA)  |
+| `36867`   | 0x9003      | 2     | local administrator (assigned number) |
+
+The `L` suffix forces the global administrator into the 4-byte
+AS-specific layout (type 0x02 family). Without it, a bare number ≤
+0xFFFF would be a 2-byte global administrator.
+
+The first field `65000` is **not** a route target or site-of-origin.
+When it is a bare integer, Junos splits it into the two leading octets
+of the 8-byte community: `65000 >> 8 = 0xFD` (type) and
+`65000 & 0xFF = 0xE8` (subtype). 0xFD has both the IANA (0x80) and
+non-transitive (0x40) bits set, which is why it does not resemble a
+standard transitive route target (0x02:0x02).
+
+## Topology
+
+```
+sender (AS 65001) --- receiver (AS 65002)
+       ge-0/0/0  <->  ge-0/0/0
+       10.0.12.0      10.0.12.1
+```
+
+## Test Routes
+
+sender originates these static routes, tagging each via export policy:
+
+| Prefix       | Community Applied    | Purpose                |
+| ------------ | -------------------- | ---------------------- |
+| 10.10.0.0/24 | (none)               | control                |
+| 10.10.1.0/24 | 65000:672277L:36867  | the mystery literal    |
+| 10.10.2.0/24 | target:672277L:36867 | 4-byte-AS route target |
+| 10.10.3.0/24 | target:65000:36867   | 2-byte-AS route target |
+
+## Findings (confirmed on vJunos-router 25.4R1.12)
+
+The syntax is exactly a generic 2:4:2-byte extended community literal,
+as hypothesized. On the sender, `show route 10.10.1.0/24 extensive`
+renders the configured `members 65000:672277L:36867` as:
+
+```
+Communities: unknown type 0xffe8:0xa4215:0x9003
+```
+
+Decoding:
+
+- `0xa4215` = 672277 — the 4-byte global administrator (the `L` forces
+  the 4-byte width; without it the value would have to fit in 2 bytes).
+- `0x9003` = 36867 — the 2-byte local administrator.
+- Type renders as `0xffe8`: the configured `65000` = 0xFDE8, with the
+  0x02 bit set (`0xFD | 0x02 = 0xFF`) — the AS-specific-4-byte type bit
+  that the `L` suffix selects. Junos classifies this as an **unknown
+  type** because 0xFF:0xE8 is not an IANA-assigned extended-community
+  type/subtype.
+
+Wire behavior: because the type's transitivity bit marks it
+non-transitive, Junos **strips the community at the eBGP boundary**.
+The receiver sees `10.10.1.0/24` with no community at all, while the
+comparison routes carrying `target:672277L:36867` (4-byte-AS RT) and
+`target:65000:36867` (2-byte-AS RT) cross unchanged. The `L` suffix is
+purely about global-administrator width, confirmed by the two RT rows.
+
+## Batfish Notes
+
+### Extended-community rendering
+
+Batfish prints route targets in numeric type-prefix form rather than
+with the Junos `target` keyword: `target:672277L:36867` becomes
+`514:672277L:36867` (type 0x0202, 4-byte-AS) and `target:65000:36867`
+becomes `2:65000:36867` (type 0x0002, 2-byte-AS). These are the same
+communities in a different notation, so `JunosValidator` canonicalizes
+the Junos `target:GA:LA` form to Batfish's numeric form before
+comparing. Without that canonicalization the receiver's BGP routes
+would mismatch on community form alone.
+
+### Literal parse rejection (batfish/batfish#10018)
+
+`ExtendedCommunity.parse` (flatjuniper) handles the `L` suffix (4-byte
+GA) and splits a bare numeric first field into type/subtype octets.
+But it computes the type via signed-byte arithmetic — `(byte) 0xFD` is
+negative — and `ExtendedCommunity.of` rejects negative types. So a
+`65000:…` literal (any type octet ≥ 0x80) fails literal parsing and
+falls back to a **regex** community member. Initializing this snapshot
+in Batfish yields the convert warning
+
+```
+FATAL: 'MYSTERY' community contains no non-wildcard members in an add action
+```
+
+i.e. the `community add MYSTERY` is dropped because the member was
+parsed as a wildcard regex, not a literal. This does not fail a lab
+test today — the community is stripped at the eBGP boundary on the real
+device, so the receiver's routes carry no community on either side, and
+the FATAL is a _convert_ warning (not caught by `test_parse_warnings`,
+which only checks _parse_ warnings) on the sender. It is a genuine
+parser gap tracked in batfish/batfish#10018.

--- a/snapshots/junos_ext_community_literal/source/configs/receiver.cfg
+++ b/snapshots/junos_ext_community_literal/source/configs/receiver.cfg
@@ -1,0 +1,33 @@
+system {
+    host-name receiver;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 2.2.2.2/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to sender";
+        unit 0 {
+            family inet {
+                address 10.0.12.1/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65002;
+    router-id 2.2.2.2;
+}
+protocols {
+    bgp {
+        group FROM-SENDER {
+            type external;
+            peer-as 65001;
+            neighbor 10.0.12.0;
+        }
+    }
+}

--- a/snapshots/junos_ext_community_literal/source/configs/sender.cfg
+++ b/snapshots/junos_ext_community_literal/source/configs/sender.cfg
@@ -1,0 +1,96 @@
+system {
+    host-name sender;
+}
+interfaces {
+    lo0 {
+        unit 0 {
+            family inet {
+                address 1.1.1.1/32;
+            }
+        }
+    }
+    ge-0/0/0 {
+        description "link to receiver";
+        unit 0 {
+            family inet {
+                address 10.0.12.0/31;
+            }
+        }
+    }
+}
+routing-options {
+    autonomous-system 65001;
+    router-id 1.1.1.1;
+    static {
+        /* Each prefix is tagged with a different extended-community literal */
+        route 10.10.0.0/24 discard;
+        route 10.10.1.0/24 discard;
+        route 10.10.2.0/24 discard;
+        route 10.10.3.0/24 discard;
+    }
+}
+policy-options {
+    /* The community under test: a bare numeric type 65000 (=0xFDE8),
+       a 4-byte global administrator forced with the L suffix, and a
+       2-byte local administrator. */
+    community MYSTERY {
+        members 65000:672277L:36867;
+    }
+    /* Comparison: a normal 4-byte-AS route target (type "target" = 0x02:0x02). */
+    community RT-4BYTE {
+        members target:672277L:36867;
+    }
+    /* Comparison: a normal 2-byte-AS route target. */
+    community RT-2BYTE {
+        members target:65000:36867;
+    }
+    policy-statement ADVERTISE {
+        term mystery {
+            from {
+                route-filter 10.10.1.0/24 exact;
+            }
+            then {
+                community add MYSTERY;
+                accept;
+            }
+        }
+        term rt4 {
+            from {
+                route-filter 10.10.2.0/24 exact;
+            }
+            then {
+                community add RT-4BYTE;
+                accept;
+            }
+        }
+        term rt2 {
+            from {
+                route-filter 10.10.3.0/24 exact;
+            }
+            then {
+                community add RT-2BYTE;
+                accept;
+            }
+        }
+        term control {
+            from {
+                route-filter 10.10.0.0/24 exact;
+            }
+            then accept;
+        }
+        term default {
+            then reject;
+        }
+    }
+}
+protocols {
+    bgp {
+        group TO-RECEIVER {
+            type external;
+            peer-as 65002;
+            neighbor 10.0.12.1 {
+                export ADVERTISE;
+            }
+        }
+    }
+}

--- a/snapshots/junos_ext_community_literal/source/topology.clab.yml
+++ b/snapshots/junos_ext_community_literal/source/topology.clab.yml
@@ -1,0 +1,33 @@
+# Junos extended-community literal lab.
+#
+# Confirms how Junos interprets the generic extended-community literal
+# syntax "members 65000:672277L:36867" seen in the wild:
+#   - 65000   : the two type/subtype octets (0xFD:0xE8)
+#   - 672277L : 4-byte global administrator (the L forces 4 bytes)
+#   - 36867   : 2-byte local administrator
+#
+# Topology:
+#   sender (AS 65001) --[ge-0/0/0]--[ge-0/0/0]-- receiver (AS 65002)
+#     lo0: 1.1.1.1/32                              lo0: 2.2.2.2/32
+#     link: 10.0.12.0/31                           link: 10.0.12.1/31
+#
+# sender originates 10.10.0-3.0/24 and tags each with a different
+# extended community (the mystery literal, plus 4-byte and 2-byte route
+# targets for comparison). receiver shows how each is encoded on the wire.
+
+name: junos-ext-community-literal
+
+topology:
+  nodes:
+    sender:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/sender.cfg
+    receiver:
+      kind: juniper_vjunosrouter
+      image: vrnetlab/juniper_vjunos-router:25.4R1.12
+      startup-config: configs/receiver.cfg
+
+  links:
+    # sender ge-0/0/0 (eth1) <-> receiver ge-0/0/0 (eth1)
+    - endpoints: ["sender:eth1", "receiver:eth1"]

--- a/src/lab_validation/parsers/junos/commands/bgp_routes.py
+++ b/src/lab_validation/parsers/junos/commands/bgp_routes.py
@@ -27,6 +27,7 @@ VIA = "via"
 AS_PATH = "as-path"
 COMMUNITIES = "communities"
 COMMUNITY = "community"
+EXTENDED_COMMUNITY = "extended-community"
 RT_PREFIX_LENGTH = "rt-prefix-length"
 
 
@@ -77,9 +78,14 @@ def _get_routes(vrf: str, route_json_obj: list[Any]) -> list[JunosBgpRoute]:
                 metric = None
             as_path_str = entry[AS_PATH][0][DATA]
             local_pref = entry[LOCAL_PREFERENCE][0][DATA]
+            comms = entry.get(COMMUNITIES, [{}])[0]
+            # Standard communities live under "community"; extended communities
+            # (route targets, site-of-origin, generic type:ga:la literals) live
+            # under "extended-community". Collect both so community comparison
+            # sees the full set rather than silently dropping extended ones.
             communities = tuple(
                 c[DATA]
-                for c in entry.get(COMMUNITIES, [{}])[0].get(COMMUNITY, [])
+                for c in comms.get(COMMUNITY, []) + comms.get(EXTENDED_COMMUNITY, [])
                 if c.get(DATA)
             )
 

--- a/src/lab_validation/validators/JunosValidator.py
+++ b/src/lab_validation/validators/JunosValidator.py
@@ -381,19 +381,50 @@ _WELL_KNOWN_COMMUNITY_MAP: dict[str, str] = {
 }
 
 
+def _canonicalize_route_target(s: str) -> str:
+    """Convert a Junos ``target:GA:LA`` route target to Batfish's numeric form.
+
+    Junos prints route targets with the ``target`` keyword; Batfish prints
+    them as ``(type << 8 | subtype):GA:LA`` where subtype is 0x02 (route
+    target) and the type byte encodes the global-administrator width:
+
+      * 4-byte-AS global admin (``L`` suffix, or a value > 0xFFFF): type
+        0x02 -> ``514:GA:LA`` (e.g. ``target:672277L:36867`` ->
+        ``514:672277L:36867``).
+      * 2-byte-AS global admin (value <= 0xFFFF): type 0x00 -> ``2:GA:LA``
+        (e.g. ``target:65000:36867`` -> ``2:65000:36867``).
+
+    The global-administrator token (including any ``L`` suffix) is preserved
+    verbatim; only the leading ``target`` keyword is rewritten. IP-address
+    global administrators (type 0x01) are not yet handled and raise.
+    """
+    _, ga, la = s.split(":", 2)
+    if "." in ga:
+        raise ValueError(
+            f"IP-address route target {s!r} not yet handled in "
+            "_canonicalize_route_target in JunosValidator.py"
+        )
+    four_byte = ga[-1:].lower() == "l" or int(ga) > 0xFFFF
+    type_subtype = 0x0202 if four_byte else 0x0002
+    return f"{type_subtype}:{ga}:{la}"
+
+
 def _canonicalize_community(s: str) -> str:
     """Return canonical form of a single community string.
 
     Accepts either the Junos symbolic name or the numeric form for the
-    well-known communities listed in ``_WELL_KNOWN_COMMUNITY_MAP``. Other
-    forms (standard ``ASN:value``, ``target:..``, ``origin:..``,
-    ``large:..``) are returned verbatim because Junos and Batfish print
-    them identically.
+    well-known communities listed in ``_WELL_KNOWN_COMMUNITY_MAP``. Junos
+    route targets (``target:GA:LA``) are rewritten to the numeric type-prefix
+    form Batfish emits. Other forms (standard ``ASN:value``, ``origin:..``,
+    ``large:..``) are returned verbatim because Junos and Batfish print them
+    identically.
     """
     if s in _WELL_KNOWN_COMMUNITY_MAP:
         return _WELL_KNOWN_COMMUNITY_MAP[s]
     if s in _WELL_KNOWN_COMMUNITY_MAP.values():
         return s
+    if s.startswith("target:"):
+        return _canonicalize_route_target(s)
     # Loud-fail on unknown symbolic names so a future contributor adds the
     # mapping rather than silently ignoring the mismatch.
     if s and not s[0].isdigit() and ":" not in s:

--- a/tests/lab_validation/parsers/junos/commands/test_bgp_routes.py
+++ b/tests/lab_validation/parsers/junos/commands/test_bgp_routes.py
@@ -351,7 +351,9 @@ def test_parse_show_route_protocol_bgp_detail_with_communities() -> None:
     #   1. rt-destination is bare ("10.10.10.0") and rt-prefix-length is its
     #      own field instead of the "10.10.10.0/24" combined string.
     #   2. as-path data is prefixed with "AS path: ".
-    #   3. The communities array is present.
+    #   3. The communities array is present, carrying standard communities
+    #      under "community" and extended communities (route targets) under
+    #      "extended-community".
     text = """
     {
     "route-information" : [
@@ -377,8 +379,11 @@ def test_parse_show_route_protocol_bgp_detail_with_communities() -> None:
                     {
                         "community" : [
                             {"data" : "65001:100"},
-                            {"data" : "target:65001:200"},
                             {"data" : "no-export"}
+                        ],
+                        "extended-community" : [
+                            {"data" : "target:65001:200"},
+                            {"data" : "target:672277L:36867"}
                         ]
                     }
                     ],
@@ -412,7 +417,15 @@ def test_parse_show_route_protocol_bgp_detail_with_communities() -> None:
             as_path=(1,),
             origin_type="I",
             is_active=True,
-            communities=("65001:100", "target:65001:200", "no-export"),
+            # Standard communities ("community") and extended communities
+            # ("extended-community", e.g. route targets) are both collected;
+            # the device emits route targets only under extended-community.
+            communities=(
+                "65001:100",
+                "no-export",
+                "target:65001:200",
+                "target:672277L:36867",
+            ),
         ),
     ]
 

--- a/tests/lab_validation/validators/test_junosValidator.py
+++ b/tests/lab_validation/validators/test_junosValidator.py
@@ -594,11 +594,23 @@ def test_canonicalize_community_well_known() -> None:
 
 
 def test_canonicalize_community_passthrough() -> None:
-    # Standard, extended, and large communities pass through unchanged.
+    # Standard, origin (site-of-origin), and large communities pass through
+    # unchanged; Junos and Batfish print them identically.
     assert _canonicalize_community("65001:100") == "65001:100"
-    assert _canonicalize_community("target:65001:200") == "target:65001:200"
     assert _canonicalize_community("origin:65001:300") == "origin:65001:300"
     assert _canonicalize_community("large:65001:1:1") == "large:65001:1:1"
+
+
+def test_canonicalize_community_route_target() -> None:
+    # Junos prints route targets with the "target" keyword; Batfish prints
+    # them as "(type << 8 | 0x02):GA:LA". A 2-byte-AS global admin uses type
+    # 0x00 -> 2; a 4-byte-AS global admin (L suffix or value > 0xFFFF) uses
+    # type 0x02 -> 514.
+    assert _canonicalize_community("target:65000:36867") == "2:65000:36867"
+    assert _canonicalize_community("target:672277L:36867") == "514:672277L:36867"
+    assert _canonicalize_community("target:65001:200") == "2:65001:200"
+    # A bare 4-byte global admin (no L) is also the 4-byte-AS form.
+    assert _canonicalize_community("target:100000:1") == "514:100000:1"
 
 
 def test_canonicalize_community_unknown_symbolic_raises() -> None:


### PR DESCRIPTION
Two-router vJunos eBGP lab (snapshots/junos_ext_community_literal) that
pins down how Junos interprets the generic extended-community literal
`members 65000:672277L:36867`, a 2:4:2-byte form seen in real configs
whose high-order `65000` "type" is non-obvious. On vJunos-router
25.4R1.12 the sender renders it as `unknown type 0xffe8:0xa4215:0x9003`:

- `65000` (0xFDE8) is the two type/subtype octets, not a route target;
- `672277L` (0xa4215) is the 4-byte global administrator, the `L`
  forcing 4-byte width;
- `36867` (0x9003) is the 2-byte local administrator.

The type is non-transitive, so Junos strips the community at the eBGP
boundary -- the receiver gets the route with no community, while the
two comparison route targets (`target:672277L:36867` 4-byte-AS and
`target:65000:36867` 2-byte-AS) cross unchanged.

Junos route parser: the BGP detail JSON puts route targets and other
extended communities under `extended-community`, not `community`. The
parser only read `community`, so it silently dropped every extended
community -- which left the lab's routes looking community-free and
disabled community comparison entirely. Collect both arrays.

JunosValidator: Batfish renders route targets numerically
(`target:672277L:36867` -> `514:672277L:36867` for 4-byte-AS,
`target:65000:36867` -> `2:65000:36867` for 2-byte-AS). Canonicalize
the Junos `target:GA:LA` form to Batfish's `(type << 8 | 0x02):GA:LA`
form before comparing, alongside the existing well-known-community
mapping.

Batfish does not parse the `65000:...` literal itself:
ExtendedCommunity.parse builds the type via signed-byte arithmetic, so
a type octet >= 0x80 goes negative and ExtendedCommunity.of rejects it,
falling back to a regex member and dropping the `community add` with a
FATAL convert warning. That is a convert (not parse) warning on the
sender, so it does not fail a lab test today; tracked in
batfish/batfish#10018 and documented in source/README.md.

For batfish/batfish#10018.

----

Prompt:
```
I saw configs that had what looks like an extcommunity defined in an
unusual syntax: "members 65000:672277L:36867" Build and collect a lab to
confirm what it is on Junos? I think it's likely an extended community
literal with 2:4:2 bytes, but the 65000 high order type confuses me
```

Follow-up: tests passed initially only because the Junos parser was
dropping extended communities; fixing the parser exposed a route-target
rendering mismatch, resolved by canonicalizing in the validator rather
than sickbaying (the communities are semantically identical). Filed the
Batfish literal-parse issue.
