### PR TITLE
junos_ext_community_literal: sickbay receiver for non-transitive ext-community

### DIFF
--- a/snapshots/junos_ext_community_literal/source/README.md
+++ b/snapshots/junos_ext_community_literal/source/README.md
@@ -87,24 +87,13 @@ the Junos `target:GA:LA` form to Batfish's numeric form before
 comparing. Without that canonicalization the receiver's BGP routes
 would mismatch on community form alone.
 
-### Literal parse rejection (batfish/batfish#10018)
+### Non-transitive extended community not stripped on eBGP (batfish/batfish#10019)
 
-`ExtendedCommunity.parse` (flatjuniper) handles the `L` suffix (4-byte
-GA) and splits a bare numeric first field into type/subtype octets.
-But it computes the type via signed-byte arithmetic — `(byte) 0xFD` is
-negative — and `ExtendedCommunity.of` rejects negative types. So a
-`65000:…` literal (any type octet ≥ 0x80) fails literal parsing and
-falls back to a **regex** community member. Initializing this snapshot
-in Batfish yields the convert warning
-
-```
-FATAL: 'MYSTERY' community contains no non-wildcard members in an add action
-```
-
-i.e. the `community add MYSTERY` is dropped because the member was
-parsed as a wildcard regex, not a literal. This does not fail a lab
-test today — the community is stripped at the eBGP boundary on the real
-device, so the receiver's routes carry no community on either side, and
-the FATAL is a _convert_ warning (not caught by `test_parse_warnings`,
-which only checks _parse_ warnings) on the sender. It is a genuine
-parser gap tracked in batfish/batfish#10018.
+The mystery community's type octet has the transitive bit set (`0x40`),
+so the real device strips it when advertising across the eBGP
+boundary — the receiver's `10.10.1.0/24` carries no community. Batfish
+does not yet model non-transitive extended-community stripping on eBGP,
+so it retains `65000:672277L:36867` on the received route. The
+transitive route targets on `10.10.2.0/24` and `10.10.3.0/24` cross
+unchanged on both. `test_bgp_rib_routes[receiver]` is sickbayed to
+batfish/batfish#10019.

--- a/snapshots/junos_ext_community_literal/validation/sickbay.yaml
+++ b/snapshots/junos_ext_community_literal/validation/sickbay.yaml
@@ -1,0 +1,12 @@
+entries:
+  # The receiver's 10.10.1.0/24 carries the mystery extended-community
+  # literal (65000:672277L:36867) in Batfish but no community on the real
+  # device. The community's type octet has the transitive bit set, so the
+  # device strips it when advertising across the eBGP boundary; Batfish does
+  # not yet model non-transitive extended-community stripping on eBGP, so it
+  # retains the community. The transitive route targets on the sibling routes
+  # (10.10.2.0/24, 10.10.3.0/24) match on both sides.
+  - hostname: receiver
+    test_name: test_bgp_rib_routes
+    skip:
+      reason: "https://github.com/batfish/batfish/issues/10019 (non-transitive extended community not stripped on eBGP: 10.10.1.0/24)"


### PR DESCRIPTION
With batfish/batfish#10018 fixed, Batfish now models the mystery
extended-community literal (65000:672277L:36867) instead of dropping it.
That surfaces a separate modeling gap: the community's type octet has
the transitive bit set, so the real device strips it across the eBGP
boundary, but Batfish does not model non-transitive extended-community
stripping on eBGP and retains it on the receiver's 10.10.1.0/24. The
transitive route targets on the sibling routes still match on both
sides. Sickbay test_bgp_rib_routes[receiver] to batfish/batfish#10019
and refresh the README's Batfish notes.

For batfish/batfish#10019.

----

Prompt:
```
now fix batfish (~/batfish/batfish), re-test the lab (rerunning the
server of course), and send a batfish PR
```

Follow-up after the Batfish fix re-test: modeling the literal exposed
the non-transitive eBGP stripping discrepancy, handled here with a
sickbay entry per the file-issue-plus-sickbay plan.
