### PR TITLE
junos_static_route_defaults: un-sickbay now that static defaults are modeled

### DIFF
--- a/snapshots/junos_static_route_defaults/validation/sickbay.yaml
+++ b/snapshots/junos_static_route_defaults/validation/sickbay.yaml
@@ -1,8 +1,0 @@
-entries:
-  # Batfish does not model the Junos `routing-options static defaults`
-  # block, so static routes that inherit preference/metric/tag from
-  # defaults mismatch the device (preference 5, metric 0, no tag).
-  - hostname: "r1"
-    test_name: test_main_rib_routes
-    skip:
-      reason: https://github.com/batfish/batfish/issues/10017


### PR DESCRIPTION
batfish/batfish#10017 is fixed: Batfish now parses
"routing-options static defaults" and inherits preference/metric/tag into
the static routes, so test_main_rib_routes[r1] matches the device. Remove
the sickbay entry; the lab validates green with no expected failures.

Fixes batfish/batfish#10017.

----

Prompt:
```
ok wait for it to merge (I set it to auto-merge) and then send the lab
validation fix
```
